### PR TITLE
Update in-source translation files to build baseline

### DIFF
--- a/i18n/venus-gui-v2.ts
+++ b/i18n/venus-gui-v2.ts
@@ -4,28 +4,28 @@
 <context>
     <name></name>
     <message id="brief_solar_yield">
-        <location filename="../pages/BriefMonitorPanel.qml" line="86"/>
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
         <source>Solar yield</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="power">
-        <location filename="../pages/BriefMonitorPanel.qml" line="170"/>
-        <source>Power</source>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="brief_loads">
-        <location filename="../pages/BriefMonitorPanel.qml" line="343"/>
-        <source>Loads</source>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="controlcard_ess">
-        <location filename="../pages/controlcards/ESSCard.qml" line="15"/>
-        <source>ESS</source>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ess_card_minimum_soc">
         <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-        <location filename="../pages/controlcards/ESSCard.qml" line="43"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
         <source>Minimum SOC</source>
         <translation type="unfinished"></translation>
     </message>
@@ -37,69 +37,79 @@
     </message>
     <message id="ess_recommended">
         <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-        <source>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="ess_card_minimum_soc_value">
-        <location filename="../pages/controlcards/ESSCard.qml" line="46"/>
-        <source>%1%</source>
-        <extracomment>State of charge as a percentage value</extracomment>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="ess_battery_life_limit">
-        <location filename="../pages/controlcards/ESSCard.qml" line="79"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
         <source>Battery life limit: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_label_autostart">
-        <location filename="../pages/controlcards/GeneratorCard.qml" line="43"/>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
         <source>Autostart</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-        <location filename="../components/dialogs/GeneratorDisableAutostartDialog.qml" line="15"/>
-        <source>Disable Autostart?</source>
-        <oldsource>Disable autostart?</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="controlcard_generator_disableautostartdialog_consequences">
-        <location filename="../components/dialogs/GeneratorDisableAutostartDialog.qml" line="19"/>
-        <source>Consequences description...</source>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-        <location filename="../pages/controlcards/GeneratorCard.qml" line="73"/>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
         <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
-        <source>The generator will start and stop based on the configured autostart conditions.</source>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-        <location filename="../pages/controlcards/GeneratorCard.qml" line="126"/>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
         <source>Manual Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-        <location filename="../pages/controlcards/GeneratorCard.qml" line="129"/>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
         <source>Manual Start</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="generator_dialog_disabled">
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="generator_dialog_remote_start_disabled">
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="controlcard_switches">
-        <location filename="../pages/controlcards/SwitchesCard.qml" line="14"/>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="controlcard_inverter_charger">
-        <location filename="../pages/controlcards/VeBusDeviceCard.qml" line="18"/>
-        <source>Inverter / Charger</source>
+    <message id="controlcard_switches_relay_name">
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="amps">
-        <location filename="../pages/controlcards/VeBusDeviceCard.qml" line="54"/>
-        <source>%1 A</source>
+    <message id="controlcard_inverter">
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="controlcard_inverter_charger">
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_charging_stations">
@@ -108,2336 +118,332 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_session">
-        <location filename="../pages/evcs/EvChargerPage.qml" line="37"/>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
         <source>Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_charging_time">
-        <location filename="../pages/evcs/EvChargerPage.qml" line="59"/>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
         <source>Time</source>
         <extracomment>Charging time for the EV charger</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_charge_mode">
-        <location filename="../pages/evcs/EvChargerPage.qml" line="105"/>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
         <source>Charge mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_manual_caption">
-        <location filename="../pages/evcs/EvChargerPage.qml" line="112"/>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
         <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_auto_caption">
-        <location filename="../pages/evcs/EvChargerPage.qml" line="118"/>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
         <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_scheduled_caption">
-        <location filename="../pages/evcs/EvChargerPage.qml" line="124"/>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
         <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_enable_charging">
-        <location filename="../pages/evcs/EvChargerPage.qml" line="139"/>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
         <source>Enable charging</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="evcs_max_charging_current">
-        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="19"/>
-        <source>Max charging current</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="evcs_ac_position">
-        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="28"/>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
         <source>Position</source>
         <extracomment>EVCS AC input/output position</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="evcs_auto_start">
-        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="44"/>
-        <source>Auto start</source>
+    <message id="evcs_autostart">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evcs_lock_charger_display">
-        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="50"/>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
         <source>Lock charger display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="levels_page_tanks">
-        <location filename="../pages/LevelsPage.qml" line="45"/>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
         <source>Tanks</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="levels_page_environment">
-        <location filename="../pages/LevelsPage.qml" line="47"/>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
         <source>Environment</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="notifications_no_current_alerts">
-        <location filename="../pages/NotificationsPage.qml" line="60"/>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
         <source>No current alerts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_page_debug_quit">
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-        <location filename="../pages/settings/debug/PageDebug.qml" line="18"/>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
         <source>Enable frame-rate visualizer</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_page_debug_display_cpu_usage">
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_page_debug_pause_electron_animations">
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_page_debug_application_version">
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_page_debug_quit_application">
-        <location filename="../pages/settings/debug/PageDebug.qml" line="36"/>
-        <source>Quit Application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_l1_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="21"/>
-        <source>AC voltage L1 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="23"/>
-        <source>AC voltage too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_l1_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="28"/>
-        <source>AC voltage L1 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="30"/>
-        <source>AC voltage too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_l1_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="35"/>
-        <source>AC frequency L1 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="37"/>
-        <source>AC frequency too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_l1_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="42"/>
-        <source>AC frequency L1 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="44"/>
-        <source>AC frequency too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_l1_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="49"/>
-        <source>AC current L1 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="51"/>
-        <source>AC current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_l1_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="56"/>
-        <source>AC current L1 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="58"/>
-        <source>AC current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_l1_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="63"/>
-        <source>AC power L1 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="65"/>
-        <source>AC power too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_l1_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="70"/>
-        <source>AC power L1 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="72"/>
-        <source>AC power too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_emergency_stop">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="76"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="420"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="424"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="820"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="996"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1316"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1884"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2288"/>
-        <source>Emergency stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_servo_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="80"/>
-        <source>Servo current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_servo_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="84"/>
-        <source>Servo current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_oil_pressure_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="88"/>
-        <source>Oil pressure too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_oil_pressure_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="92"/>
-        <source>Oil pressure too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_engine_temperature_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="96"/>
-        <source>Engine temperature too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_engine_temperature_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="100"/>
-        <source>Engine temperature too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_winding_temperature_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="104"/>
-        <source>Winding temperature too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_winding_temperature_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="108"/>
-        <source>Winding temperature too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_exhaust_temperature_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="112"/>
-        <source>Exhaust temperature too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_exhaust_temperature_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="116"/>
-        <source>Exhaust temperature too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_starter_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="120"/>
-        <source>Starter current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_starter_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="124"/>
-        <source>Starter current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_glow_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="128"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="136"/>
-        <source>Glow current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_glow_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="132"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="140"/>
-        <source>Glow current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_holding_magnet_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="144"/>
-        <source>Fuel holding magnet current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_holding_magnet_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="148"/>
-        <source>Fuel holding magnet current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_stop_solenoid_hold_coil_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="152"/>
-        <source>Stop solenoid hold coil current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_stop_solenoid_hold_coil_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="156"/>
-        <source>Stop solenoid hold coil current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_stop_solenoid_pull_coil_current_too_low_">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="160"/>
-        <source>Stop solenoid pull coil current too low </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_stop_solenoid_pull_coil_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="164"/>
-        <source>Stop solenoid pull coil current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_optional_dc_out_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="168"/>
-        <source>Optional DC out current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_optional_dc_out_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="172"/>
-        <source>Optional DC out current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_5v_output_voltage_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="176"/>
-        <source>5V output voltage too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_5v_output_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="180"/>
-        <source>5V output current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_boost_output_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="184"/>
-        <source>Boost output current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_boost_output_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="188"/>
-        <source>Boost output current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_panel_supply_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="192"/>
-        <source>Panel supply current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_starter_battery_voltage_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="196"/>
-        <source>Starter battery voltage too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_starter_battery_voltage_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="200"/>
-        <source>Starter battery voltage too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_startup_aborted_rotation_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="204"/>
-        <source>Startup aborted (rotation too low)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_startup_aborted_rotation_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="208"/>
-        <source>Startup aborted (rotation too high)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_rotation_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="212"/>
-        <source>Rotation too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_rotation_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="216"/>
-        <source>Rotation too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_power_contactor_current_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="220"/>
-        <source>Power contactor current too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_power_contactor_current_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="224"/>
-        <source>Power contactor current too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_l2_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="228"/>
-        <source>AC voltage L2 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_l2_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="232"/>
-        <source>AC voltage L2 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_l2_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="236"/>
-        <source>AC frequency L2 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_l2_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="240"/>
-        <source>AC frequency L2 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_l2_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="244"/>
-        <source>AC current L2 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_l2_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="248"/>
-        <source>AC current L2 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_l2_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="252"/>
-        <source>AC power L2 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_l2_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="256"/>
-        <source>AC power L2 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_l3_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="260"/>
-        <source>AC voltage L3 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_voltage_l3_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="264"/>
-        <source>AC voltage L3 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_l3_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="268"/>
-        <source>AC frequency L3 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_frequency_l3_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="272"/>
-        <source>AC frequency L3 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_l3_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="276"/>
-        <source>AC current L3 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_current_l3_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="280"/>
-        <source>AC current L3 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_l3_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="284"/>
-        <source>AC power L3 too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ac_power_l3_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="288"/>
-        <source>AC power L3 too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_temperature_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="292"/>
-        <source>Fuel temperature too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_temperature_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="296"/>
-        <source>Fuel temperature too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_level_too_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="300"/>
-        <source>Fuel level too low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_level_too_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="304"/>
-        <source>Fuel level too high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_lost_control_unit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="308"/>
-        <source>Lost control unit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_lost_panel">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="312"/>
-        <source>Lost panel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_service_needed">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="316"/>
-        <source>Service needed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_lost_3-phase_module">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="320"/>
-        <source>Lost 3-phase module</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_lost_agt_module">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="324"/>
-        <source>Lost AGT module</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_synchronization_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="328"/>
-        <source>Synchronization failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_intake_airfilter">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="332"/>
-        <source>Intake airfilter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_lost_sync._module">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="336"/>
-        <source>Lost sync. module</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_load-balance_failed">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="340"/>
-        <source>Load-balance failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_sync-mode_deactivated">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="344"/>
-        <source>Sync-mode deactivated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_engine_controller">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="348"/>
-        <source>Engine controller</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_rotating_field_wrong">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="352"/>
-        <source>Rotating field wrong</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_level_sensor_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="356"/>
-        <source>Fuel level sensor lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_init_failed">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="360"/>
-        <source>Init failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_watchdog">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="364"/>
-        <source>Watchdog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_out:_winding">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="368"/>
-        <source>Out: winding</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_out:_exhaust">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="372"/>
-        <source>Out: exhaust</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_out:_cyl._head">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="376"/>
-        <source>Out: Cyl. head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_inverter_over_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="380"/>
-        <source>Inverter over temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_inverter_overload">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="384"/>
-        <source>Inverter overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_inverter_communication_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="388"/>
-        <source>Inverter communication lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_inverter_sync_failed">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="392"/>
-        <source>Inverter sync failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_can_communication_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="396"/>
-        <source>CAN communication lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_l1_overload">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="400"/>
-        <source>L1 overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_l2_overload">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="404"/>
-        <source>L2 overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_l3_overload">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="408"/>
-        <source>L3 overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_dc_overload">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="412"/>
-        <source>DC overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_dc_overvoltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="416"/>
-        <source>DC overvoltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_oil_pressure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="428"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="824"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1000"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1320"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1888"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2292"/>
-        <source>Low oil pressure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_coolant_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="432"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="828"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1004"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1324"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1892"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2296"/>
-        <source>High coolant temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_oil_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="436"/>
-        <source>High oil temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_under_speed">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="440"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="836"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1012"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1332"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1900"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2304"/>
-        <source>Under speed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_over_speed">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="444"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="840"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1016"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1336"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1904"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2308"/>
-        <source>Over speed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fail_to_start">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="448"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="872"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1048"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1368"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1936"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2340"/>
-        <source>Fail to start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fail_to_come_to_rest">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="452"/>
-        <source>Fail to come to rest</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_loss_of_speed_sensing">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="456"/>
-        <source>Loss of speed sensing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="460"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="852"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1028"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1348"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1916"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2320"/>
-        <source>Generator low voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="464"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="856"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1032"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1352"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1920"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2324"/>
-        <source>Generator high voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_low_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="468"/>
-        <source>Generator low frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_high_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="472"/>
-        <source>Generator high frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_high_current">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="476"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="900"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1076"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1396"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1964"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2368"/>
-        <source>Generator high current</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_earth_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="480"/>
-        <source>Generator earth fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_reverse_power">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="484"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1212"/>
-        <source>Generator reverse power</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_air_flap">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="488"/>
-        <source>Air flap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_oil_pressure_sender_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="492"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="888"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1064"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1384"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1952"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2356"/>
-        <source>Oil pressure sender fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_coolant_temperature_sender_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="496"/>
-        <source>Coolant temperature sender fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_oil_temperature_sender_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="500"/>
-        <source>Oil temperature sender fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_level_sender_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="504"/>
-        <source>Fuel level sender fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_magnetic_pickup_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="508"/>
-        <source>Magnetic pickup fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_loss_of_ac_speed_signal">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="512"/>
-        <source>Loss of AC speed signal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_charge_alternator_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="516"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="868"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1044"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1364"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1932"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2336"/>
-        <source>Charge alternator failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_battery_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="520"/>
-        <source>Low battery voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_battery_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="524"/>
-        <source>High battery voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_fuel_level">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="528"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="908"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1084"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1404"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1972"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2428"/>
-        <source>Low fuel level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_fuel_level">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="532"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="984"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1700"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2432"/>
-        <source>High fuel level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_failed_to_close">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="536"/>
-        <source>Generator failed to close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_failed_to_close">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="540"/>
-        <source>Mains failed to close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_failed_to_open">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="544"/>
-        <source>Generator failed to open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_failed_to_open">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="548"/>
-        <source>Mains failed to open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="552"/>
-        <source>Mains low voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="556"/>
-        <source>Mains high voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_failed_to_close">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="560"/>
-        <source>Bus failed to close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_failed_to_open">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="564"/>
-        <source>Bus failed to open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_low_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="568"/>
-        <source>Mains low frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_high_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="572"/>
-        <source>Mains high frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_failed">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="576"/>
-        <source>Mains failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_phase_rotation_wrong">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="580"/>
-        <source>Mains phase rotation wrong</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_phase_rotation_wrong">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="584"/>
-        <source>Generator phase rotation wrong</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_maintenance_due">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="588"/>
-        <source>Maintenance due</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_clock_not_set">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="592"/>
-        <source>Clock not set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_local_lcd_configuration_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="596"/>
-        <source>Local LCD configuration lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_local_telemetry_configuration_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="600"/>
-        <source>Local telemetry configuration lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_control_unit_not_calibrated">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="604"/>
-        <source>Control unit not calibrated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_modem_power_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="608"/>
-        <source>Modem power fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_short_circuit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="612"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1164"/>
-        <source>Generator short circuit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_failure_to_synchronise">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="616"/>
-        <source>Failure to synchronise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_live">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="620"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1516"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2084"/>
-        <source>Bus live</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_scheduled_run">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="624"/>
-        <source>Scheduled run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_phase_rotation_wrong">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="628"/>
-        <source>Bus phase rotation wrong</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_priority_selection_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="632"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1528"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2096"/>
-        <source>Priority selection error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_multiset_communications_msc_data_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="636"/>
-        <source>Multiset communications (MSC) data error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_multiset_communications_msc_id_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="640"/>
-        <source>Multiset communications (MSC) ID error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_multiset_communications_msc_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="644"/>
-        <source>Multiset communications (MSC) failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_multiset_communications_msc_too_few_sets">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="648"/>
-        <source>Multiset communications (MSC) too few sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_multiset_communications_msc_alarms_inhibited">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="652"/>
-        <source>Multiset communications (MSC) alarms inhibited</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_multiset_communications_msc_old_version_units">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="656"/>
-        <source>Multiset communications (MSC) old version units</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_reverse_power">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="660"/>
-        <source>Mains reverse power</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_minimum_sets_not_reached">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="664"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1576"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2144"/>
-        <source>Minimum sets not reached</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_insufficient_capacity_available">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="668"/>
-        <source>Insufficient capacity available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_expansion_input_unit_not_calibrated">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="672"/>
-        <source>Expansion input unit not calibrated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_expansion_input_unit_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="676"/>
-        <source>Expansion input unit failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_1_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="680"/>
-        <source>Auxiliary sender 1 low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_1_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="684"/>
-        <source>Auxiliary sender 1 high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_1_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="688"/>
-        <source>Auxiliary sender 1 fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_2_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="692"/>
-        <source>Auxiliary sender 2 low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_2_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="696"/>
-        <source>Auxiliary sender 2 high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_2_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="700"/>
-        <source>Auxiliary sender 2 fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_3_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="704"/>
-        <source>Auxiliary sender 3 low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_3_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="708"/>
-        <source>Auxiliary sender 3 high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_3_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="712"/>
-        <source>Auxiliary sender 3 fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_4_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="716"/>
-        <source>Auxiliary sender 4 low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_4_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="720"/>
-        <source>Auxiliary sender 4 high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auxiliary_sender_4_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="724"/>
-        <source>Auxiliary sender 4 fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_engine_control_unit_ecu_link_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="728"/>
-        <source>Engine control unit (ECU) link lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_engine_control_unit_ecu_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="732"/>
-        <source>Engine control unit (ECU) failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_engine_control_unit_ecu_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="736"/>
-        <source>Engine control unit (ECU) error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_coolant_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="740"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="832"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1008"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1328"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1896"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2300"/>
-        <source>Low coolant temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_out_of_sync">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="744"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1584"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2152"/>
-        <source>Out of sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_oil_pressure_switch">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="748"/>
-        <source>Low Oil Pressure Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_alternative_auxiliary_mains_fail">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="752"/>
-        <source>Alternative Auxiliary Mains Fail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_loss_of_excitation">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="756"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1592"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2160"/>
-        <source>Loss of excitation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_kw_limit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="760"/>
-        <source>Mains kW Limit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_negative_phase_sequence">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="764"/>
-        <source>Negative phase sequence</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_rocof">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="768"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1596"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2164"/>
-        <source>Mains ROCOF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_vector_shift">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="772"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1600"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2168"/>
-        <source>Mains vector shift</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_g59_low_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="776"/>
-        <source>Mains G59 low frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_g59_high_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="780"/>
-        <source>Mains G59 high frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_g59_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="784"/>
-        <source>Mains G59 low voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_g59_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="788"/>
-        <source>Mains G59 high voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_g59_trip">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="792"/>
-        <source>Mains G59 trip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_kw_overload">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="796"/>
-        <source>Generator kW Overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_engine_inlet_temperature_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="800"/>
-        <source>Engine Inlet Temperature high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_1_live">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="804"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1652"/>
-        <source>Bus 1 live</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_1_phase_rotation_wrong">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="808"/>
-        <source>Bus 1 phase rotation wrong</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_2_live">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="812"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1660"/>
-        <source>Bus 2 live</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_2_phase_rotation_wrong">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="816"/>
-        <source>Bus 2 phase rotation wrong</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_under_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="844"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1020"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1340"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1908"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2312"/>
-        <source>Generator Under frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_over_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="848"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1024"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1344"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1912"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2316"/>
-        <source>Generator Over frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_battery_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="860"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1036"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1356"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1924"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2328"/>
-        <source>Battery low voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_battery_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="864"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1040"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1360"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1928"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2332"/>
-        <source>Battery high voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fail_to_stop">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="876"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1052"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1372"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1940"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2344"/>
-        <source>Fail to stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_fail_to_close">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="880"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1056"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1376"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1944"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2348"/>
-        <source>Generator fail to close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_fail_to_close">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="884"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1060"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1380"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1948"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2352"/>
-        <source>Mains fail to close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_loss_of_magnetic_pick_up">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="892"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1068"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1388"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1956"/>
-        <source>Loss of magnetic pick up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_magnetic_pick_up_open_circuit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="896"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1072"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1392"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1960"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2364"/>
-        <source>Magnetic pick up open circuit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_calibration_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="904"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1080"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1400"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1968"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2372"/>
-        <source>Calibration lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_can_ecu_warning">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="912"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1088"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1408"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1976"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2376"/>
-        <source>CAN ECU Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_can_ecu_shutdown">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="916"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1092"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1412"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1980"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2380"/>
-        <source>CAN ECU Shutdown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_can_ecu_data_fail">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="920"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1096"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1416"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1984"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2384"/>
-        <source>CAN ECU Data fail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_oil_level_switch">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="924"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1100"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1420"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1988"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2388"/>
-        <source>Low oil level switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_temperature_switch">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="928"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1104"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1424"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1992"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2392"/>
-        <source>High temperature switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_fuel_level_switch">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="932"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1108"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1428"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1996"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2396"/>
-        <source>Low fuel level switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_expansion_unit_watchdog_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="936"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1112"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1432"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2000"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2400"/>
-        <source>Expansion unit watchdog alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_kw_overload_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="940"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1116"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1436"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2004"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2404"/>
-        <source>kW overload alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_maintenance_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="944"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1136"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1456"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2024"/>
-        <source>Maintenance alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_loading_frequency_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="948"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1140"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1460"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2028"/>
-        <source>Loading frequency alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_loading_voltage_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="952"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1144"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1464"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2032"/>
-        <source>Loading voltage alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_protect">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="956"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1180"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1668"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2212"/>
-        <source>ECU protect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_malfunction">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="960"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1184"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1672"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2216"/>
-        <source>ECU Malfunction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_information">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="964"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1188"/>
-        <source>ECU Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_shutdown">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="968"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1192"/>
-        <source>ECU Shutdown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_warning">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="972"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1196"/>
-        <source>ECU Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_hest">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="976"/>
-        <source>ECU HEST</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_water_in_fuel">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="980"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1208"/>
-        <source>ECU Water In Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_def_level_low">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="988"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1232"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1736"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2440"/>
-        <source>DEF Level Low</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_scr_inducement">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="992"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1236"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1740"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2444"/>
-        <source>SCR Inducement</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_negative_phase_sequence_current_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1120"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1440"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2008"/>
-        <source>Negative phase sequence current alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_earth_fault_trip_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1124"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1444"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2012"/>
-        <source>Earth fault trip alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_phase_rotation_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1128"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1448"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2016"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2416"/>
-        <source>Generator phase rotation alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_auto_voltage_sense_fail">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1132"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1452"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2020"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2420"/>
-        <source>Auto Voltage Sense Fail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_usage_running">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1148"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1468"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2036"/>
-        <source>Fuel usage running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_usage_stopped">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1152"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1472"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2040"/>
-        <source>Fuel usage stopped</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_protections_disabled">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1156"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1476"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2044"/>
-        <source>Protections disabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_protections_blocked">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1160"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1480"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2048"/>
-        <source>Protections blocked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_high_current">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1168"/>
-        <source>Mains High Current</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_earth_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1172"/>
-        <source>Mains Earth Fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_short_circuit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1176"/>
-        <source>Mains Short Circuit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_electrical_trip">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1200"/>
-        <source>ECU Electrical Trip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_after_treatment">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1204"/>
-        <source>ECU After treatment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_positive_var">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1216"/>
-        <source>Generator Positive VAr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_negative_var">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1220"/>
-        <source>Generator Negative VAr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_lcd_heater_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1224"/>
-        <source>LCD Heater Low Voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_lcd_heater_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1228"/>
-        <source>LCD Heater High Voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_old_version">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1240"/>
-        <source>MSC Old version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_id_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1244"/>
-        <source>MSC ID alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1248"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1556"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2124"/>
-        <source>MSC failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_priority_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1252"/>
-        <source>MSC priority Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_sender_open_circuit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1256"/>
-        <source>Fuel Sender open circuit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_over_speed_runaway">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1260"/>
-        <source>Over speed runaway</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_over_frequency_run_away">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1264"/>
-        <source>Over frequency run away</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_coolant_sensor_open_circuit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1268"/>
-        <source>Coolant sensor open circuit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_remote_display_link_lost">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1272"/>
-        <source>Remote display link lost</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_tank_bund_level">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1276"/>
-        <source>Fuel tank bund level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_charge_air_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1280"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2192"/>
-        <source>Charge air temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_level_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1284"/>
-        <source>Fuel level high</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_gen_breaker_failed_to_open_v5.0+">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1288"/>
-        <source>Gen breaker failed to open (v5.0+)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_breaker_failed_to_open_v5.0+_–_7x20_only">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1292"/>
-        <source>Mains breaker failed to open (v5.0+) – 7x20 only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fail_to_synchronise_v5.0+_–_7x20_only">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1296"/>
-        <source>Fail to synchronise (v5.0+) – 7x20 only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_avr_data_fail_v5.0+">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1300"/>
-        <source>AVR Data Fail (v5.0+)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_avr_dm1_red_stop_lamp_v5.0+">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1304"/>
-        <source>AVR DM1 Red Stop Lamp (v5.0+)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_escape_mode_v5.0+">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1308"/>
-        <source>Escape Mode (v5.0+)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_coolant_high_temp_electrical_trip_v5.0+">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1312"/>
-        <source>Coolant high temp electrical trip (v5.0+)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_breaker_failed_to_open">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1484"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2052"/>
-        <source>Generator breaker failed to open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_breaker_failed_to_open">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1488"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2056"/>
-        <source>Mains breaker failed to open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_breaker_failed_to_close">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1492"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2060"/>
-        <source>Bus breaker failed to close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_breaker_failed_to_open">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1496"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2064"/>
-        <source>Bus breaker failed to open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_generator_reverse_power_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1500"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2068"/>
-        <source>Generator reverse power alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_short_circuit_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1504"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2072"/>
-        <source>Short circuit alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_air_flap_closed_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1508"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2076"/>
-        <source>Air flap closed alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_failure_to_sync">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1512"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2080"/>
-        <source>Failure to sync</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_not_live">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1520"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2088"/>
-        <source>Bus not live</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_phase_rotation">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1524"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2092"/>
-        <source>Bus phase rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_data_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1532"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2100"/>
-        <source>MSC data error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_id_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1536"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2104"/>
-        <source>MSC ID error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1540"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2108"/>
-        <source>Bus low voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1544"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2112"/>
-        <source>Bus high voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_low_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1548"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2116"/>
-        <source>Bus low frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_high_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1552"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2120"/>
-        <source>Bus high frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_too_few_sets">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1560"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2128"/>
-        <source>MSC too few sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_alarms_inhibited">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1564"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2132"/>
-        <source>MSC alarms inhibited</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_old_version_units_on_the_bus">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1568"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2136"/>
-        <source>MSC old version units on the bus</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_reverse_power_alarm/mains_export_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1572"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2140"/>
-        <source>Mains reverse power alarm/mains export alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_insufficient_capacity">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1580"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2148"/>
-        <source>Insufficient capacity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_alternative_aux_mains_fail">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1588"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2156"/>
-        <source>Alternative aux mains fail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_low_frequency_stage_1">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1604"/>
-        <source>Mains decoupling low frequency stage 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_high_frequency_stage_1">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1608"/>
-        <source>Mains decoupling high frequency stage 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_low_voltage_stage_1">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1612"/>
-        <source>Mains decoupling low voltage stage 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_high_voltage_stage_1">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1616"/>
-        <source>Mains decoupling high voltage stage 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_combined_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1620"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2188"/>
-        <source>Mains decoupling combined alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_inlet_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1624"/>
-        <source>Inlet Temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_phase_rotation_alarm_identifier">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1628"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2196"/>
-        <source>Mains phase rotation alarm identifier</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_avr_max_trim_limit_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1632"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2200"/>
-        <source>AVR Max Trim Limit alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_coolant_temperature_electrical_trip_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1636"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2204"/>
-        <source>High coolant temperature electrical trip alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_temperature_sender_open_circuit_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1640"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2208"/>
-        <source>Temperature sender open circuit alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_out_of_sync_bus">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1644"/>
-        <source>Out of sync Bus</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_out_of_sync_mains">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1648"/>
-        <source>Out of sync Mains</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_1_phase_rotation">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1656"/>
-        <source>Bus 1 Phase Rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_2_phase_rotation">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1664"/>
-        <source>Bus 2 Phase Rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_indication">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1676"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2220"/>
-        <source>Indication</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_hest_active">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1680"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2448"/>
-        <source>HEST Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_dptc_filter">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1684"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2452"/>
-        <source>DPTC Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_water_in_fuel">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1688"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2240"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2436"/>
-        <source>Water In Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_heater">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1692"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2244"/>
-        <source>ECU Heater</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_cooler">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1696"/>
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2248"/>
-        <source>ECU Cooler</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_module_communication_fail_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1704"/>
-        <source>Module Communication Fail (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_module_warning_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1708"/>
-        <source>Bus Module Warning (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_module_trip_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1712"/>
-        <source>Bus Module Trip (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_module_warning_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1716"/>
-        <source>Mains Module Warning (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_module_trip_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1720"/>
-        <source>Mains Module Trip (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_load_live_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1724"/>
-        <source>Load Live (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_load_not_live_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1728"/>
-        <source>Load Not Live (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_load_phase_rotation_8661">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1732"/>
-        <source>Load Phase Rotation (8661)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_heater_sensor_failure_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1744"/>
-        <source>Heater Sensor Failure Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_over_zero_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1748"/>
-        <source>Mains Over Zero Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_under_positive_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1752"/>
-        <source>Mains Under Positive Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_over_negative_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1756"/>
-        <source>Mains Over Negative Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_asymmetry_high_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1760"/>
-        <source>Mains Asymmetry High Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_over_zero_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1764"/>
-        <source>Bus Over Zero Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_under_positive_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1768"/>
-        <source>Bus Under Positive Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_over_negative_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1772"/>
-        <source>Bus Over Negative Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_asymmetry_high_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1776"/>
-        <source>Bus Asymmetry High Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_e-trip_stop_inhibited">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1780"/>
-        <source>E-Trip Stop Inhibited</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fuel_tank_bund_level_high">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1784"/>
-        <source>Fuel Tank Bund Level High</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_link_1_data_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1788"/>
-        <source>MSC Link 1 Data Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_link_2_data_error">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1792"/>
-        <source>MSC Link 2 Data Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_2_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1796"/>
-        <source>Bus 2 Low Voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_2_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1800"/>
-        <source>Bus 2 High Voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_2_low_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1804"/>
-        <source>Bus 2 Low Frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_bus_2_high_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1808"/>
-        <source>Bus 2 High Frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_link_1_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1812"/>
-        <source>MSC Link 1 Failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_link_2_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1816"/>
-        <source>MSC Link 2 Failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_link_1_too_few_sets">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1820"/>
-        <source>MSC Link 1 Too Few Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_link_2_too_few_sets">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1824"/>
-        <source>MSC Link 2 Too Few Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_msc_link_1_and_2_failure">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1828"/>
-        <source>MSC Link 1 and 2 Failure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_electrical_trip_from_8660">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1832"/>
-        <source>Electrical Trip from 8660</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_avr_can_dm1_red_stop_lamp_fault">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1836"/>
-        <source>AVR CAN DM1 Red Stop Lamp Fault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_gen_over_zero_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1840"/>
-        <source>Gen Over Zero Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_gen_under_positive_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1844"/>
-        <source>Gen Under Positive Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_gen_over_negative_sequence_volts_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1848"/>
-        <source>Gen Over Negative Sequence Volts Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_gen_asymmetry_high_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1852"/>
-        <source>Gen Asymmetry High Alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_low_frequency_stage_2">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1856"/>
-        <source>Mains decoupling low frequency stage 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_high_frequency_stage_2">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1860"/>
-        <source>Mains decoupling high frequency stage 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_low_voltage_stage_2">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1864"/>
-        <source>Mains decoupling low voltage stage 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_high_voltage_stage_2">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1868"/>
-        <source>Mains decoupling high voltage stage 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_fault_ride_through_event">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1872"/>
-        <source>Fault Ride Through event</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_avr_data_fail">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1876"/>
-        <source>AVR Data Fail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_avr_red_lamp">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="1880"/>
-        <source>AVR Red Lamp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_low_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2172"/>
-        <source>Mains decoupling low frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_high_frequency">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2176"/>
-        <source>Mains decoupling high frequency</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_low_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2180"/>
-        <source>Mains decoupling low voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_mains_decoupling_high_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2184"/>
-        <source>Mains decoupling high voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_red">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2224"/>
-        <source>ECU Red</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_ecu_amber">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2228"/>
-        <source>ECU Amber</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_electrical_trip">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2232"/>
-        <source>Electrical Trip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_aftertreatment_exhaust">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2236"/>
-        <source>Aftertreatment Exhaust</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_dc_total_watts_overload">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2252"/>
-        <source>DC Total Watts Overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_plant_battery_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2256"/>
-        <source>High Plant Battery Temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_plant_battery_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2260"/>
-        <source>Low Plant Battery Temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_low_plant_battery_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2264"/>
-        <source>Low Plant Battery Voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_plant_battery_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2268"/>
-        <source>High Plant Battery Voltage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_plant_battery_depth_of_discharge">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2272"/>
-        <source>Plant Battery Depth Of Discharge</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_dc_battery_over_current">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2276"/>
-        <source>DC Battery Over Current</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_dc_load_over_current">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2280"/>
-        <source>DC Load Over Current</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_high_total_dc_current">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2284"/>
-        <source>High Total DC Current</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_loss_of_mag_pickup_signal">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2360"/>
-        <source>Loss of Mag Pickup signal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_negative_phase_sequence_alarm">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2408"/>
-        <source>Negative phase sequence alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_earth_fault_trip">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2412"/>
-        <source>Earth fault trip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="fp-genset-error_temperature_sensor_open_circuit">
-        <location filename="../pages/settings/devicelist/ac-in/ListFpGensetErrorItem.qml" line="2424"/>
-        <source>Temperature sensor open circuit</source>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="43"/>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
         <source>Front selector locked (%1)</source>
         <extracomment>%1 = the error number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="47"/>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
         <source>No error (%1)</source>
         <extracomment>%1 = the error number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="87"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
         <source>AC Totals</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="112"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
         <source>Energy L%1</source>
         <extracomment>%1 = phase number (1-3)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="127"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
         <source>Phase Sequence</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="133"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
         <source>L1-L3-L2</source>
         <extracomment>Phase sequence L1-L3-L2</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="136"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
         <source>L1-L2-L3</source>
         <extracomment>Phase sequence L1-L2-L3</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelDefault.qml" line="176"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
         <source>Data manager version</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="ac-in-genset_autostart_functionality_disabled">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="60"/>
-        <source>AutoStart functionality is currently disabled, enable it on the genset panel in order to start the genset from this menu.</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="ac-in-genset_ac">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="124"/>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
         <source>AC</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="ac-in-genset_auto_start_stop">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="152"/>
-        <source>Auto start/stop</source>
+    <message id="genset_controller_requires_helper_relay">
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ac-in-genset_auto_start_functionality">
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ac-in-genset_auto_control_status">
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ac-in-genset_control_error_code">
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ac-in-genset_status">
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ac-in-genset_error">
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ac-in-genset_remote_start_mode">
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_engine">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="167"/>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
         <source>Engine</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_speed">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="180"/>
+        <location filename="../components/PageGensetModel.qml" line="210"/>
         <source>Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_load">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="187"/>
+        <location filename="../components/PageGensetModel.qml" line="217"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="194"/>
-        <source>Oil Pressure</source>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ac-in-genset_oil_temperature">
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="201"/>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
         <source>Coolant temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="208"/>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
         <source>Exhaust temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="215"/>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
         <source>Winding temperature</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="ac-in-genset_operating_time">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="222"/>
-        <source>Operating time</source>
+    <message id="genset_heatsink_temperature">
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_genset_model_dc_genset_settings">
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="genset_charge_voltage_controlled_by_bms">
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="genset_charge_current_limit">
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="genset_bms_controlled">
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="genset_bms_control_enabled_automatically">
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="230"/>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
         <source>Starter battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInModelGenset.qml" line="238"/>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
         <source>Number of starts</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
         <source>Unlocked (kVARh)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
         <source>Unlocked (2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
         <source>Unlocked (1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_locked">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="52"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="102"/>
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="133"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
         <source>Phase configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_switch_position">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="118"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
         <source>Switch position</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_single_phase">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="138"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
         <source>Single phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_two_phase">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="140"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
         <source>2-phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_three_phase">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
         <source>3-phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ac-in-setup_devices">
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="157"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
         <source>Devices</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2541,149 +547,178 @@
         <source>Alarm Flags</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="battery_switch">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="23"/>
-        <source>Switch</source>
-        <extracomment>Change the battery mode</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="devicelist_battery_initializing">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="43"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
         <source>Initializing</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_battery_shutdown">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="54"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
         <source>Shutdown</source>
         <extracomment>Status is &apos;Shutdown&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_battery_updating">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="58"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
         <source>Updating</source>
         <extracomment>Status is &apos;Updating&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="64"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
         <source>Going to run</source>
         <extracomment>Status is &apos;Going to run&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="68"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
         <source>Pre-Charging</source>
         <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="72"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
         <source>Contactor check</source>
         <extracomment>Status is &apos;Contactor check&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="battery_state_of_health">
+    <message id="battery_bank_error">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="battery_bank_error_voltage_not_supported">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="battery_bank_error_incorrect_number_of_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="battery_bank_error_invalid_configuration">
         <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="devicelist_battery_total_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="devicelist_battery_system_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="devicelist_battery_number_of_bmses">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
         <source>State of health</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="battery_temp">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="112"/>
-        <source>Battery temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="battery_air_temp">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="120"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
         <source>Air temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_starter_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
         <source>Starter voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_bus_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="136"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
         <source>Bus voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_top_section_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="145"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
         <source>Top section voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_bottom_section_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="154"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
         <source>Bottom section voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_mid_point_deviation">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="163"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
         <source>Mid-point deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_consumed_amphours">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="171"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
         <source>Consumed AmpHours</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_buss_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="179"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
         <source>Bus voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_time_to_go">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="188"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
         <source>Time-to-go</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_details">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="203"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_module_level_alarms">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="226"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
         <source>Module level alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_settings_diagnostics">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="256"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
         <source>Diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_settings_fuses">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="281"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
         <source>Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_settings_io">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="297"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
         <source>IO</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_settings_system">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="312"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_settings_parameters">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="335"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_redetect_battery">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="360"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
         <source>Redetect Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_press_to_redetect">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="362"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
         <source>Press to redetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="369"/>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
         <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2778,124 +813,130 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="28"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
         <source>Highest cell voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="37"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
         <source>Minimum cell temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="52"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
         <source>Maximum cell temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterydetails_modules">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="67"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
         <source>Battery modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="71"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
         <source>%1 online</source>
         <extracomment>%1 = number of battery modules that are online</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="74"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
         <source>%1 offline</source>
         <extracomment>%1 = number of battery modules that are offline</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="80"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
         <source>Number of modules blocking charge / discharge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="86"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
         <source>Installed / Available capacity</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="batterydetails_connection_information">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="batteryalarms_deepest_discharge">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="18"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
         <source>Deepest discharge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_last_discharge">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="26"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
         <source>Last discharge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_average_discharge">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="34"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
         <source>Average discharge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="42"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
         <source>Total charge cycles</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="49"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
         <source>Number of full discharges</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="56"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
         <source>Cumulative Ah drawn</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="80"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
         <source>Minimum cell voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="89"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
         <source>Maximum cell voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="98"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
         <source>Time since last full charge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="106"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
         <source>Synchronisation count</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="127"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
         <source>Low starter battery voltage alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="139"/>
-        <source>High starter batttery voltage alarms</source>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="146"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
         <source>Minimum starter battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="155"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
         <source>Maximum starter battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="181"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
         <source>Discharged energy</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_charged_energy">
-        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="189"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
         <source>Charged energy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2920,32 +961,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettings_battery_bank">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="62"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
         <source>Battery bank</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="80"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
         <source>Relay (on battery monitor)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="92"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
         <source>Restore factory defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettings_press_to_restore">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="94"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
         <source>Press to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="110"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
         <source>Restore factory defaults?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="124"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
         <source>Bluetooth Enabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3011,7 +1052,8 @@
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
         <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</source>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
@@ -3025,22 +1067,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="146"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
         <source>Synchronise state-of-charge to 100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="148"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
         <source>Press to sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="161"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
         <source>Calibrate zero current</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="163"/>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
         <source>Press to set to 0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3168,19 +1210,84 @@
         <source>Balancing</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="alternator_wakespeed_output">
-        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="16"/>
-        <source>Output</source>
+    <message id="lynxionsystem_balancer_status">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="lynxionsystem_balancer_balanced">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="lynxionsystem_balancer_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="lynxionsystem_balancer_imbalance">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_temperature">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="60"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
         <source>Field drive</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="73"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
         <source>Engine speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="engine_temperature">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_wakespeed_operation_time">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_wakespeed_charged_ah">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_wakespeed_cycles_started">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_wakespeed_cycles_completed">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_wakespeed_nr_of_power_ups">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_wakespeed_nr_of_deep_discharges">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alternator_wakespeed_charge_cycle_history">
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
@@ -3209,53 +1316,55 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="59"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
         <source>Low aux voltage alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="66"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
         <source>High aux voltage alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="73"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
         <source>Minimum aux voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="82"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
         <source>Maximum aux voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="103"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
         <source>Produced energy</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="111"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
         <source>Consumed energy</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcmeter_aux_voltage">
-        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="54"/>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
         <source>Aux voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_solarcharger_error">
-        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="63"/>
-        <source>Error: %1</source>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_unsupported">
-        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="177"/>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
         <source>Unsupported</source>
         <extracomment>Device is not supported</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="228"/>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
         <source>Remove disconnected devices</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3285,22 +1394,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="43"/>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
         <source>External temperature (1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_meteo_external_temperature">
-        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="45"/>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
         <source>External temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="54"/>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
         <source>External temperature (2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_meteo_wind_speed">
-        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="61"/>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
         <source>Wind speed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3317,11 +1426,6 @@
     <message id="page_meteo_settings_external_temperature_sensor">
         <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
         <source>External temperature sensor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="devicelist_not_yet_implemented">
-        <location filename="../pages/settings/devicelist/PageNotYetImplemented.qml" line="18"/>
-        <source>The settings details for this device will be provided in a future update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
@@ -3380,106 +1484,110 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksensor_sensor_battery">
-        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="45"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
         <source>Sensor battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="21"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
         <source>Capacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
         <source>Sensor type</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="58"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="63"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
         <source>European (0 to 180 Ohm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="65"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
         <source>US (240 to 30 Ohm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_custom">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="67"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="73"/>
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="83"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
         <source>Sensor value when empty</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="devicelist_tanksetup_sensor_value_when_full">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="devicelist_tanksetup_fluid_type">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="93"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
         <source>Fluid type</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="102"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
         <source>Butane ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="112"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
         <source>Custom shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="128"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
         <source>Averaging time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="136"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
         <source>Sensor value</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tankshape_empty">
-        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="78"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
         <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tankshape_point">
-        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="87"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
         <source>Point %1</source>
         <extracomment>%1 = the point number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="123"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
         <source>Add point</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="146"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
         <source>Sensor level</source>
         <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tankshape_volume">
-        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="171"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
         <source>Volume</source>
         <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="232"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
         <source>Duplicate sensor level values are not allowed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="238"/>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
         <source>Volume values must be increasing.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3499,32 +1607,37 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="temperature_humidity">
-        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="59"/>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
         <source>Humidity</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="temperature_pressure">
-        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="67"/>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
         <source>Pressure</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="temperature_sensor_battery">
-        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="75"/>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
         <source>Sensor battery</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="temperature_offset">
-        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="39"/>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="temperature_scale">
-        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="49"/>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="temperature_sensor_voltage">
-        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="60"/>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
         <source>Sensor voltage</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3544,37 +1657,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-        <location filename="../pages/settings/DvccCommonSettings.qml" line="45"/>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
         <source>Maximum charge current</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-        <location filename="../pages/settings/GeneratorCondition.qml" line="20"/>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
         <source>Use %1 value to start/stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-        <location filename="../pages/settings/GeneratorCondition.qml" line="23"/>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
         <source>Start when %1 is higher than</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-        <location filename="../pages/settings/GeneratorCondition.qml" line="26"/>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
         <source>Start when %1 is lower than</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-        <location filename="../pages/settings/GeneratorCondition.qml" line="31"/>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
         <source>Stop when %1 is higher than</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-        <location filename="../pages/settings/GeneratorCondition.qml" line="34"/>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
         <source>Stop when %1 is lower than</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_generator_condition_skip_warmup">
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_fronius_remove_ip_address">
-        <location filename="../pages/settings/IpAddressListView.qml" line="58"/>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
         <source>Remove IP address?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3584,7 +1702,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_max">
-        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="81"/>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
         <source>Max: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3604,99 +1722,45 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-        <location filename="../pages/settings/PageDeviceInfo.qml" line="65"/>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
         <source>Product ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-        <location filename="../pages/settings/PageDeviceInfo.qml" line="78"/>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
         <source>Hardware version</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-        <location filename="../pages/settings/PageDeviceInfo.qml" line="99"/>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
         <source>Device name</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-        <location filename="../pages/settings/PageGenerator.qml" line="74"/>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
         <source>Remote switch control disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-        <location filename="../pages/settings/PageGenerator.qml" line="76"/>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
         <source>Generator in fault condition</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_generator_not_detected">
-        <location filename="../pages/settings/PageGenerator.qml" line="78"/>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
         <source>Generator not detected at AC input</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-        <location filename="../pages/settings/PageGenerator.qml" line="86"/>
-        <source>Run time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_total_run_time">
-        <location filename="../pages/settings/PageGenerator.qml" line="94"/>
-        <source>Total run time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_accumulated_running_time">
-        <location filename="../pages/settings/PageGenerator.qml" line="101"/>
-        <source>Accumulated running time since last test run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_time_to_next_test_run">
-        <location filename="../pages/settings/PageGenerator.qml" line="111"/>
-        <source>Time to next test run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_running_now">
-        <location filename="../pages/settings/PageGenerator.qml" line="128"/>
-        <source>Running now</source>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-        <location filename="../pages/settings/PageGenerator.qml" line="135"/>
-        <source>Auto start functionality</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_manual_start">
-        <location filename="../pages/settings/PageGenerator.qml" line="142"/>
-        <source>Manual start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_start_generator">
-        <location filename="../pages/settings/PageGenerator.qml" line="158"/>
-        <source>Start generator</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_stop_info">
-        <location filename="../pages/settings/PageGenerator.qml" line="165"/>
-        <source>Stopping, generator will continue running if other conditions are reached</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_start_info">
-        <location filename="../pages/settings/PageGenerator.qml" line="169"/>
-        <source>Starting, generator won&apos;t stop till user intervention</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_start_timer">
-        <location filename="../pages/settings/PageGenerator.qml" line="174"/>
-        <source>Starting. The generator will stop in %1, unless other conditions keep it running</source>
-        <extracomment>%1 = time until generator is stopped</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_run_for_hh_mm">
-        <location filename="../pages/settings/PageGenerator.qml" line="182"/>
-        <source>Run for (hh:mm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_page_relay_generator_daily_run_time">
-        <location filename="../pages/settings/PageGenerator.qml" line="195"/>
-        <source>Daily run time</source>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
@@ -3745,7 +1809,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="93"/>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
         <source>Stop when power is lower than</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3785,27 +1849,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-        <location filename="../pages/settings/PageGeneratorConditions.qml" line="88"/>
-        <source>Make sure that the generator is not connected to AC input %1 when using this option.</source>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-        <location filename="../pages/settings/PageGeneratorConditions.qml" line="96"/>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
         <source>Battery SOC</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_conditions_inverter_high_temperature">
-        <location filename="../pages/settings/PageGeneratorConditions.qml" line="130"/>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
         <source>Inverter high temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-        <location filename="../pages/settings/PageGeneratorConditions.qml" line="132"/>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
         <source>Start on high temperature warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-        <location filename="../pages/settings/PageGeneratorConditions.qml" line="141"/>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
         <source>Start on overload warning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3814,44 +1879,79 @@
         <source>Periodic run</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="page_settings_generator_reset_daily_run_time_counters">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="28"/>
-        <source>Reset daily run time counters</source>
+    <message id="page_settings_run_time_and_service_total_run_time">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="page_settings_generator_runtime_counter_reset">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="37"/>
-        <source>The daily runtime counter has been reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="page_settings_generator_runtime_counter_cant_reset_while_running">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="40"/>
-        <source>It is not possible to modify the counters while the generator is running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="page_settings_generator_total_run_time">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="55"/>
+    <message id="page_settings_run_time_and_service_generator_total_run_time">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
         <source>Generator total run time (hours)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_page_run_time_and_service_daily_run_time">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_run_time_and_service_runtime_counter_reset">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_page_run_time_and_service_time_to_next_test_run">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_page_run_time_and_service_running_now">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_page_run_time_and_service_accumulated_running_time">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_page_run_time_and_service_time_to_service">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="page_settings_generator_service_interval">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="77"/>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
         <source>Generator service interval (hours)</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="page_settings_generator_service_time_interval">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="84"/>
+    <message id="page_settings_run_time_and_service_service_time_interval">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
         <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="page_settings_generator_reset_service_timer">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+    <message id="page_settings_run_time_and_service_service_time_disabled">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_run_time_and_service_reset_service_timer">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
         <source>Reset service timer</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="page_settings_generator_service_timer_has_been_reset">
-        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="96"/>
-        <source>The service timer has been reset.</source>
+    <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="run_interval">
@@ -3890,66 +1990,66 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_ok_fix">
-        <location filename="../pages/settings/PageGps.qml" line="42"/>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
         <source>GPS OK (fix)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
         <source>GPS connected, but no GPS fix</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_not_connected">
-        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
         <source>No GPS connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_latitude">
-        <location filename="../pages/settings/PageGps.qml" line="54"/>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
         <source>Latitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_longitude">
-        <location filename="../pages/settings/PageGps.qml" line="61"/>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
         <source>Longitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_speed_kmh">
-        <location filename="../pages/settings/PageGps.qml" line="76"/>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
         <source>%1 km/h</source>
         <extracomment>GPS speed data, in kilometers per hour</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_speed_mph">
-        <location filename="../pages/settings/PageGps.qml" line="80"/>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
         <source>%1 mph</source>
         <extracomment>GPS speed data, in miles per hour</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_speed_kt">
-        <location filename="../pages/settings/PageGps.qml" line="84"/>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
         <source>%1 kt</source>
         <extracomment>GPS speed data, in knots</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_speed_ms">
-        <location filename="../pages/settings/PageGps.qml" line="88"/>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
         <source>%1 m/s</source>
         <extracomment>GPS speed data, in meters per second</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_course">
-        <location filename="../pages/settings/PageGps.qml" line="95"/>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
         <source>Course</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_altitude">
-        <location filename="../pages/settings/PageGps.qml" line="102"/>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
         <source>Altitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps_num_satellites">
-        <location filename="../pages/settings/PageGps.qml" line="108"/>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
         <source>Number of satellites</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3999,7 +2099,8 @@
     </message>
     <message id="settings_generator_function_not_enabled">
         <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
-        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</source>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_batteries_battery_visible">
@@ -4014,7 +2115,8 @@
     </message>
     <message id="settings_batteries_intro">
         <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
-        <source>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</source>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
@@ -4049,7 +2151,8 @@
     </message>
     <message id="settings_continuous_scan_may_interfere">
         <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-        <source>Continuous scanning may interfere with Wi-Fi operation</source>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
@@ -4063,127 +2166,133 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
         <source>It might be necessary to remove existing pairing information before connecting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_profile">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="54"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
         <source>CAN-bus profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_disabled">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="59"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="64"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
         <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
         <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_bms">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
-        <source>CAN-bus BMS (500 kbit/s)</source>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_canbus_high_voltage">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_oceanvolt">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
         <source>Oceanvolt (250 kbit/s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_rvc">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
         <source>RV-C (250 kbit/s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_up_bu_no_services">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
         <source>Up, but no services (250 kbit/s)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_up_but_no_services_500">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_devices">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="103"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
         <source>Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="118"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
         <source>NMEA2000-out</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="125"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
         <source>Unique identity number selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="134"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
         <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="137"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
         <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
         <source>Please wait, changing and checking the unique number takes a while</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="160"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
         <source>Check Unique id numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_press_to_check">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="165"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
         <source>Press to check</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
         <source>There is another device connected with this unique number, please select a new number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="186"/>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
         <source>OK: No other device is connected with this unique number.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_network_status">
-        <location filename="../pages/settings/PageSettingsCanbus.qml" line="218"/>
-        <source>Network status</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_cgwacs_phase_type">
-        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="64"/>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
         <source>Phase type</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_single_phase">
-        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="69"/>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
         <source>Single phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_multi_phase">
-        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="71"/>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
         <source>Multi phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="78"/>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
         <source>PV inverter on phase 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="88"/>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
         <source>PV inverter on phase 2 Position</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4198,98 +2307,171 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_display_off_time">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="37"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
         <source>Display off time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_displayoff_10sec">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
         <source>10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_displayoff_30sec">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
         <source>30 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_displayoff_1min">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
         <source>1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_displayoff_10min">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
         <source>10 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_displayoff_30min">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
         <source>30 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_displayoff_never">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="53"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_display_color_mode">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="59"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
         <source>Display mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_display_dark_mode">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="64"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
         <source>Dark</source>
         <extracomment>Dark colors mode</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_display_light_mode">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="67"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
         <source>Light</source>
         <extracomment>Light colors mode</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_display_auto_mode">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="70"/>
-        <source>Auto</source>
-        <extracomment>Auto colors mode: will automatically switch to Dark or Light mode</extracomment>
+    <message id="settings_display_minmax">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_display_onscreen_ui">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_display_remote_console_ui">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_display_classic_ui">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_display_new_ui">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_restarting_app">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_app_restarted">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_switch_ui">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_has_switched_ui">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_brief_view_levels">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="88"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
         <source>Brief view levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_language">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="96"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_language_changing_language">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="127"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
         <source>Changing language</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_language_change_failed">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_language_change_succeeded">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_language_please_wait">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="129"/>
-        <source>Please wait while the language is changed</source>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_units">
-        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_briefview_level">
-        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="32"/>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
         <source>Level %1</source>
         <extracomment>Level number</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_briefview_show_percentage">
-        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="52"/>
-        <source>Show %</source>
+    <message id="settings_briefview_unit">
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
         <extracomment>Show percentage values in Brief view</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_briefview_unit_none">
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_briefview_unit_absolute">
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_briefview_unit_percentages">
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_units_energy">
@@ -4303,22 +2485,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_units_amps">
-        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="24"/>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
         <source>Current (Amps)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_units_amps_exceptions">
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_units_celsius">
-        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="37"/>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
         <source>Celsius</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_units_fahrenheit">
-        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="39"/>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
         <source>Fahrenheit</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="components_volumeunit_volume">
-        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="51"/>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
         <source>Volume</source>
         <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
         <translation type="unfinished"></translation>
@@ -4330,7 +2517,8 @@
     </message>
     <message id="settings_dvcc_charge_current_limits">
         <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
-        <source>Charge Current limits</source>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
@@ -4339,7 +2527,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-        <location filename="../pages/settings/PageSettingsDvcc.qml" line="53"/>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
         <source>Maximum charge voltage</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4410,33 +2598,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-        <location filename="../pages/settings/PageSettingsDvcc.qml" line="180"/>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
         <source>Auto selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_auto_selected_none">
-        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
         <source>None</source>
         <extracomment>Indicates no option is selected</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_build_date_time">
-        <location filename="../pages/settings/PageSettingsFirmware.qml" line="26"/>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
         <source>Build date/time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_online_updates">
-        <location filename="../pages/settings/PageSettingsFirmware.qml" line="32"/>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
         <source>Online updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-        <location filename="../pages/settings/PageSettingsFirmware.qml" line="40"/>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
         <source>Install firmware from SD/USB</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_stored_backup_firmware">
-        <location filename="../pages/settings/PageSettingsFirmware.qml" line="48"/>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
         <source>Stored backup firmware</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4492,25 +2680,25 @@
         <source>Update feed</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_firmware_latest_release">
+    <message id="settings_firmware_official_release">
         <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-        <source>Latest release</source>
+        <source>Official release</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_firmware_latest_release_candidate">
+    <message id="settings_firmware_beta_release">
         <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-        <source>Latest release candidate</source>
+        <source>Beta release</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_firmware_testing">
+    <message id="settings_firmware_testing_internal">
         <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-        <source>Testing</source>
+        <source>Testing (Victron internal)</source>
         <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_firmware_develop">
+    <message id="settings_firmware_develop_internal">
         <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-        <source>Develop</source>
+        <source>Develop (Victron internal)</source>
         <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
         <translation type="unfinished"></translation>
     </message>
@@ -4588,32 +2776,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
         <source>Multiphase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
         <source>L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
         <source>L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
         <source>L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
         <source>Split-phase (L1+L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="58"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4684,87 +2872,232 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_access_level">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="72"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
         <source>Access level</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_access_user">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="78"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
         <source>User</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_access_user_installer">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
         <source>User &amp; Installer</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_access_superuser">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
         <source>Superuser</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_access_service">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
         <source>Service</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_set_root_password">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="90"/>
-        <source>Set root password</source>
+    <message id="settings_access_incorrect_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_network_security_profile">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_indeterminate">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_secured">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_secured_caption">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_weak">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_weak_caption">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_unsecured">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_unsecured_caption">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_secured_title">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_weak_title">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_unsecured_title">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_secured_description">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
+• The network communication is encrypted
+• A secure connection with VRM is enabled
+• Insecure settings cannot be enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_weak_description">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
+• Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_profile_unsecured_description">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
+• Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_root_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_root_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_root_password_changed_to">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ssh_on_lan">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
         <source>SSH on LAN</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_remote_support">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
         <source>Remote support</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_remote_support_tunnel">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="119"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
         <source>Remote support tunnel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_remote_ip_and_support">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="128"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
         <source>Remote support IP and port</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_logout">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_logout_dialog_title">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_logout_dialog_description">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_logout_dialog_accept_text">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_reboot_now">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="136"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
         <source>Reboot now</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="press_ok_to_reboot">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="dialoglayer_rebooting">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_audible_alarm">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="143"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
         <source>Audible alarm</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_enable_status_leds">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_demo_mode">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="154"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
         <source>Demo mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_demo_ess">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="163"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
         <source>ESS demo</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_demo_1">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="165"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
         <source>Boat/Motorhome demo 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_demo_2">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="167"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
         <source>Boat/Motorhome demo 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_demo_mode_caption">
-        <location filename="../pages/settings/PageSettingsGeneral.qml" line="177"/>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
         <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4778,53 +3111,66 @@
         <source>Minimum run time</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="page_settings_generator_warm_up_time">
+    <message id="settings_page_generator_warm_up_cool_down">
         <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_generator_warm_up_time">
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
         <source>Warm-up time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="53"/>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
         <source>Cool-down time</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="page_settings_generator_stop_time">
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="64"/>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
         <source>Detect generator at AC input</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="71"/>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
         <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="75"/>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
         <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
-        <source>Alarm when generator is not in auto start mode</source>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="102"/>
-        <source>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</source>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="117"/>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
         <source>Quiet hours start time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="125"/>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
         <source>Quiet hours end time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-        <location filename="../pages/settings/PageSettingsGenerator.qml" line="133"/>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
         <source>Run time and service</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4980,22 +3326,22 @@ If that doesn&apos;t work, check sim-card in a phone to make sure that there is 
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-        <location filename="../pages/settings/PageSettingsGsm.qml" line="179"/>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
         <source>APN name</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-        <location filename="../pages/settings/PageSettingsGsm.qml" line="193"/>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
         <source>Use authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_gsm_user_name">
-        <location filename="../pages/settings/PageSettingsGsm.qml" line="207"/>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
         <source>User name</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_settings_gsm_imei">
-        <location filename="../pages/settings/PageSettingsGsm.qml" line="222"/>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5009,152 +3355,230 @@ If that doesn&apos;t work, check sim-card in a phone to make sure that there is 
         <source>No ESS Assistant found</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_ess_rs_information">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_ess_grid_metering">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="51"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
         <source>Grid metering</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_external_meter">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="56"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
         <source>External meter</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_inverter_charger">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
         <source>Inverter/Charger</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="64"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
         <source>Inverter AC output in use</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_ess_self_consumption_battery">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_all_system_loads">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_only_critical_loads">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_ess_multiphase_regulation">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="71"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
         <source>Multiphase regulation</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_phase_compensation">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
         <source>Total of all phases</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_individual_phase">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="81"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
         <source>Individual phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="87"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
         <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="90"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
         <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_min_soc">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="101"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
         <source>Minimum SOC (unless grid fails)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="122"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
         <source>Active SOC limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_peak_shaving">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="131"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
         <source>Peak shaving</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_ess_scheduled_charge_levels">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_active">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_ess_above_minimum_soc_only">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="143"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
         <source>Above minimum SOC only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_ess_always">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="145"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="151"/>
-        <source>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
-See documentation for further information.</source>
+See documentation for further information.</oldsource>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_ess_do_not_perform_peak_shaving">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="154"/>
-        <source>Use this option in systems that do not perform peak shaving.</source>
+    <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_limit_system_ac_import_current">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_limit_ac_import_restrictions">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_max_system_import_current">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_limit_system_ac_export_current">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_limit_ac_export_restrictions">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_max_system_export_current">
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="169"/>
-        <source>BatteryLife state</source>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="181"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
         <source>Discharge disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="183"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
         <source>Slow charge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_battery_life_sustain">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="185"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
         <source>Sustain</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_battery_life_recharge">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="187"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
         <source>Recharge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="195"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
         <source>Limit charge power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_max_charge_power">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="214"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
         <source>Maximum charge power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="226"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
         <source>Limit inverter power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="245"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
         <source>Maximum inverter power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="255"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
         <source>Grid setpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
         <source>Grid feed-in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_ess_scheduled_charging">
-        <location filename="../pages/settings/PageSettingsHub4.qml" line="277"/>
-        <source>Scheduled charging</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
@@ -5173,73 +3597,33 @@ See documentation for further information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_max_feed_in">
-        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="61"/>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
         <source>Maximum feed-in</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="72"/>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
         <source>Feed-in limiting active</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_io_analog_inputs">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="29"/>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
         <source>Analog inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_io_digital_inputs">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="57"/>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
         <source>Digital inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_io_digital_input">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="73"/>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
         <source>Digital input %1</source>
         <extracomment>%1 = number of the digital input</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_io_digital_input_pulse_meter">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="78"/>
-        <source>Pulse meter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_io_digital_input_door_alarm">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="80"/>
-        <source>Door alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_io_digital_input_bilge_pump">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="82"/>
-        <source>Bilge pump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_io_digital_input_bilge_alarm">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="84"/>
-        <source>Bilge alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_io_digital_input_burglar_alarm">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="86"/>
-        <source>Burglar alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_io_digital_input_smoke_alarm">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="88"/>
-        <source>Smoke alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_io_digital_input_bilge_fire">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
-        <source>Fire alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_io_digital_input_co2_alarm">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="92"/>
-        <source>CO2 alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_io_bt_sensors">
-        <location filename="../pages/settings/PageSettingsIo.qml" line="103"/>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
         <source>Bluetooth sensors</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5256,23 +3640,37 @@ Documentation at https://ve3.nl/vol</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_large_access_signal_k">
-        <location filename="../pages/settings/PageSettingsLarge.qml" line="31"/>
-        <source>Access Signal K at http://venus.local:3000 and via VRM</source>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_large_node_red">
-        <location filename="../pages/settings/PageSettingsLarge.qml" line="39"/>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
         <source>Node-RED</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-        <location filename="../pages/settings/PageSettingsLarge.qml" line="47"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
         <source>Enabled (safe mode)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="page_settings_nodered_factory_reset">
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_nodered_factory_reset_confirmation">
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_large_access_node_red">
-        <location filename="../pages/settings/PageSettingsLarge.qml" line="53"/>
-        <source>Access Node-RED at https://venus.local:1881 and via VRM</source>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
@@ -5281,234 +3679,269 @@ Documentation at https://ve3.nl/vol</source>
         <extracomment>%1 = number of seconds</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_logging_enabled">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="39"/>
-        <source>Logging enabled</source>
+    <message id="settings_logging_vrm_portal">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_vrm_portal_readonly">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_vrm_portal_full">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_vrm_portal_mode_confirm_title">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_vrm_portal_mode_confirm_description">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_portal_id">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="49"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
         <source>VRM Portal ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_log_interval">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
         <source>Log interval</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_1_min">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="58"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
         <source>1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_5_min">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="60"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
         <source>5 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_10_min">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="62"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
         <source>10 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_15_min">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="64"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
         <source>15 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_30_min">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="66"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
         <source>30 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_1_hr">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="68"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
         <source>1 hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_2_hr">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="70"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
         <source>2 hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_4_hr">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="72"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
         <source>4 hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_12_hr">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="74"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
         <source>12 hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_1_day">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="76"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
         <source>1 day</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_https_enabled">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="84"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
         <source>Use secure connection (HTTPS)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_last_contact">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="90"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
         <source>Last contact</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_connection_status">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_connection_error_150">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="110"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
         <source>#150 Unexpected response text</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_connection_error_151">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
         <source>#151 Unexpected HTTP response</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_connection_error_152">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="116"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
         <source>#152 Connection timeout</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_connection_error_153">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="119"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
         <source>#153 Connection error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_connection_error_154">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="122"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
         <source>#154 DNS failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_connection_error_155">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="125"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
         <source>#155 Routing error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_connection_error_156">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="128"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
         <source>#156 VRM unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_connection_error_157">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="131"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
         <source>#159 Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_connection_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="137"/>
-        <source>Connection error</source>
+    <message id="settings_connection_error_https_channel">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_connection_error_http_channel">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_connection_error_realtime_channel">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_connection_error_rpc_channel">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_error_message">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="144"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
         <source>Error message: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_vrm_communication">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="155"/>
-        <source>VRM two-way communication</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_no_contact_reboot">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="161"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
         <source>Reboot device when no contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="171"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
         <source>No contact reset delay (hh:mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_storage_location">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="177"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
         <source>Storage location</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
         <source>No buffer active</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_internal_storage">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="182"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
         <source>Internal storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_transferring">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="184"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
         <source>Transferring</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_external_storage">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="186"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
         <source>External storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_unknown_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="195"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_no_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="198"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
         <source>No Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_no_space_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
         <source>No space left on storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_io_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="202"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
         <source>IO error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_mount_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="204"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
         <source>Mount error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
         <source>Contains firmware image. Not using.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="208"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
         <source>SD card / USB stick not writable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="217"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
         <source>Free disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_byte">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
         <source>byte</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_bytes">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_stored_records">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="230"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
         <source>Stored records</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_records_count">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="233"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
         <source>%1 records</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-        <location filename="../pages/settings/PageSettingsLogger.qml" line="241"/>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
         <source>Oldest record age</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5538,23 +3971,28 @@ Documentation at https://ve3.nl/vol</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_function_relay1">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
         <source>Function (Relay 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_function">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="24"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_alarm_relay">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
         <source>Alarm relay</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_relay_generator_start_stop">
+    <message id="settings_relay_genset_start_stop">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_relay_genset_helper_relay">
         <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
-        <source>Generator start/stop</source>
+        <source>Connected genset helper relay</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_tank_pump">
@@ -5564,7 +4002,7 @@ Documentation at https://ve3.nl/vol</source>
     </message>
     <message id="settings_relay_manual">
         <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5583,143 +4021,81 @@ Documentation at https://ve3.nl/vol</source>
         <source>Normally closed</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_relay_alarm_relay_on">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="58"/>
-        <source>Alarm relay on</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_relay_relay1on">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="76"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
         <source>Relay 1 on</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_on">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="78"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
         <source>Relay on</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_function_relay2">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="87"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
         <source>Function (Relay 2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_relay2on">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="101"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
         <source>Relay 2 on</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-        <location filename="../pages/settings/PageSettingsRelay.qml" line="108"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
         <source>Temperature control rules</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="89"/>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
         <source>Relay activation on temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="113"/>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
         <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_remoteconsole_reboot_warning">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="16"/>
-        <source>Manually reboot the GX device after changing these settings.
-
-First time use? Make sure to either set or disable the password check.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_password_disable_password_check">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="21"/>
-        <source>Disable password check</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_disable_password">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="23"/>
-        <source>Disable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_password_check_disabled">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="27"/>
-        <source>Password check has been disabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_enable_password_check">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="36"/>
-        <source>Enable password check</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_enter_password">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="38"/>
-        <source>Enter password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_password_check_is_disabled">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="44"/>
-        <source>Password check is disabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_password_check_enabled">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="46"/>
-        <source>Password check enabled and the password is set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_enable_on_vrm">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="61"/>
-        <source>Enable on VRM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_vrm_status">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="67"/>
-        <source>Remote Console on VRM - status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_enable_on_lan">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="82"/>
-        <source>Enable on LAN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_remoteconsole_enable_on_lan_warning">
-        <location filename="../pages/settings/PageSettingsRemoteConsole.qml" line="91"/>
-        <source>Security warning: only enable the console on LAN when the GX device is connected to a trusted network.</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_firmware_version_switch_option">
-        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="47"/>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
         <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_backup_version">
-        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="55"/>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
         <source>Firmware %1 (%2)</source>
         <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="58"/>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
         <source>Press to boot</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_firmware_switching_not_possible_indeterminate_profile">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_firmware_rebooting_to">
-        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="69"/>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
         <source>Rebooting to %1</source>
         <extracomment>%1 = backup version</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="73"/>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
         <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_current_version">
-        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="83"/>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
         <source>Firmware %1 (%2)</source>
         <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="90"/>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
         <source>Backup firmware not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5791,23 +4167,18 @@ First time use? Make sure to either set or disable the password check.</source>
         <source>Modbus TCP</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_services_mqtt_on_lan_ssl">
-        <location filename="../pages/settings/PageSettingsServices.qml" line="33"/>
-        <source>MQTT on LAN (SSL)</source>
+    <message id="settings_services_tailscale_remote_vpn_access">
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_services_mqtt_on_lan_insecure">
-        <location filename="../pages/settings/PageSettingsServices.qml" line="41"/>
-        <source>MQTT on LAN (Plain-text)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
+    <message id="settings_services_mqtt_access">
         <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
-        <source>Console on VE.Direct 1</source>
+        <source>MQTT Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-        <location filename="../pages/settings/PageSettingsServices.qml" line="81"/>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
         <source>CAN-bus over TCP/IP (Debug)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5866,44 +4237,71 @@ First time use? Make sure to either set or disable the password check.</source>
         <source>AC input 2</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_system_ac_position">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_system_ac_input_and_output">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_system_ac_input_and_output_description">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_system_ac_output_only">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_system_ac_output_only_description">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_system_monitor_for_grid_failure">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="89"/>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
         <source>Monitor for grid failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="91"/>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
         <source>Monitor for shore disconnect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_battery_monitor">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="104"/>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
         <source>Battery monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="107"/>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
         <source>Unavailable monitor, set another</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_auto_selected">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
         <source>Auto-selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_has_dc_system">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="138"/>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
         <source>Has DC system</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_battery_measurements">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="144"/>
-        <source>Battery Measurements</source>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_system_status">
-        <location filename="../pages/settings/PageSettingsSystem.qml" line="150"/>
-        <source>System Status</source>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
@@ -5932,132 +4330,138 @@ First time use? Make sure to either set or disable the password check.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-        <location filename="../pages/settings/PageSettingsTankPump.qml" line="39"/>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
         <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_pump_state">
-        <location filename="../pages/settings/PageSettingsTankPump.qml" line="48"/>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
         <source>Pump state</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_pump_auto">
-        <location filename="../pages/settings/PageSettingsTankPump.qml" line="57"/>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tank_sensor">
-        <location filename="../pages/settings/PageSettingsTankPump.qml" line="68"/>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
         <source>Tank sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-        <location filename="../pages/settings/PageSettingsTankPump.qml" line="71"/>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
         <source>Unavailable sensor, set another</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tank_start_level">
-        <location filename="../pages/settings/PageSettingsTankPump.qml" line="91"/>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
         <source>Start level</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tank_stop_level">
-        <location filename="../pages/settings/PageSettingsTankPump.qml" line="100"/>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
         <source>Stop level</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="116"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
         <source>Connection lost</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="118"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
         <source>Unplugged</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_name">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="132"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_tcpip_wired">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_tcpip_hidden">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="134"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
         <source>[Hidden]</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="153"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
         <source>Connect to network?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_connect">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="155"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_forget_network">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
         <source>Forget network?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_forget">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
         <source>Forget</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="188"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
         <source>Are you sure that you want to forget this network?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_mac_address">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="204"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
         <source>MAC address</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_ip_config">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
         <source>IP configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_auto">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="216"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_manual">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="218"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_off">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="220"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_fixed">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="222"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_netmask">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="246"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
         <source>Netmask</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_gateway">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
         <source>Gateway</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_dns_server">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="262"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
         <source>DNS server</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tcpip_link_local">
-        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="272"/>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
         <source>Link-local IP address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6087,189 +4491,190 @@ First time use? Make sure to either set or disable the password check.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_wifi_no_access_points">
-        <location filename="../pages/settings/PageSettingsWifi.qml" line="33"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
         <source>No access points</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-        <location filename="../pages/settings/PageSettingsWifi.qml" line="39"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
         <source>No Wi-Fi adapter connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_wifi_create_ap">
-        <location filename="../pages/settings/PageSettingsWifiWithAccessPoint.qml" line="21"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
         <source>Create access point</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_wifi_networks">
-        <location filename="../pages/settings/PageSettingsWifiWithAccessPoint.qml" line="39"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
         <source>Wi-Fi networks</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_wifi_disable_ap">
-        <location filename="../pages/settings/PageSettingsWifiWithAccessPoint.qml" line="51"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
         <source>Disable Access Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-        <location filename="../pages/settings/PageSettingsWifiWithAccessPoint.qml" line="53"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
         <source>Are you sure that you want to disable the access point?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_date_time_utc">
-        <location filename="../pages/settings/PageTzInfo.qml" line="71"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
         <source>Date/Time UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_date_time_local">
-        <location filename="../pages/settings/PageTzInfo.qml" line="77"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
         <source>Date/Time local</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_time_zone">
-        <location filename="../pages/settings/PageTzInfo.qml" line="89"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
         <source>Time zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_africa">
-        <location filename="../pages/settings/PageTzInfo.qml" line="179"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
         <source>Africa</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_america">
-        <location filename="../pages/settings/PageTzInfo.qml" line="185"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
         <source>America</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_antartica">
-        <location filename="../pages/settings/PageTzInfo.qml" line="191"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
         <source>Antartica</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_artic">
-        <location filename="../pages/settings/PageTzInfo.qml" line="197"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
         <source>Artic</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_asia">
-        <location filename="../pages/settings/PageTzInfo.qml" line="203"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
         <source>Asia</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_atlantic">
-        <location filename="../pages/settings/PageTzInfo.qml" line="209"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
         <source>Atlantic</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_ustralia">
-        <location filename="../pages/settings/PageTzInfo.qml" line="215"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
         <source>Australia</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_europe">
-        <location filename="../pages/settings/PageTzInfo.qml" line="221"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_indian">
-        <location filename="../pages/settings/PageTzInfo.qml" line="227"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
         <source>Indian</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_pacific">
-        <location filename="../pages/settings/PageTzInfo.qml" line="233"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
         <source>Pacific</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tz_etc">
-        <location filename="../pages/settings/PageTzInfo.qml" line="239"/>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
         <source>Etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="276"/>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
         <source>Unconnected %1</source>
         <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="357"/>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
         <source>Reboot now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="360"/>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
         <source>VRM instance changes will not be applied until the device is rebooted.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_vrm_device_instances_close">
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_vrm_device_instances_rebooting">
-        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="378"/>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
         <source>Device is rebooting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="381"/>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
         <source>Device has been rebooted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_device_list">
-        <location filename="../pages/SettingsPage.qml" line="28"/>
-        <source>Device List</source>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_general">
-        <location filename="../pages/SettingsPage.qml" line="33"/>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware">
-        <location filename="../pages/SettingsPage.qml" line="38"/>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
         <source>Firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_date_and_time">
-        <location filename="../pages/SettingsPage.qml" line="43"/>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
         <source>Date &amp; Time</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_remote_console">
-        <location filename="../pages/SettingsPage.qml" line="48"/>
-        <source>Remote Console</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_system_setup">
-        <location filename="../pages/SettingsPage.qml" line="53"/>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
         <source>System setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_system_dvcc">
-        <location filename="../pages/SettingsPage.qml" line="58"/>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
         <source>DVCC</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_display_and_language">
-        <location filename="../pages/SettingsPage.qml" line="63"/>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
         <source>Display &amp; Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_online_portal">
-        <location filename="../pages/SettingsPage.qml" line="68"/>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
         <source>VRM online portal</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_ess">
-        <location filename="../pages/SettingsPage.qml" line="73"/>
-        <source>ESS</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_energy_meters">
-        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
         <source>Energy meters</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_pv_inverters">
-        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
         <source>PV inverters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_modbus_tcp_udp_devices">
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_ethernet">
@@ -6283,113 +4688,90 @@ First time use? Make sure to either set or disable the password check.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gsm_modem">
-        <location filename="../pages/SettingsPage.qml" line="100"/>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
         <source>GSM modem</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_gps">
-        <location filename="../pages/SettingsPage.qml" line="105"/>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_bluetooth">
-        <location filename="../pages/SettingsPage.qml" line="110"/>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_generator_start_stop">
-        <location filename="../pages/SettingsPage.qml" line="116"/>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
         <source>Generator start/stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_tank_pump">
-        <location filename="../pages/SettingsPage.qml" line="121"/>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
         <source>Tank pump</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_services">
-        <location filename="../pages/SettingsPage.qml" line="131"/>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
         <source>Services</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_io">
-        <location filename="../pages/SettingsPage.qml" line="136"/>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_venus_os_large_features">
-        <location filename="../pages/SettingsPage.qml" line="141"/>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
         <source>Venus OS Large features</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_vrm_device_instances">
-        <location filename="../pages/SettingsPage.qml" line="147"/>
-        <source>VRM Device Instances</source>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_alarms_low_battery_voltage_alarm">
-        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="33"/>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
         <source>Low battery voltage alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_alarms_high_battery_voltage_alarm">
-        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="42"/>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
         <source>High battery voltage alarm</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="charger_alarms_header_last_errors">
-        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="54"/>
-        <source>Last Errors</source>
-        <extracomment>Details of most recent errors</extracomment>
+    <message id="charger_alarms_high_temperature_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="charger_alarm_last_error">
-        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="73"/>
-        <source>Last error</source>
-        <extracomment>Details of last error</extracomment>
+    <message id="charger_alarms_short_circuit_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="charger_alarm_2nd_last_error">
-        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="76"/>
-        <source>2nd last error</source>
-        <extracomment>Details of 2nd last error</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="charger_alarm_3rd_last_error">
-        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="79"/>
-        <source>3rd last error</source>
-        <extracomment>Details of 3rd last error</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="charger_alarm_4th_last_error">
-        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="82"/>
-        <source>4th last error</source>
-        <extracomment>Details of 4th last error</extracomment>
+    <message id="charger_alarms_header_active_errors">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_table_view">
-        <location filename="../pages/solar/SolarChargerHistoryPage.qml" line="24"/>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
         <source>Table view</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_chart">
-        <location filename="../pages/solar/SolarChargerHistoryPage.qml" line="26"/>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
         <source>Chart</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="charger_history_last_7_days">
-        <location filename="../pages/solar/SolarChargerHistoryPage.qml" line="52"/>
-        <source>Last 7 days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="charger_history_last_14_days">
-        <location filename="../pages/solar/SolarChargerHistoryPage.qml" line="54"/>
-        <source>Last 14 days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="charger_history_last_30_days">
-        <location filename="../pages/solar/SolarChargerHistoryPage.qml" line="56"/>
-        <source>Last 30 days</source>
+    <message id="charger_history_last_x_days">
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_networked">
@@ -6397,157 +4779,134 @@ First time use? Make sure to either set or disable the password check.</source>
         <source>Networked</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="charger_network_status">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="30"/>
-        <source>Network status</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="charger_mode_setting">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="38"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
         <source>Mode setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_standalone">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="46"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
         <source>Standalone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_charge">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="49"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
         <source>Charge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_external_control">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="52"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
         <source>External control</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_charge_hub_1">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="55"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
         <source>Charge &amp; HUB-1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_bms">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="58"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
         <source>BMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_charge_bms">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="61"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
         <source>Charge &amp; BMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_ext_control_bms">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="64"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
         <source>Ext. Control &amp; BMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="67"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
         <source>Charge, Hub-1 &amp; BMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_master_setting">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="78"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
         <source>Master setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_slave">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="86"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
         <source>Slave</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_group_master">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="89"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
         <source>Group master</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_charge_master">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="92"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
         <source>Charge master</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_group_charge_master">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="95"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
         <source>Group &amp; Charge master</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_charge_voltage">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="106"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
         <source>Charge voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_network_bms_controlled">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="121"/>
-        <source>BMS Controlled</source>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_network_bms_control">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="129"/>
-        <source>BMS Control</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="charger_network_bms_control_reset">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="132"/>
-        <source>Reset</source>
-        <extracomment>Reset the BMS control</extracomment>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_network_bms_control_info">
-        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="143"/>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
         <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_total_pv_power">
-        <location filename="../pages/solar/SolarChargerPage.qml" line="53"/>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
         <source>Total PV Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_load">
-        <location filename="../pages/solar/SolarChargerPage.qml" line="118"/>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-        <location filename="../pages/solar/SolarChargerPage.qml" line="140"/>
-        <source>Alarms and Errors</source>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_found_with_count">
-        <location filename="../pages/solar/SolarChargerPage.qml" line="145"/>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
         <source>%1 found</source>
         <extracomment>Shows number of items found. %1 = number of items</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_name">
-        <location filename="../pages/solar/SolarChargerPage.qml" line="176"/>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
         <source>%1 History</source>
         <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_networked_operation">
-        <location filename="../pages/solar/SolarChargerPage.qml" line="184"/>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
         <source>Networked operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solardevices_pv_charger">
-        <location filename="../pages/solar/SolarDeviceListPage.qml" line="119"/>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
         <source>PV Charger</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_device_page_dc">
-        <location filename="../pages/vebusdevice/OverviewVeBusDevicePage.qml" line="135"/>
-        <source>DC</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_device_page_state_of_charge">
-        <location filename="../pages/vebusdevice/OverviewVeBusDevicePage.qml" line="141"/>
-        <source>SOC %1%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_device_product_page">
-        <location filename="../pages/vebusdevice/OverviewVeBusDevicePage.qml" line="147"/>
-        <source>Product page</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
@@ -6556,113 +4915,103 @@ First time use? Make sure to either set or disable the password check.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="126"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
         <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="132"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
         <source>Update the MK3</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_press_to_update">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="134"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
         <source>Press to update</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="138"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
         <source>Updating the MK3, values will reappear after the update is complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_charging_to_100">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
         <source>Charging the battery to 100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_in_progress">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="155"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
         <source>In progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_press_to_stop">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="162"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
         <source>Press to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_press_to_start">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="165"/>
         <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
         <source>Press to start</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
         <source>Charging the battery to 100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="171"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
         <source>Charge the battery to 100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="180"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
         <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_use_shore_power">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="198"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
         <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="203"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
         <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="231"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
         <source>DC Voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_page_dc_current">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="238"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
         <source>DC Current</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="vebus_device_page_battery_temperature">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
-        <source>Battery temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="vebus_device_page_advanced">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="271"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="vebus_device_alarm_setup">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="290"/>
-        <source>Alarm setup</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="vebus_device_bms_message">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="301"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
         <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_bms_not_found">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="307"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
         <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_vebus_bms">
-        <location filename="../pages/vebusdevice/PageVeBus.qml" line="313"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
         <source>VE.Bus BMS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6678,7 +5027,7 @@ Do you want to continue?</source>
     </message>
     <message id="vebus_device_interrupt_equalization">
         <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="148"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
         <source>Interrupt equalization</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6704,106 +5053,109 @@ Do you want to continue?</source>
     </message>
     <message id="vebus_device_update_firmware">
         <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-        <source>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</source>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_charger_not_ready">
         <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-        <source>Charger not ready, equalization cannot be started.</source>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
         <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-        <source>Equalization cannot be triggered during bulk charge state.</source>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="152"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
         <source>Interrupt and restart absorption</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="158"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
         <source>Interrupt and go to float</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_interrupt">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="164"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
         <source>Interrupt</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="170"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
         <source>Do not interrupt</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="194"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
         <source>Redetect VE.Bus system</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_redetecting">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="197"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
         <source>Redetecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="199"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
         <source>Press to redetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="207"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
         <source>Restart VE.Bus system</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_restarting">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="210"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
         <source>Restarting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_press_to_restart">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="212"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
         <source>Press to restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="220"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
         <source>AC input 1 ignored</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="228"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
         <source>AC input 2 ignored</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="236"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
         <source>ESS Relay test</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_ess_relay_test_completed">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="242"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
         <source>Completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_ess_relay_test_pending">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="244"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
         <source>Pending</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_diagnostics">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="251"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
         <source>VE.Bus diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="270"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
         <source>Network quality counter Phase L%1, device %2 (%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="51"/>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
         <source>VE.Bus Error 8 / 11 report</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6935,13 +5287,8 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_active_ac_input">
-        <location filename="../pages/vebusdevice/VeBusDeviceActiveAcInputTextItem.qml" line="19"/>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
         <source>Active AC Input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_device_page_ac_in">
-        <location filename="../pages/vebusdevice/VeBusDeviceActiveAcInputTextItem.qml" line="25"/>
-        <source>AC in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_alarm_group_warning">
@@ -6974,23 +5321,13 @@ Do you want to continue?</source>
         <source>Voltage sense error</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="vebus_device_overload">
-        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="14"/>
-        <source>Overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_device_dc_ripple">
-        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-        <source>DC ripple</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="vebus_device_voltage_sensor">
-        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="18"/>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
         <source>Voltage Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="vebus_device_phase_rotation">
-        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="21"/>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
         <source>Phase rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7019,731 +5356,878 @@ Do you want to continue?</source>
         <source>VE.Bus BMS version</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="vebus_no_adjustable_by_dmc">
-        <location filename="../pages/vebusdevice/VeBusDeviceModeButton.qml" line="21"/>
-        <source>This setting is disabled when a Digital Multi Control is connected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_no_adjustable_by_bms">
-        <location filename="../pages/vebusdevice/VeBusDeviceModeButton.qml" line="23"/>
-        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_no_adjustable_text_by_config">
-        <location filename="../pages/vebusdevice/VeBusDeviceModeButton.qml" line="25"/>
-        <source>This setting is disabled. Possible reasons are &quot;Overruled by remote&quot; is not enabled or an assistant is preventing the adjustment. Please, check the inverter configuration with VEConfigure.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="vebus_device_setting_disabled">
-        <location filename="../components/AcInputsCurrentLimits.qml" line="16"/>
-        <source>This setting is disabled. Possible reasons are &quot;Overruled by remote&quot; is not enabled or an assistant is preventing the adjustment. Please, check the inverter configuration with VEConfigure.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="%1%">
-        <location filename="../components/CircularMultiGauge.qml" line="112"/>
-        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
-        <source>%1%</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="common_words_ac_in">
         <location filename="../components/CommonWords.qml" line="14"/>
         <source>AC In</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_grid">
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_ac_input">
-        <location filename="../components/CommonWords.qml" line="17"/>
+        <location filename="../components/CommonWords.qml" line="525"/>
         <source>AC Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_input_1">
-        <location filename="../components/CommonWords.qml" line="20"/>
+        <location filename="../components/CommonWords.qml" line="521"/>
         <source>AC Input 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_input_2">
-        <location filename="../components/CommonWords.qml" line="23"/>
+        <location filename="../components/CommonWords.qml" line="523"/>
         <source>AC Input 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_input_role">
-        <location filename="../components/CommonWords.qml" line="27"/>
+        <location filename="../components/CommonWords.qml" line="21"/>
         <source>Role</source>
-        <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_add_device">
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_load">
-        <location filename="../components/CommonWords.qml" line="30"/>
+        <location filename="../components/CommonWords.qml" line="24"/>
         <source>AC load</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_out">
-        <location filename="../components/CommonWords.qml" line="33"/>
+        <location filename="../components/CommonWords.qml" line="27"/>
         <source>AC Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_output">
-        <location filename="../components/CommonWords.qml" line="36"/>
+        <location filename="../components/CommonWords.qml" line="30"/>
         <source>AC Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_phase_x">
-        <location filename="../components/CommonWords.qml" line="40"/>
+        <location filename="../components/CommonWords.qml" line="34"/>
         <source>AC Phase L%1</source>
         <extracomment>%1 = phase number (1-3)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_sensor_x">
-        <location filename="../components/CommonWords.qml" line="43"/>
+        <location filename="../components/CommonWords.qml" line="37"/>
         <source>AC Sensor %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ac_sensor">
-        <location filename="../components/CommonWords.qml" line="46"/>
+        <location filename="../components/CommonWords.qml" line="40"/>
         <source>AC Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_active">
-        <location filename="../components/CommonWords.qml" line="50"/>
+        <location filename="../components/CommonWords.qml" line="44"/>
         <source>Active</source>
         <extracomment>Status is &apos;active&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_alarm">
-        <location filename="../components/CommonWords.qml" line="54"/>
+        <location filename="../components/CommonWords.qml" line="48"/>
         <source>Alarm</source>
         <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_alarm_setting_dc_ripple">
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_alarm_setup">
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_alarm_status">
-        <location filename="../components/CommonWords.qml" line="57"/>
+        <location filename="../components/CommonWords.qml" line="62"/>
         <source>Alarm status</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_alarms">
-        <location filename="../components/CommonWords.qml" line="60"/>
+        <location filename="../components/CommonWords.qml" line="65"/>
         <source>Alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_allow_to_charge">
-        <location filename="../components/CommonWords.qml" line="63"/>
+        <location filename="../components/CommonWords.qml" line="68"/>
         <source>Allow to charge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_allow_to_discharge">
-        <location filename="../components/CommonWords.qml" line="66"/>
+        <location filename="../components/CommonWords.qml" line="71"/>
         <source>Allow to discharge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_auto">
-        <location filename="../components/CommonWords.qml" line="69"/>
+        <location filename="../components/CommonWords.qml" line="74"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_automatic_scanning">
-        <location filename="../components/CommonWords.qml" line="72"/>
+        <location filename="../components/CommonWords.qml" line="77"/>
         <source>Automatic scanning</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="controlcard_generator_autostarted">
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_battery">
-        <location filename="../components/CommonWords.qml" line="75"/>
+        <location filename="../components/CommonWords.qml" line="83"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_battery_current">
-        <location filename="../components/CommonWords.qml" line="78"/>
+        <location filename="../components/CommonWords.qml" line="86"/>
         <source>Battery current</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_battery_temperature">
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_battery_voltage">
-        <location filename="../components/CommonWords.qml" line="81"/>
+        <location filename="../components/CommonWords.qml" line="92"/>
         <source>Battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_cancel">
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_charge_current">
-        <location filename="../components/CommonWords.qml" line="84"/>
+        <location filename="../components/CommonWords.qml" line="98"/>
         <source>Charge current</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_charging">
-        <location filename="../components/CommonWords.qml" line="88"/>
+        <location filename="../components/CommonWords.qml" line="102"/>
         <source>Charging</source>
         <extracomment>&quot;Charging&quot; state</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_clear_error_action">
-        <location filename="../components/CommonWords.qml" line="92"/>
+        <location filename="../components/CommonWords.qml" line="106"/>
         <source>Clear error</source>
         <extracomment>Action to clear an error state</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_closed_status">
-        <location filename="../components/CommonWords.qml" line="96"/>
+        <location filename="../components/CommonWords.qml" line="110"/>
         <source>Closed</source>
         <extracomment>Status is &apos;closed&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_connected">
-        <location filename="../components/CommonWords.qml" line="99"/>
+        <location filename="../components/CommonWords.qml" line="113"/>
         <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_current_amps">
-        <location filename="../components/CommonWords.qml" line="103"/>
+        <location filename="../components/CommonWords.qml" line="117"/>
         <source>Current</source>
         <extracomment>Electric current, as measured in Amps</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_current_transformers">
-        <location filename="../components/CommonWords.qml" line="106"/>
+        <location filename="../components/CommonWords.qml" line="120"/>
         <source>Current transformers</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_custom_name">
-        <location filename="../components/CommonWords.qml" line="109"/>
+        <location filename="../components/CommonWords.qml" line="123"/>
         <source>Custom name</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_daily_history">
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_dc">
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_debug">
-        <location filename="../components/CommonWords.qml" line="113"/>
+        <location filename="../components/CommonWords.qml" line="133"/>
         <source>Debug</source>
         <extracomment>Title for a menu item which displays debugging information</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_device">
-        <location filename="../components/CommonWords.qml" line="117"/>
+        <location filename="../components/CommonWords.qml" line="137"/>
         <source>Device</source>
         <extracomment>Title for device information</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_disabled">
-        <location filename="../components/CommonWords.qml" line="120"/>
+        <location filename="../components/CommonWords.qml" line="140"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_discharging">
-        <location filename="../components/CommonWords.qml" line="123"/>
+        <location filename="../components/CommonWords.qml" line="143"/>
         <source>Discharging</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_disconnected">
-        <location filename="../components/CommonWords.qml" line="126"/>
+        <location filename="../components/CommonWords.qml" line="146"/>
         <source>Disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_enable">
-        <location filename="../components/CommonWords.qml" line="129"/>
+        <location filename="../components/CommonWords.qml" line="149"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_enabled">
-        <location filename="../components/CommonWords.qml" line="132"/>
+        <location filename="../components/CommonWords.qml" line="152"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_energy">
-        <location filename="../components/CommonWords.qml" line="136"/>
+        <location filename="../components/CommonWords.qml" line="156"/>
         <source>Energy</source>
         <extracomment>Amount of charged energy</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_error">
-        <location filename="../components/CommonWords.qml" line="139"/>
+        <location filename="../components/CommonWords.qml" line="159"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_error_colon">
-        <location filename="../components/CommonWords.qml" line="142"/>
+        <location filename="../components/CommonWords.qml" line="162"/>
         <source>Error:</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_error_code">
-        <location filename="../components/CommonWords.qml" line="145"/>
+        <location filename="../components/CommonWords.qml" line="165"/>
         <source>Error code</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_error_not_a_number">
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_ess">
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_firmware_version">
-        <location filename="../components/CommonWords.qml" line="148"/>
+        <location filename="../components/CommonWords.qml" line="174"/>
         <source>Firmware version</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_generator">
-        <location filename="../components/CommonWords.qml" line="151"/>
+        <location filename="../components/CommonWords.qml" line="177"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="common_words_grid_meter">
-        <location filename="../components/CommonWords.qml" line="154"/>
-        <source>Grid meter</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="common_words_high_battery_temperature">
-        <location filename="../components/CommonWords.qml" line="157"/>
+        <location filename="../components/CommonWords.qml" line="183"/>
         <source>High battery temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_high_battery_voltage">
-        <location filename="../components/CommonWords.qml" line="160"/>
+        <location filename="../components/CommonWords.qml" line="186"/>
         <source>High battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_high_level_alarm">
-        <location filename="../components/CommonWords.qml" line="164"/>
+        <location filename="../components/CommonWords.qml" line="190"/>
         <source>High level alarm</source>
         <extracomment>An alarm that triggers when the level is too high</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-        <location filename="../components/CommonWords.qml" line="167"/>
+        <location filename="../components/CommonWords.qml" line="193"/>
         <source>High starter battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_high_temperature">
-        <location filename="../components/CommonWords.qml" line="170"/>
+        <location filename="../components/CommonWords.qml" line="196"/>
         <source>High temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-        <location filename="../components/CommonWords.qml" line="173"/>
+        <location filename="../components/CommonWords.qml" line="199"/>
         <source>High voltage alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_history">
-        <location filename="../components/CommonWords.qml" line="176"/>
+        <location filename="../components/CommonWords.qml" line="202"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_x_hours">
-        <location filename="../components/CommonWords.qml" line="179"/>
+        <location filename="../components/CommonWords.qml" line="205"/>
         <source>%1 Hour(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_idle">
-        <location filename="../components/CommonWords.qml" line="182"/>
+        <location filename="../components/CommonWords.qml" line="208"/>
         <source>Idle</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_inactive_status">
-        <location filename="../components/CommonWords.qml" line="186"/>
+        <location filename="../components/CommonWords.qml" line="212"/>
         <source>Inactive</source>
         <extracomment>Status is &apos;inactive&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_input_current_limit">
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_inverter_charger">
-        <location filename="../components/CommonWords.qml" line="189"/>
+        <location filename="../components/CommonWords.qml" line="218"/>
         <source>Inverter / Charger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_inverter_mode_eco">
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_inverter_overload">
-        <location filename="../components/CommonWords.qml" line="192"/>
+        <location filename="../components/CommonWords.qml" line="225"/>
         <source>Inverter overload</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ip_address">
-        <location filename="../components/CommonWords.qml" line="195"/>
+        <location filename="../components/CommonWords.qml" line="228"/>
         <source>IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_low_battery_temperature">
-        <location filename="../components/CommonWords.qml" line="198"/>
+        <location filename="../components/CommonWords.qml" line="231"/>
         <source>Low battery temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_low_battery_voltage">
-        <location filename="../components/CommonWords.qml" line="201"/>
+        <location filename="../components/CommonWords.qml" line="234"/>
         <source>Low battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_low_level_alarm">
-        <location filename="../components/CommonWords.qml" line="205"/>
+        <location filename="../components/CommonWords.qml" line="238"/>
         <source>Low level alarm</source>
         <extracomment>An alarm that triggers when the level is too low</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-        <location filename="../components/CommonWords.qml" line="208"/>
+        <location filename="../components/CommonWords.qml" line="241"/>
         <source>Low starter battery voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_low_state_of_charge">
-        <location filename="../components/CommonWords.qml" line="211"/>
+        <location filename="../components/CommonWords.qml" line="244"/>
         <source>Low state-of-charge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_low_temperature">
-        <location filename="../components/CommonWords.qml" line="214"/>
+        <location filename="../components/CommonWords.qml" line="247"/>
         <source>Low temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-        <location filename="../components/CommonWords.qml" line="217"/>
+        <location filename="../components/CommonWords.qml" line="250"/>
         <source>Low voltage alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_manual">
-        <location filename="../components/CommonWords.qml" line="220"/>
+        <location filename="../components/CommonWords.qml" line="253"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_manual_control">
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_manual_start">
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_manual_stop">
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_manufacturer">
-        <location filename="../components/CommonWords.qml" line="223"/>
+        <location filename="../components/CommonWords.qml" line="265"/>
         <source>Manufacturer</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_maximum_current">
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_maximum_power">
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_maximum_temperature">
-        <location filename="../components/CommonWords.qml" line="226"/>
+        <location filename="../components/CommonWords.qml" line="274"/>
         <source>Maximum temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_maximum_voltage">
-        <location filename="../components/CommonWords.qml" line="229"/>
+        <location filename="../components/CommonWords.qml" line="277"/>
         <source>Maximum voltage</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_minimum_current">
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_minimum_temperature">
-        <location filename="../components/CommonWords.qml" line="232"/>
+        <location filename="../components/CommonWords.qml" line="283"/>
         <source>Minimum temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_minimum_voltage">
-        <location filename="../components/CommonWords.qml" line="235"/>
+        <location filename="../components/CommonWords.qml" line="286"/>
         <source>Minimum voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_mode">
-        <location filename="../components/CommonWords.qml" line="238"/>
+        <location filename="../components/CommonWords.qml" line="289"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_model_name">
-        <location filename="../components/CommonWords.qml" line="241"/>
+        <location filename="../components/CommonWords.qml" line="292"/>
         <source>Model name</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_network_status">
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_no">
-        <location filename="../components/CommonWords.qml" line="244"/>
+        <location filename="../components/CommonWords.qml" line="298"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-        <location filename="../components/CommonWords.qml" line="247"/>
-        <source>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</source>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-        <location filename="../components/CommonWords.qml" line="250"/>
-        <source>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</source>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_no_error">
-        <location filename="../components/CommonWords.qml" line="253"/>
+        <location filename="../components/CommonWords.qml" line="307"/>
         <source>No error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_none_errors">
-        <location filename="../components/CommonWords.qml" line="257"/>
+        <location filename="../components/CommonWords.qml" line="311"/>
         <source>None</source>
         <extracomment>Indicates there are no errors</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_not_available">
-        <location filename="../components/CommonWords.qml" line="260"/>
+        <location filename="../components/CommonWords.qml" line="314"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_not_connected">
-        <location filename="../components/CommonWords.qml" line="263"/>
+        <location filename="../components/CommonWords.qml" line="317"/>
         <source>Not connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_off">
-        <location filename="../components/CommonWords.qml" line="266"/>
+        <location filename="../components/CommonWords.qml" line="320"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_offline">
-        <location filename="../components/CommonWords.qml" line="269"/>
+        <location filename="../components/CommonWords.qml" line="323"/>
         <source>Offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_ok">
-        <location filename="../components/CommonWords.qml" line="272"/>
+        <location filename="../components/CommonWords.qml" line="326"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_on">
-        <location filename="../components/CommonWords.qml" line="275"/>
+        <location filename="../components/CommonWords.qml" line="329"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_online">
-        <location filename="../components/CommonWords.qml" line="278"/>
+        <location filename="../components/CommonWords.qml" line="332"/>
         <source>Online</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_open_status">
-        <location filename="../components/CommonWords.qml" line="282"/>
+        <location filename="../components/CommonWords.qml" line="336"/>
         <source>Open</source>
         <extracomment>Status is &apos;open&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_open_circuit">
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_overall_history">
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_pending">
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_password">
-        <location filename="../components/CommonWords.qml" line="285"/>
+        <location filename="../components/CommonWords.qml" line="348"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_power_watts">
-        <location filename="../components/CommonWords.qml" line="289"/>
+        <location filename="../components/CommonWords.qml" line="352"/>
         <source>Power</source>
         <extracomment>Electric power, as measured in Watts</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_phase">
-        <location filename="../components/CommonWords.qml" line="292"/>
+        <location filename="../components/CommonWords.qml" line="355"/>
         <source>Phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_position_ac">
-        <location filename="../components/CommonWords.qml" line="296"/>
+        <location filename="../components/CommonWords.qml" line="359"/>
         <source>Position</source>
         <extracomment>AC input or output position</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_press_to_clear">
-        <location filename="../components/CommonWords.qml" line="299"/>
+        <location filename="../components/CommonWords.qml" line="362"/>
         <source>Press to clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_press_to_reset">
-        <location filename="../components/CommonWords.qml" line="302"/>
+        <location filename="../components/CommonWords.qml" line="365"/>
         <source>Press to reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_press_to_scan">
-        <location filename="../components/CommonWords.qml" line="305"/>
+        <location filename="../components/CommonWords.qml" line="368"/>
         <source>Press to scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_product_page">
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_pv_inverter">
-        <location filename="../components/CommonWords.qml" line="308"/>
+        <location filename="../components/CommonWords.qml" line="374"/>
         <source>PV Inverter</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_pv_power">
-        <location filename="../components/CommonWords.qml" line="312"/>
+        <location filename="../components/CommonWords.qml" line="378"/>
         <source>PV Power</source>
         <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_quiet_hours">
-        <location filename="../components/CommonWords.qml" line="315"/>
+        <location filename="../components/CommonWords.qml" line="381"/>
         <source>Quiet hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_relay">
-        <location filename="../components/CommonWords.qml" line="319"/>
+        <location filename="../components/CommonWords.qml" line="385"/>
         <source>Relay</source>
         <extracomment>Relay switch</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_reset">
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_reboot">
-        <location filename="../components/CommonWords.qml" line="322"/>
+        <location filename="../components/CommonWords.qml" line="391"/>
         <source>Reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_remove">
-        <location filename="../components/CommonWords.qml" line="325"/>
+        <location filename="../components/CommonWords.qml" line="394"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_running_status">
-        <location filename="../components/CommonWords.qml" line="329"/>
+        <location filename="../components/CommonWords.qml" line="398"/>
         <source>Running</source>
         <extracomment>Status = &quot;running&quot;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_scanning">
-        <location filename="../components/CommonWords.qml" line="332"/>
+        <location filename="../components/CommonWords.qml" line="401"/>
         <source>Scanning %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_serial_number">
-        <location filename="../components/CommonWords.qml" line="335"/>
+        <location filename="../components/CommonWords.qml" line="404"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_settings">
-        <location filename="../components/CommonWords.qml" line="338"/>
+        <location filename="../components/CommonWords.qml" line="407"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_setup">
-        <location filename="../components/CommonWords.qml" line="341"/>
+        <location filename="../components/CommonWords.qml" line="410"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_signal_strength">
-        <location filename="../components/CommonWords.qml" line="344"/>
+        <location filename="../components/CommonWords.qml" line="413"/>
         <source>Signal strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_soc">
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_speed">
-        <location filename="../components/CommonWords.qml" line="348"/>
+        <location filename="../components/CommonWords.qml" line="421"/>
         <source>Speed</source>
         <extracomment>A speed measurement value</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_standby">
-        <location filename="../components/CommonWords.qml" line="351"/>
+        <location filename="../components/CommonWords.qml" line="424"/>
         <source>Standby</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-        <location filename="../components/CommonWords.qml" line="354"/>
+        <location filename="../components/CommonWords.qml" line="427"/>
         <source>Start after the condition is reached for</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_start_time">
-        <location filename="../components/CommonWords.qml" line="357"/>
+        <location filename="../components/CommonWords.qml" line="430"/>
         <source>Start time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-        <location filename="../components/CommonWords.qml" line="360"/>
+        <location filename="../components/CommonWords.qml" line="433"/>
         <source>Start value during quiet hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-        <location filename="../components/CommonWords.qml" line="363"/>
+        <location filename="../components/CommonWords.qml" line="436"/>
         <source>Start when warning is active for</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_state">
-        <location filename="../components/CommonWords.qml" line="366"/>
+        <location filename="../components/CommonWords.qml" line="439"/>
         <source>State</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_state_of_charge">
-        <location filename="../components/CommonWords.qml" line="369"/>
+        <location filename="../components/CommonWords.qml" line="442"/>
         <source>State of charge</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_status">
-        <location filename="../components/CommonWords.qml" line="372"/>
+        <location filename="../components/CommonWords.qml" line="445"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_startup_status">
-        <location filename="../components/CommonWords.qml" line="376"/>
+        <location filename="../components/CommonWords.qml" line="449"/>
         <source>Startup (%1)</source>
         <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-        <location filename="../components/CommonWords.qml" line="379"/>
+        <location filename="../components/CommonWords.qml" line="452"/>
         <source>Stop value during quiet hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-        <location filename="../components/CommonWords.qml" line="382"/>
+        <location filename="../components/CommonWords.qml" line="455"/>
         <source>Stop after the condition is reached for</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_stopped">
-        <location filename="../components/CommonWords.qml" line="385"/>
+        <location filename="../components/CommonWords.qml" line="458"/>
         <source>Stopped</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_switch">
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="common_words_temperature">
-        <location filename="../components/CommonWords.qml" line="388"/>
+        <location filename="../components/CommonWords.qml" line="465"/>
         <source>Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_temperature_sensor">
-        <location filename="../components/CommonWords.qml" line="391"/>
+        <location filename="../components/CommonWords.qml" line="468"/>
         <source>Temperature sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_today">
-        <location filename="../components/CommonWords.qml" line="394"/>
+        <location filename="../components/CommonWords.qml" line="471"/>
         <source>Today</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_total">
-        <location filename="../components/CommonWords.qml" line="397"/>
+        <location filename="../components/CommonWords.qml" line="474"/>
         <source>Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_tracker">
-        <location filename="../components/CommonWords.qml" line="401"/>
+        <location filename="../components/CommonWords.qml" line="478"/>
         <source>Tracker</source>
         <extracomment>Solar tracker</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_type">
-        <location filename="../components/CommonWords.qml" line="404"/>
+        <location filename="../components/CommonWords.qml" line="481"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_unique_id_number">
-        <location filename="../components/CommonWords.qml" line="407"/>
+        <location filename="../components/CommonWords.qml" line="484"/>
         <source>Unique Identity Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_unknown_status">
-        <location filename="../components/CommonWords.qml" line="411"/>
+        <location filename="../components/CommonWords.qml" line="488"/>
         <source>Unknown</source>
         <extracomment>Status = &quot;unknown&quot;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_vebus_error">
-        <location filename="../components/CommonWords.qml" line="414"/>
+        <location filename="../components/CommonWords.qml" line="491"/>
         <source>VE.Bus Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_voltage">
-        <location filename="../components/CommonWords.qml" line="417"/>
+        <location filename="../components/CommonWords.qml" line="494"/>
         <source>Voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_vrm_instance">
-        <location filename="../components/CommonWords.qml" line="420"/>
+        <location filename="../components/CommonWords.qml" line="497"/>
         <source>VRM instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-        <location filename="../components/CommonWords.qml" line="423"/>
+        <location filename="../components/CommonWords.qml" line="500"/>
         <source>When warning is cleared stop after</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_yes">
-        <location filename="../components/CommonWords.qml" line="426"/>
+        <location filename="../components/CommonWords.qml" line="503"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_yesterday">
-        <location filename="../components/CommonWords.qml" line="429"/>
+        <location filename="../components/CommonWords.qml" line="506"/>
         <source>Yesterday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_yield_kwh">
-        <location filename="../components/CommonWords.qml" line="433"/>
+        <location filename="../components/CommonWords.qml" line="510"/>
         <source>Yield</source>
         <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_yield_today">
-        <location filename="../components/CommonWords.qml" line="437"/>
-        <source>Yield today</source>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
         <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-        <location filename="../components/CommonWords.qml" line="440"/>
+        <location filename="../components/CommonWords.qml" line="517"/>
         <source>Zero feed-in power limit</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="common_words_format_error">
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_last_error">
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_2nd_last_error">
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_3rd_last_error">
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_4th_last_error">
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="dateselectordialog_set_date">
-        <location filename="../components/dialogs/DateSelectorDialog.qml" line="39"/>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
         <source>Set date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7753,13 +6237,18 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="37"/>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
         <source>Timed run</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="controlcard_generator_startdialog_description">
-        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="60"/>
-        <source>Generator will stop after the set time, unless autostart condition is met, in which case it will keep running.</source>
+    <message id="generator_start_dialog_will_stop_in_x">
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="generator_start_dialog_will_run_until_manually_stopped">
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
@@ -7768,39 +6257,34 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="39"/>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
         <source>Total Run Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="57"/>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
         <source>Set Time %1</source>
         <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="69"/>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
         <source>Generator will keep running if an autostart condition is met.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="controlcard_inverter_mode">
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="controlcard_inverter_charger_mode">
-        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="16"/>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
         <source>Inverter / Charger mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="modaldialog_set">
         <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
         <source>Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="modaldialog_cancel">
-        <location filename="../components/dialogs/ModalDialog.qml" line="36"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="modaldialog_close">
-        <location filename="../components/dialogs/ModalDialog.qml" line="38"/>
-        <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="timeselectordialog_set_time">
@@ -7856,116 +6340,111 @@ Do you want to continue?</source>
         <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="environment_gauge_humidity">
-        <location filename="../components/EnvironmentGaugePanel.qml" line="123"/>
-        <source>RH</source>
-        <extracomment>Abbreviation of &quot;Room Humidity&quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-        <location filename="../components/FirmwareUpdate.qml" line="35"/>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
         <source>Error while checking for firmware updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-        <location filename="../components/FirmwareUpdate.qml" line="43"/>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
         <source>Downloading and installing firmware %1...</source>
         <extracomment>%1 = firmware version</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_installing">
-        <location filename="../components/FirmwareUpdate.qml" line="47"/>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
         <source>Installing %1...</source>
         <extracomment>%1 = firmware version</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-        <location filename="../components/FirmwareUpdate.qml" line="50"/>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
         <source>Installing firmware...</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
         <source>Error during firmware installation</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-        <location filename="../components/FirmwareUpdate.qml" line="59"/>
-        <source>Firmware installed, rebooting.</source>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-        <location filename="../components/FirmwareUpdate.qml" line="122"/>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
         <source>No newer version available</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-        <location filename="../components/FirmwareUpdate.qml" line="125"/>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
         <source>No firmware found</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_battery">
-        <location filename="../components/Gauges.js" line="41"/>
+        <location filename="../components/Gauges.js" line="19"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_fuel">
-        <location filename="../components/Gauges.js" line="49"/>
+        <location filename="../components/Gauges.js" line="27"/>
         <source>Fuel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_fresh_water">
-        <location filename="../components/Gauges.js" line="57"/>
+        <location filename="../components/Gauges.js" line="35"/>
         <source>Fresh water</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_waste_water">
-        <location filename="../components/Gauges.js" line="65"/>
+        <location filename="../components/Gauges.js" line="43"/>
         <source>Waste water</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_live_well">
-        <location filename="../components/Gauges.js" line="73"/>
+        <location filename="../components/Gauges.js" line="51"/>
         <source>Live well</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_oil">
-        <location filename="../components/Gauges.js" line="81"/>
+        <location filename="../components/Gauges.js" line="59"/>
         <source>Oil</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_black_water">
-        <location filename="../components/Gauges.js" line="89"/>
+        <location filename="../components/Gauges.js" line="67"/>
         <source>Black water</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_gasoline">
-        <location filename="../components/Gauges.js" line="97"/>
+        <location filename="../components/Gauges.js" line="75"/>
         <source>Gasoline</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_diesel">
-        <location filename="../components/Gauges.js" line="105"/>
+        <location filename="../components/Gauges.js" line="83"/>
         <source>Diesel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_lpg">
-        <location filename="../components/Gauges.js" line="113"/>
+        <location filename="../components/Gauges.js" line="91"/>
         <source>LPG</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_lng">
-        <location filename="../components/Gauges.js" line="121"/>
+        <location filename="../components/Gauges.js" line="99"/>
         <source>LNG</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_hydraulic_oil">
-        <location filename="../components/Gauges.js" line="129"/>
+        <location filename="../components/Gauges.js" line="107"/>
         <source>Hydraulic oil</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="gauges_raw_water">
-        <location filename="../components/Gauges.js" line="137"/>
+        <location filename="../components/Gauges.js" line="115"/>
         <source>Raw water</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7988,162 +6467,159 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_radio_button_group_unknown">
-        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="44"/>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="60"/>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
         <source>Setting locked for access level</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="settings_radio_button_group_confirm">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="settings_radio_button_enter_password">
-        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="138"/>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_radio_button_incorrect_password">
-        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="151"/>
-        <source>Incorrect password</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="nav_brief">
-        <location filename="../components/NavBar.qml" line="31"/>
+        <location filename="../pages/BriefPage.qml" line="155"/>
         <source>Brief</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="nav_brief_close_side_panel_high_cpu">
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="nav_overview">
-        <location filename="../components/NavBar.qml" line="37"/>
+        <location filename="../pages/OverviewPage.qml" line="397"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="nav_levels">
-        <location filename="../components/NavBar.qml" line="43"/>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
         <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="nav_notifications">
-        <location filename="../components/NavBar.qml" line="49"/>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="nav_settings">
-        <location filename="../components/NavBar.qml" line="55"/>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="notifications_page_now">
-        <location filename="../components/NotificationDelegate.qml" line="25"/>
-        <source>now</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="%1m ago">
-        <location filename="../components/NotificationDelegate.qml" line="29"/>
-        <source>%1m ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="%1h %2m ago">
-        <location filename="../components/NotificationDelegate.qml" line="35"/>
-        <source>%1h %2m ago</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="cgwacs_battery_schedule_every_day">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="17"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
         <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="19"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
         <source>Weekdays</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="21"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
         <source>Weekends</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="cgwacs_battery_schedule_monthly">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="cgwacs_battery_schedule_monday">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="23"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
         <source>Monday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="25"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
         <source>Tuesday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="27"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
         <source>Wednesday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="29"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
         <source>Thursday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="31"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
         <source>Friday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="33"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
         <source>Saturday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="35"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
         <source>Sunday</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="68"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
         <source>%1 %2 (%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="71"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
         <source>%1 %2 (%3 or %4%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="77"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
         <source>Schedule %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="124"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
         <source>Day</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="128"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
         <source>Not set</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="140"/>
-        <source>Duration (hh:mm)</source>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="150"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
         <source>SOC limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="161"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
         <source>Self-consumption above limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_pv">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="166"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
         <source>PV</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-        <location filename="../components/settings/CGwacsBatteryScheduleNavigationItem.qml" line="168"/>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
         <source>PV &amp; Battery</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8179,12 +6655,12 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-        <location filename="../components/settings/ListDvccSwitch.qml" line="19"/>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
         <source>Forced on</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-        <location filename="../components/settings/ListDvccSwitch.qml" line="22"/>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
         <source>Forced off</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8194,27 +6670,27 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-        <location filename="../components/settings/ListResetHistoryLabel.qml" line="28"/>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
         <source>Reset history on the monitor itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-        <location filename="../components/settings/MountStateListButton.qml" line="16"/>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
         <source>Press to eject</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="components_mount_state_ejecting">
-        <location filename="../components/settings/MountStateListButton.qml" line="20"/>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
         <source>Ejecting, please wait</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-        <location filename="../components/settings/MountStateListButton.qml" line="23"/>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
         <source>No storage found</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-        <location filename="../components/settings/MountStateListButton.qml" line="28"/>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
         <source>microSD / USB</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8294,8 +6770,9 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="settings_relay_deactivation_value">
-        <location filename="../components/settings/TemperatureRelaySettings.qml" line="90"/>
-        <source>Deativation value</source>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="components_volumeunit_title">
@@ -8369,126 +6846,121 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_errors_occurred">
-        <location filename="../components/SolarHistoryErrorView.qml" line="98"/>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
         <source>%1 error(s) occurred</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_errors_last">
-        <location filename="../components/SolarHistoryErrorView.qml" line="122"/>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
         <source>Last</source>
         <extracomment>Details of last error</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-        <location filename="../components/SolarHistoryErrorView.qml" line="125"/>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
         <source>2nd last</source>
         <extracomment>Details of 2nd last error</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-        <location filename="../components/SolarHistoryErrorView.qml" line="128"/>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
         <source>3rd last</source>
         <extracomment>Details of 3rd last error</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_errors_4th_last">
-        <location filename="../components/SolarHistoryErrorView.qml" line="131"/>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
         <source>4th last</source>
         <extracomment>Details of 4th last error</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_max_voltage">
-        <location filename="../components/SolarHistoryTableView.qml" line="85"/>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
         <source>Max Voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="charger_history_max_power">
-        <location filename="../components/SolarHistoryTableView.qml" line="91"/>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
         <source>Max Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_unable_to_connect">
-        <location filename="../components/SplashView.qml" line="219"/>
+        <location filename="../components/SplashView.qml" line="231"/>
         <source>Unable to connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_reconnecting">
-        <location filename="../components/SplashView.qml" line="221"/>
+        <location filename="../components/SplashView.qml" line="233"/>
         <source>Disconnected, attempting to reconnect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_connecting">
-        <location filename="../components/SplashView.qml" line="224"/>
+        <location filename="../components/SplashView.qml" line="236"/>
         <source>Connecting</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_connected">
-        <location filename="../components/SplashView.qml" line="226"/>
+        <location filename="../components/SplashView.qml" line="238"/>
         <source>Connected, awaiting broker messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_initializing">
-        <location filename="../components/SplashView.qml" line="228"/>
+        <location filename="../components/SplashView.qml" line="240"/>
         <source>Connected, receiving broker messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_ready">
-        <location filename="../components/SplashView.qml" line="230"/>
+        <location filename="../components/SplashView.qml" line="242"/>
         <source>Connected, loading user interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-        <location filename="../components/SplashView.qml" line="245"/>
+        <location filename="../components/SplashView.qml" line="257"/>
         <source>Invalid protocol version</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_client_id_rejected">
-        <location filename="../components/SplashView.qml" line="247"/>
+        <location filename="../components/SplashView.qml" line="259"/>
         <source>Client ID rejected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_server_unavailable">
-        <location filename="../components/SplashView.qml" line="249"/>
+        <location filename="../components/SplashView.qml" line="261"/>
         <source>Broker service not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-        <location filename="../components/SplashView.qml" line="251"/>
+        <location filename="../components/SplashView.qml" line="263"/>
         <source>Bad username or password</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_not_authorized">
-        <location filename="../components/SplashView.qml" line="253"/>
+        <location filename="../components/SplashView.qml" line="265"/>
         <source>Client not authorized</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_transport_invalid">
-        <location filename="../components/SplashView.qml" line="255"/>
+        <location filename="../components/SplashView.qml" line="267"/>
         <source>Transport connection error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_protocol_violation">
-        <location filename="../components/SplashView.qml" line="257"/>
+        <location filename="../components/SplashView.qml" line="269"/>
         <source>Protocol violation error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_unknown_error">
-        <location filename="../components/SplashView.qml" line="259"/>
+        <location filename="../components/SplashView.qml" line="271"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="splash_view_mqtt5_error">
-        <location filename="../components/SplashView.qml" line="261"/>
+        <location filename="../components/SplashView.qml" line="273"/>
         <source>MQTT protocol level 5 error</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="silence_alarm">
-        <location filename="../components/StatusBar.qml" line="114"/>
-        <source>Silence alarm</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="vebus_device_page_total_power">
-        <location filename="../components/ThreePhaseQuantityTable.qml" line="79"/>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
         <source>Total Power</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8503,88 +6975,106 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_format_days_hours">
-        <location filename="../components/Utils.js" line="205"/>
+        <location filename="../components/Utils.js" line="186"/>
         <source>%1d %2h</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_format_hours_min">
-        <location filename="../components/Utils.js" line="210"/>
+        <location filename="../components/Utils.js" line="191"/>
         <source>%1h %2m</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_format_min_sec">
-        <location filename="../components/Utils.js" line="231"/>
+        <location filename="../components/Utils.js" line="212"/>
         <source>%1m %2s</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_format_min">
-        <location filename="../components/Utils.js" line="233"/>
+        <location filename="../components/Utils.js" line="214"/>
         <source>%1m</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_format_sec">
-        <location filename="../components/Utils.js" line="237"/>
+        <location filename="../components/Utils.js" line="218"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_zero_minutes">
-        <location filename="../components/Utils.js" line="239"/>
+        <location filename="../components/Utils.js" line="220"/>
         <source>0m</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="utils_formatTimestamp_now">
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="utils_formatTimestamp_min_ago">
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="utils_formatTimestamp_hours_min_ago">
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="utils_connman_failure">
-        <location filename="../components/Utils.js" line="264"/>
+        <location filename="../components/Utils.js" line="270"/>
         <source>Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_connman_connecting">
-        <location filename="../components/Utils.js" line="267"/>
+        <location filename="../components/Utils.js" line="273"/>
         <source>Connecting</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-        <location filename="../components/Utils.js" line="270"/>
+        <location filename="../components/Utils.js" line="276"/>
         <source>Retrieving IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_connman_connected">
-        <location filename="../components/Utils.js" line="274"/>
+        <location filename="../components/Utils.js" line="280"/>
         <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_connman_disconnect">
-        <location filename="../components/Utils.js" line="277"/>
+        <location filename="../components/Utils.js" line="283"/>
         <source>Disconnect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="utils_connman_disconnected">
-        <location filename="../components/Utils.js" line="281"/>
+        <location filename="../components/Utils.js" line="287"/>
         <source>Disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="overview_widget_acloads_title">
-        <location filename="../components/widgets/AcLoadsWidget.qml" line="13"/>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
         <source>AC Loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="overview_widget_dcloads_title">
-        <location filename="../components/widgets/DcLoadsWidget.qml" line="14"/>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
         <source>DC Loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="overview_widget_evcs_title">
-        <location filename="../components/widgets/EvcsWidget.qml" line="14"/>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
         <source>EVCS</source>
         <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="overview_widget_solaryield_title">
-        <location filename="../components/widgets/SolarYieldWidget.qml" line="13"/>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
         <source>Solar yield</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="overview_widget_inverter_title">
-        <location filename="../components/widgets/VeBusDeviceWidget.qml" line="13"/>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
         <source>Inverter / Charger</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8593,33 +7083,43 @@ Do you want to continue?</source>
         <source>Wind</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="acInputs_evcharger">
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="acInputs_heat_pump">
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="acInputs_not_available">
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="acInputs_shore">
-        <location filename="../data/AcInputs.qml" line="48"/>
+        <location filename="../data/AcInputs.qml" line="115"/>
         <source>Shore</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="acInputs_current_limit_grid">
-        <location filename="../data/AcInputs.qml" line="72"/>
+        <location filename="../data/AcInputs.qml" line="141"/>
         <source>Grid current limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="acInputs_current_limit_generator">
-        <location filename="../data/AcInputs.qml" line="75"/>
+        <location filename="../data/AcInputs.qml" line="144"/>
         <source>Generator current limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="acInputs_current_limit_shore">
-        <location filename="../data/AcInputs.qml" line="78"/>
+        <location filename="../data/AcInputs.qml" line="147"/>
         <source>Shore current limit</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="acInputs_current_limit_unrecognized">
-        <location filename="../data/AcInputs.qml" line="82"/>
-        <source>Unrecognized current limit</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="acInputs_statusCode_stopping">
-        <location filename="../data/AcInputs.qml" line="102"/>
+        <location filename="../data/AcInputs.qml" line="169"/>
         <source>Stopping</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8629,60 +7129,54 @@ Do you want to continue?</source>
         <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="solarcharger_tracker_title">
-        <location filename="../data/common/SolarCharger.qml" line="142"/>
-        <source>%1 (#%2)</source>
-        <extracomment>Name for a tracker of a solar charger. %1 = solar charger name, %2 = the number of this tracker for the charger</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="tank_description">
-        <location filename="../data/common/Tank.qml" line="98"/>
+        <location filename="../data/common/Tank.qml" line="96"/>
         <source>%1 tank (%2)</source>
         <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_ac_charger">
-        <location filename="../data/DcInputs.qml" line="109"/>
+        <location filename="../data/DcInputs.qml" line="112"/>
         <source>AC charger</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_alternator">
-        <location filename="../data/DcInputs.qml" line="112"/>
+        <location filename="../data/DcInputs.qml" line="115"/>
         <source>Alternator</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_dccharger">
-        <location filename="../data/DcInputs.qml" line="115"/>
+        <location filename="../data/DcInputs.qml" line="118"/>
         <source>DC charger</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_dc_generator">
-        <location filename="../data/DcInputs.qml" line="118"/>
+        <location filename="../data/DcInputs.qml" line="121"/>
         <source>DC generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_dc_system">
-        <location filename="../data/DcInputs.qml" line="121"/>
+        <location filename="../data/DcInputs.qml" line="124"/>
         <source>DC system</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_fuelcell">
-        <location filename="../data/DcInputs.qml" line="124"/>
+        <location filename="../data/DcInputs.qml" line="127"/>
         <source>Fuel cell</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_shaft_generator">
-        <location filename="../data/DcInputs.qml" line="127"/>
+        <location filename="../data/DcInputs.qml" line="130"/>
         <source>Shaft generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_water_generator">
-        <location filename="../data/DcInputs.qml" line="130"/>
+        <location filename="../data/DcInputs.qml" line="133"/>
         <source>Water generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="dcInputs_wind_charger">
-        <location filename="../data/DcInputs.qml" line="133"/>
+        <location filename="../data/DcInputs.qml" line="136"/>
         <source>Wind charger</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8731,34 +7225,29 @@ Do you want to continue?</source>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="digitalinputs_touch_input_control">
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="digitalinputs_state_low">
-        <location filename="../data/DigitalInputs.qml" line="56"/>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="digitalinputs_state_high">
-        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="digitalinputs_state_alarm">
-        <location filename="../data/DigitalInputs.qml" line="77"/>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
         <source>Alarm</source>
         <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message id="temperature_type_fridge">
-        <location filename="../data/EnvironmentInputs.qml" line="22"/>
-        <source>Fridge</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="temperature_type_generic">
-        <location filename="../data/EnvironmentInputs.qml" line="25"/>
-        <source>Generic</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="temperature_type_unknown">
-        <location filename="../data/EnvironmentInputs.qml" line="28"/>
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8783,177 +7272,191 @@ Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_disconnected">
-        <location filename="../data/EvChargers.qml" line="66"/>
-        <source>Unplugged</source>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_connected">
-        <location filename="../data/EvChargers.qml" line="69"/>
+        <location filename="../data/EvChargers.qml" line="89"/>
         <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_charged">
-        <location filename="../data/EvChargers.qml" line="74"/>
+        <location filename="../data/EvChargers.qml" line="94"/>
         <source>Charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-        <location filename="../data/EvChargers.qml" line="77"/>
+        <location filename="../data/EvChargers.qml" line="97"/>
         <source>Waiting for sun</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-        <location filename="../data/EvChargers.qml" line="80"/>
+        <location filename="../data/EvChargers.qml" line="100"/>
         <source>Waiting for RFID</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-        <location filename="../data/EvChargers.qml" line="83"/>
+        <location filename="../data/EvChargers.qml" line="103"/>
         <source>Waiting for start</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="evchargers_status_low_status_of_charge">
-        <location filename="../data/EvChargers.qml" line="86"/>
-        <source>Low state of charge</source>
+    <message id="evchargers_status_low_state_of_charge">
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-        <location filename="../data/EvChargers.qml" line="89"/>
+        <location filename="../data/EvChargers.qml" line="109"/>
         <source>Ground test error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-        <location filename="../data/EvChargers.qml" line="92"/>
-        <source>Welded contacts error</source>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-        <location filename="../data/EvChargers.qml" line="95"/>
+        <location filename="../data/EvChargers.qml" line="115"/>
         <source>CP input test error</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-        <location filename="../data/EvChargers.qml" line="98"/>
+        <location filename="../data/EvChargers.qml" line="118"/>
         <source>Residual current detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-        <location filename="../data/EvChargers.qml" line="101"/>
+        <location filename="../data/EvChargers.qml" line="121"/>
         <source>Undervoltage detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-        <location filename="../data/EvChargers.qml" line="104"/>
+        <location filename="../data/EvChargers.qml" line="124"/>
         <source>Overvoltage detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-        <location filename="../data/EvChargers.qml" line="107"/>
+        <location filename="../data/EvChargers.qml" line="127"/>
         <source>Overheating detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_charging_limit">
-        <location filename="../data/EvChargers.qml" line="110"/>
+        <location filename="../data/EvChargers.qml" line="130"/>
         <source>Charging limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_start_charging">
-        <location filename="../data/EvChargers.qml" line="113"/>
+        <location filename="../data/EvChargers.qml" line="133"/>
         <source>Start charging</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-        <location filename="../data/EvChargers.qml" line="116"/>
-        <source>Switching to 3-phase</source>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-        <location filename="../data/EvChargers.qml" line="119"/>
-        <source>Switching to single phase</source>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="evchargers_status_stop_charging">
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="evchargers_status_reserved">
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="evchargers_status_unknown">
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="evchargers_mode_scheduled">
-        <location filename="../data/EvChargers.qml" line="133"/>
+        <location filename="../data/EvChargers.qml" line="162"/>
         <source>Scheduled</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_warm_up">
-        <location filename="../data/Generators.qml" line="29"/>
+        <location filename="../data/Generators.qml" line="49"/>
         <source>Warm-up</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_cool_down">
-        <location filename="../data/Generators.qml" line="32"/>
+        <location filename="../data/Generators.qml" line="52"/>
         <source>Cool-down</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="page_generator_stopping">
-        <location filename="../data/Generators.qml" line="35"/>
+        <location filename="../data/Generators.qml" line="55"/>
         <source>Stopping</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="settings_running_by_soc_condition">
-        <location filename="../data/Generators.qml" line="43"/>
-        <source>Running by SOC condition</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_running_by_ac_load_condition">
-        <location filename="../data/Generators.qml" line="46"/>
-        <source>Running by AC Load condition</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_running_by_battery_current_condition">
-        <location filename="../data/Generators.qml" line="49"/>
-        <source>Running by battery current condition</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_running_by_battery_voltage_condition">
-        <location filename="../data/Generators.qml" line="52"/>
-        <source>Running by battery voltage condition</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_running_by_inverter_high_temperature">
-        <location filename="../data/Generators.qml" line="55"/>
-        <source>Running by inverter high temperature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_running_by_inverter_overload">
-        <location filename="../data/Generators.qml" line="58"/>
-        <source>Running by inverter overload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_running_by_test_run">
-        <location filename="../data/Generators.qml" line="61"/>
-        <source>Test run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_running_by_loss_of_communication">
-        <location filename="../data/Generators.qml" line="64"/>
-        <source>Running by loss of communication</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="settings_manually_started">
+    <message id="generator_not_running">
         <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="generator_manually_started">
+        <location filename="../data/Generators.qml" line="70"/>
         <source>Manually started</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="notifications_warning_title_inverter_temperature">
-        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="15"/>
-        <source>Inverter temperature</source>
+    <message id="generator_test_run">
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="notifications_warning_description_inverter_temperature">
-        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="17"/>
-        <source>Suggest user an action or inaction, inform about status.  This text can be long and should wrap.</source>
+    <message id="settings_loss_of_communication">
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_soc_condition">
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ac_load_condition">
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_battery_current_condition">
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_battery_voltage_condition">
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_inverter_high_temperature">
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_inverter_overload_condition">
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="notifications_toast_short_text">
-        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="21"/>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
         <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="notifications_toast_long_text">
-        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="24"/>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
         <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8972,234 +7475,2679 @@ Do you want to continue?</source>
         <source>Running (Throttled)</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="relay_name">
-        <location filename="../data/Relays.qml" line="36"/>
-        <source>Relay %1</source>
-        <extracomment>%1 = Relay number</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="solarchargers_state_off">
-        <location filename="../data/SolarChargers.qml" line="33"/>
+        <location filename="../data/SolarChargers.qml" line="51"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solarchargers_state_fault">
-        <location filename="../data/SolarChargers.qml" line="36"/>
+        <location filename="../data/SolarChargers.qml" line="54"/>
         <source>Fault</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solarchargers_state_bulk">
-        <location filename="../data/SolarChargers.qml" line="39"/>
+        <location filename="../data/SolarChargers.qml" line="57"/>
         <source>Bulk</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solarchargers_state_absorption">
-        <location filename="../data/SolarChargers.qml" line="42"/>
+        <location filename="../data/SolarChargers.qml" line="60"/>
         <source>Absorption</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solarchargers_state_float">
-        <location filename="../data/SolarChargers.qml" line="45"/>
+        <location filename="../data/SolarChargers.qml" line="63"/>
         <source>Float</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solarchargers_state_storage">
-        <location filename="../data/SolarChargers.qml" line="48"/>
+        <location filename="../data/SolarChargers.qml" line="66"/>
         <source>Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solarchargers_state_equalize">
-        <location filename="../data/SolarChargers.qml" line="51"/>
+        <location filename="../data/SolarChargers.qml" line="69"/>
         <source>Equalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="solarchargers_state_external control">
-        <location filename="../data/SolarChargers.qml" line="54"/>
+        <location filename="../data/SolarChargers.qml" line="72"/>
         <source>External control</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_aes_mode">
-        <location filename="../data/System.qml" line="69"/>
+        <location filename="../data/System.qml" line="123"/>
         <source>AES mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_faultcondition">
-        <location filename="../data/System.qml" line="72"/>
+        <location filename="../data/System.qml" line="126"/>
         <source>Fault condition</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_bulkcharging">
-        <location filename="../data/System.qml" line="75"/>
+        <location filename="../data/System.qml" line="129"/>
         <source>Bulk charging</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-        <location filename="../data/System.qml" line="78"/>
+        <location filename="../data/System.qml" line="132"/>
         <source>Absorption charging</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_floatcharging">
-        <location filename="../data/System.qml" line="81"/>
+        <location filename="../data/System.qml" line="135"/>
         <source>Float charging</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_storagemode">
-        <location filename="../data/System.qml" line="84"/>
+        <location filename="../data/System.qml" line="138"/>
         <source>Storage mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-        <location filename="../data/System.qml" line="87"/>
+        <location filename="../data/System.qml" line="141"/>
         <source>Equalization charging</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_passthru">
-        <location filename="../data/System.qml" line="90"/>
+        <location filename="../data/System.qml" line="144"/>
         <source>Pass-thru</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_inverting">
-        <location filename="../data/System.qml" line="93"/>
+        <location filename="../data/System.qml" line="147"/>
         <source>Inverting</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_assisting">
-        <location filename="../data/System.qml" line="96"/>
+        <location filename="../data/System.qml" line="150"/>
         <source>Assisting</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_powersupplymode">
-        <location filename="../data/System.qml" line="99"/>
+        <location filename="../data/System.qml" line="153"/>
         <source>Power supply mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_sustain">
-        <location filename="../data/System.qml" line="102"/>
+        <location filename="../data/System.qml" line="156"/>
         <source>Sustain</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_wakeup">
-        <location filename="../data/System.qml" line="106"/>
+        <location filename="../data/System.qml" line="160"/>
         <source>Wake up</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-        <location filename="../data/System.qml" line="109"/>
+        <location filename="../data/System.qml" line="163"/>
         <source>Repeated absorption</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_autoequalize">
-        <location filename="../data/System.qml" line="112"/>
+        <location filename="../data/System.qml" line="166"/>
         <source>Auto equalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_battery_safe">
-        <location filename="../data/System.qml" line="115"/>
+        <location filename="../data/System.qml" line="169"/>
         <source>Battery safe</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_loaddetect">
-        <location filename="../data/System.qml" line="118"/>
+        <location filename="../data/System.qml" line="172"/>
         <source>Load detect</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_blocked">
-        <location filename="../data/System.qml" line="121"/>
+        <location filename="../data/System.qml" line="175"/>
         <source>Blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_test">
-        <location filename="../data/System.qml" line="124"/>
+        <location filename="../data/System.qml" line="178"/>
         <source>Test</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_externalccontrol">
-        <location filename="../data/System.qml" line="127"/>
+        <location filename="../data/System.qml" line="181"/>
         <source>External control</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_system_sustain">
-        <location filename="../data/System.qml" line="133"/>
+        <location filename="../data/System.qml" line="187"/>
         <source>Sustain</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_recharge">
-        <location filename="../data/System.qml" line="136"/>
+        <location filename="../data/System.qml" line="190"/>
         <source>Recharge</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="inverters_state_scheduledrecharge">
-        <location filename="../data/System.qml" line="139"/>
-        <source>Scheduled recharge</source>
+    <message id="inverters_state_scheduledcharge">
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="inverters_state_dynamic_ess">
-        <location filename="../data/System.qml" line="142"/>
+        <location filename="../data/System.qml" line="196"/>
         <source>Dynamic ESS</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-        <location filename="../data/SystemSettings.qml" line="93"/>
+        <location filename="../data/SystemSettings.qml" line="87"/>
         <source>Slave</source>
         <extracomment>Network status: Slave</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-        <location filename="../data/SystemSettings.qml" line="97"/>
+        <location filename="../data/SystemSettings.qml" line="91"/>
         <source>Group Master</source>
         <extracomment>Network status: Group Master</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-        <location filename="../data/SystemSettings.qml" line="101"/>
+        <location filename="../data/SystemSettings.qml" line="95"/>
         <source>Instance Master</source>
         <extracomment>Network status: Instance Master</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-        <location filename="../data/SystemSettings.qml" line="105"/>
+        <location filename="../data/SystemSettings.qml" line="99"/>
         <source>Group &amp; Instance Master</source>
         <extracomment>Network status: Group &amp; Instance Master</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-        <location filename="../data/SystemSettings.qml" line="109"/>
+        <location filename="../data/SystemSettings.qml" line="103"/>
         <source>Standalone</source>
         <extracomment>Network status: Standalone</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-        <location filename="../data/SystemSettings.qml" line="113"/>
+        <location filename="../data/SystemSettings.qml" line="107"/>
         <source>Standalone &amp; Group Master</source>
         <extracomment>Network status: Standalone &amp; Group Master</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="tank_status_short_circuited">
-        <location filename="../data/Tanks.qml" line="156"/>
+        <location filename="../data/Tanks.qml" line="132"/>
         <source>Short circuited</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="tank_status_reverse_polarity">
-        <location filename="../data/Tanks.qml" line="159"/>
+        <location filename="../data/Tanks.qml" line="135"/>
         <source>Reverse polarity</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="veBusDevices_mode_charger_only">
-        <location filename="../data/VeBusDevices.qml" line="50"/>
+    <message id="application_content_touch_input_on">
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="application_content_touch_input_off">
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="application_content_touch_input_disabled">
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rs_current_limit_not_adjustable">
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_mode_not_adjustable">
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="notification_description_and_value">
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="notifications_acknowledge_alerts">
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="notifications_silence_alarm">
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ess_flags">
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systemreason_charge_discharge_disabled">
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systemreason_charge_disabled">
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systemreason_discharge_disabled">
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="number_field_input_too_long">
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="ip_address_input_not_valid">
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="port_field_title">
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="port_input_not_valid">
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alarm_level_alarm_only">
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="alarm_level_alarms_and_warnings">
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_ac-out_num">
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="dc_input">
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="dc_output">
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_security_warning_profile_configuration_order">
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="overview_widget_essential_loads_title">
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rs_alarm_low_ac_out_voltage">
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rs_alarm_high_ac_out_voltage">
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rs_alarm_short_circuit">
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverterCharger_mode_charger_only">
+        <location filename="../data/InverterChargers.qml" line="85"/>
         <source>Charger only</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="veBusDevices_mode_inverter_only">
-        <location filename="../data/VeBusDevices.qml" line="53"/>
+    <message id="inverterCharger_mode_inverter_only">
+        <location filename="../data/InverterChargers.qml" line="88"/>
         <source>Inverter only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverterCharger_mode_passthrough">
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="startpage_option_brief_with_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="startpage_option_levels_tanks">
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="startpage_option_levels_environment">
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="startpage_option_battery list">
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="firmware_installed_build_gx_device_updated">
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="firmware_installed_build_page_will_reload">
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_chargers_title">
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_cgwacs_no_energy_meters">
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
+
+Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_autorange">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_autorange_desc">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_reset">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_reset_range_values">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_reset_are_you_sure">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_ac_in_not_available">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_ac_in_header_with_source">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_dc_input">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_acout_max_power">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_acout_max_acin1">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_acout_max_acin2">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_acout_max">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_dc_out">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_minmax_solar">
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_startpage_timeout_never">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_startpage_timeout_minutes" numerus="yes">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message id="settings_startpage_name">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_startpage_none">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_startpage_description">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_startpage_timeout">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_startpage_timeout_description">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_startpage_auto_description">
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_buying">
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_selling">
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_ess_target_soc">
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_modbus_scan_for_devices">
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_modbus_saved_devices">
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_modbus_discovered_devices">
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="add_modbus_tcp_udp_device">
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="modbus_add_device_tcp">
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="modbus_add_device_udp">
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="modbus_add_device_protocol">
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="modbus_add_device_unit">
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="modbus_add_unit_invalid">
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_modbus_no_devices_saved">
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_modbus_device_number">
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="page_settings_modbus_device_remove_device">
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_modbus_no_devices_discovered">
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_replaced_invalid_characters">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_starting">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_initializing">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_backend_starting">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_backend_stopped">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_connection_failed">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_logged_out">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
+
+Please wait or check your internet connection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_wait_for_response">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_wait_for_login">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_check_internet_connection">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_unknown_state">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_error">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_ethernet">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_wifi">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_custom">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_disabled">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_disable_to_edit">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_enable">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_machinename">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_ipv4">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_ipv6">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_logout">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_logout_button">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_local_network_access">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_ethernet">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_wifi">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_custom_networks">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_explanation">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
+
+This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
+
+The custom networks field accepts a comma-separated list of CIDR notation subnets.
+
+After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_advanced">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_tailscale_advanced_custom_server_url">
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_accharger_battery">
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_accharger_current">
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_accharger_low_battery_voltage_alarm">
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_accharger_high_battery_voltage_alarm">
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="devicelist_motordrive_motorrpm">
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="devicelist_motordrive_motortemperature">
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="devicelist_motordrive_controllertemperature">
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_active">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_num">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_completed">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_dc_disconnect">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_powered_off">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_function_change">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_firmware_update">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_watchdog">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_software_reset">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_incomplete">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_elapsed_time">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_charge_maintain_ah">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cycle_history_battery_voltage">
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_maximum_pv_voltage">
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_maximum_battery_voltage">
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="inverter_minimum_battery_voltage">
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_total_yield">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_system_yield">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_history_name">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_ac_in_phase">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_ac_out_phase">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_pv">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_total_pv_power">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_multirs_trackers">
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rs_alarm_no_alarms_to_be_configured">
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rssystem_system_alarms">
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_rs_devices">
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rssystemalarms_phase_rotation">
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rssystemalarms_overload">
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="rs_no_system_alarms">
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_rs_ess_min_soc">
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="settings_rs_ess_dess">
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="battery_list_page_title">
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_page_back">
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_whatsnew">
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_skip">
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_landing_title">
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_landing_text">
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+
+With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_colors_title">
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_colors_text">
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_brief_title">
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_brief_text">
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_overview_title">
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_overview_text">
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_controls_title">
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_controls_text">
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_units_title">
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_units_text">
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_more_title">
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_more_text_wasm">
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_more_text">
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_done">
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="welcome_next">
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AlternatorError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BmsError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CRE</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DEIF</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DSE</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnvironmentInputs</name>
+    <message>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PageAcInSetup</name>
     <message>
-        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="125"/>
-        <source>Set switch in an unlocked position to change settings</source>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9804,6 +10752,298 @@ Do you want to continue?</source>
     <message>
         <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
         <source>Easter Island Standard Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/venus-gui-v2_ar.ts
+++ b/i18n/venus-gui-v2_ar.ts
@@ -1,10366 +1,11076 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ar">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>معطل</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>معطل</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>إفراط في تحيمل المعاكس</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>إفراط في تحيمل المعاكس</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>طاقة</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>طاقة</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>مطفأ</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>مطفأ</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>آلي</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>آلي</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">بطارية</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">متصل</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">منفصل</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">مولد</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>جهد البطارية مرتفع</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>جهد البطارية مرتفع</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>محول التردد/ الشاحن</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>محول التردد/ الشاحن</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>جهد البطارية منخفض</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>جهد البطارية منخفض</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>يدوي</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>يدوي</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>لا أحد</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>لا أحد</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>الموقع</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>الموقع</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>السرعة</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>السرعة</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>الحالة</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>الحالة</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>جارٍ التثبيت %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>جارٍ التثبيت %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>خطأ غير معروف</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>خطأ غير معروف</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>أدنى حالة للشحن</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>أدنى حالة للشحن</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">مجهول</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>إدخال كلمة المرور</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>إدخال كلمة المرور</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>اضغط للتحقق</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>اضغط للتحقق</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>الشبكة</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>الشبكة</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>إنتاج الطاقة الشمسية</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>إنتاج الطاقة الشمسية</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>التحكم الخارجي</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>التحكم الخارجي</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>خزانات</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>خزانات</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>بيئة</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>بيئة</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>لا توجد تنبيهات حالية</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>لا توجد تنبيهات حالية</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>بلوتوث</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>عام</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>عام</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>البرامج الثابتة</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>البرامج الثابتة</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>التاريخ والوقت</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>التاريخ والوقت</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>إعادة ضبط النظام</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>إعادة ضبط النظام</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>نظام التحكم للجهد الكهربائي الموزع</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>نظام التحكم للجهد الكهربائي الموزع</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>العرض واللغة</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>العرض واللغة</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>بوابة مباشرة ل VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>بوابة مباشرة ل VRM</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>عدادات الطاقة</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>عدادات الطاقة</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>معاكسات ضوئية</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>معاكسات ضوئية</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>إيثرنت</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>إيثرنت</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>مودم GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>مودم GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>نظام التموضع العالمي</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>نظام التموضع العالمي</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>بدء/وقف المولد</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>بدء/وقف المولد</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>مضخة الخزان</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>مضخة الخزان</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>خدمات</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>خدمات</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>داخل/خارج</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>داخل/خارج</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>سمات فينوس أو إس لارج</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>سمات فينوس أو إس لارج</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>حد عمر البطارية: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>حد عمر البطارية: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">التشغيل الآلي</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>سيتم تعطيل التشغيل التلقائي ولن يبدأ المولد تلقائيًا استنادًا إلى الأوضاع المحددة.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>سيتم تعطيل التشغيل التلقائي ولن يبدأ المولد تلقائيًا استنادًا إلى الأوضاع المحددة.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>الإيقاف اليدوي</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>الإيقاف اليدوي</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>البدء الآلي</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>البدء الآلي</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">الموقع</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>التشغيل الآلي</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>التشغيل الآلي</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>المفاتيح</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>المفاتيح</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>مستوى الدخول</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>مستوى الدخول</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>مستخدم</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>مستخدم</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>مستخدم ومركب</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>مستخدم ومركب</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>مستخدم ذو صلاحيات عليا</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>مستخدم ذو صلاحيات عليا</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>خادم</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>خادم</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">نظام التحكم للجهد الكهربائي الموزع</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>تأكد كذلك من إعادة ضبط نظام VE.Bus بعد تعطيل التحكم في تيار الجهد المستمر</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>تأكد كذلك من إعادة ضبط نظام VE.Bus بعد تعطيل التحكم في تيار الجهد المستمر</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>حد شحن التيار</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>حد شحن التيار</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>أقصى تيار للشحن</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>أقصى تيار للشحن</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>استخدم قيمة %1 للبدء/للإيقاف</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>استخدم قيمة %1 للبدء/للإيقاف</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>التشغيل عندما يكون %1 أعلى من</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>التشغيل عندما يكون %1 أعلى من</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>التشغيل عندما يكون %1 أقل من</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>التشغيل عندما يكون %1 أقل من</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>التوقف عندما يكون %1 أعلى من</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>التوقف عندما يكون %1 أعلى من</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>التوقف عندما يكون %1 أقل من</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>التوقف عندما يكون %1 أقل من</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>هل تريد حذف عنوان بروتوكول الإنترنت؟</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>هل تريد حذف عنوان بروتوكول الإنترنت؟</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>الحد الأقصى: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>الحد الأقصى: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>اتصال</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>اتصال</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>منتج</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>منتج</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>اسم</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>اسم</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">اسم</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>معرف المنتج</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>معرف المنتج</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>نسخة المكونات المادية</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>نسخة المكونات المادية</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>اسم الجهاز</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>اسم الجهاز</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>مفتاح التحكم عن بعد تم تعطيله</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>مفتاح التحكم عن بعد تم تعطيله</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>المولد في حالة الخلل</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>المولد في حالة الخلل</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>المولد غير مكتشف في دخل التيار المتردد</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>المولد غير مكتشف في دخل التيار المتردد</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>وقت التشغيل المتراكم منذ آخر تشغيل للاختبار</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>وقت التشغيل المتراكم منذ آخر تشغيل للاختبار</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>الوقت المتبقي للمعاينة التالية</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>الوقت المتبقي للمعاينة التالية</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>مشغل حاليا</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>مشغل حاليا</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>البدء الآلي</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>البدء الآلي</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>تشغيل المولد</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>تشغيل المولد</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>وقت التشغيل اليومي</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>وقت التشغيل اليومي</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>القيمة يجب أن تكون أعلى من قيمة التوقف</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>القيمة يجب أن تكون أعلى من قيمة التوقف</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>القيمة يجب أن تكون أقل من قيمة التشغيل</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>القيمة يجب أن تكون أقل من قيمة التشغيل</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>خرج التيار المتردد</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>خرج التيار المتردد</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">خرج التيار المتردد</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>استخدم تحميلات التيار المتردد ل البدء/التوقف</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>استخدم تحميلات التيار المتردد ل البدء/التوقف</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>القياس</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>القياس</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>الاسهلاك الكامل</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>الاسهلاك الكامل</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>إجمالي خرج التيار المتردد للمعاكس</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>إجمالي خرج التيار المتردد للمعاكس</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>الطور الأعلى للتيار المتردد الخارج للمعاكس</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>الطور الأعلى للتيار المتردد الخارج للمعاكس</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>تشغيل عندما تكون القدرة أعلى من</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>تشغيل عندما تكون القدرة أعلى من</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>توقف عندما تكون القدرة أقل من</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>توقف عندما تكون القدرة أقل من</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>شاشة البطارية</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>شاشة البطارية</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>الشاشة غير متاحة، عيّن غيرها</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>الشاشة غير متاحة، عيّن غيرها</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">شاشة البطارية</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">الشاشة غير متاحة، عيّن غيرها</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>فقد الاتصال</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>فقد الاتصال</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>إيقاف المولد</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>إيقاف المولد</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>دع المولد مشغلا</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>دع المولد مشغلا</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>إيقاف الموّلد عندما يكون مدخل التيار المتردد متاحًا</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>إيقاف الموّلد عندما يكون مدخل التيار المتردد متاحًا</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>بطارية SOC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>بطارية SOC</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">درجة حرارة عالية في المعاكس</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>درجة حرارة عالية في المعاكس</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>درجة حرارة عالية في المعاكس</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>بدء التشغيل عند التحذير من الحرارة المرتفعة</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>بدء التشغيل عند التحذير من الحرارة المرتفعة</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>تشغيل عند التحذير من الحمل الزائد</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>تشغيل عند التحذير من الحمل الزائد</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>تشغيل دوري</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>تشغيل دوري</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>فترة التشغيل</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>فترة التشغيل</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 يوم/ أيام</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 يوم/ أيام</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>تجاهل التشغيل إذا كان قد تم تشغيله خلال</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>تجاهل التشغيل إذا كان قد تم تشغيله خلال</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>البدء دائما</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>البدء دائما</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>تاريخ بدء فترة التشغيل</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>تاريخ بدء فترة التشغيل</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>مدة التشغيل (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>مدة التشغيل (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>تشغيل حتى يتم شحن البطارية بالكامل</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>تشغيل حتى يتم شحن البطارية بالكامل</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>النظام الكوني لتحديد المواقع صحيح (مهيأ)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>النظام الكوني لتحديد المواقع صحيح (مهيأ)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>النظام الكوني لتحديد المواقع متصل، لكنه غير مهيأ</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>النظام الكوني لتحديد المواقع متصل، لكنه غير مهيأ</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>نظام التموضع العالمي غير متصل</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>نظام التموضع العالمي غير متصل</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>خط العرض</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>خط العرض</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>خط الطول</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>خط الطول</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 كم/ ساعة</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 كم/ ساعة</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 ميل/ ساعة</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 ميل/ ساعة</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 كيلو طن</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 كيلو طن</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 متر/ ثانية</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 متر/ ثانية</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>المسار</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>المسار</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>الارتفاع</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>الارتفاع</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>عدد الأقمار الصناعية</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>عدد الأقمار الصناعية</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>نقطة ضبط الشبكة</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>نقطة ضبط الشبكة</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>نقطة ضبط التيار المتردد-الداخل</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>نقطة ضبط التيار المتردد-الداخل</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>التيار: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>التيار: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>الجهد الكهربي: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>الجهد الكهربي: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>الحدود (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>الحدود (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>الشحن: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>الشحن: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>التفريغ: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>التفريغ: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>الحدود (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>الحدود (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>ظاهر</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>ظاهر</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>مخفي</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>مخفي</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (قياسات مساعدة)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (قياسات مساعدة)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (مخرجات %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (مخرجات %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>شاشة البطارية مفعلة</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>شاشة البطارية مفعلة</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">اسم</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">إدخال الاسم</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>إدخال الاسم</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>إدخال الاسم</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>مسح متواصل</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>مسح متواصل</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>مهايئات بلوتوث</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>مهايئات بلوتوث</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>الرقم السري</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>الرقم السري</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>قد يكون من الضروري إزالة معلومات الاقتران الموجودة قبل الاتصال.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>قد يكون من الضروري إزالة معلومات الاقتران الموجودة قبل الاتصال.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>نوع المرحلة</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>نوع المرحلة</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>طور مفرد</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>طور مفرد</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>طور متعدد</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>طور متعدد</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>العاكس الكهروضوئي للمرحلة 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>العاكس الكهروضوئي للمرحلة 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>موقع المعاكس الضوئي بالطور 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>موقع المعاكس الضوئي بالطور 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>ضابط مجال الشبكة-بيانات المسار التجميعي</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>ضابط مجال الشبكة-بيانات المسار التجميعي</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">معطل</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can و Lynx Ion BMS (250 كيلوبت/ثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can و Lynx Ion BMS (250 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can و CAN-مسار تجميعي BMS (250 كيلوبت/ثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can و CAN-مسار تجميعي BMS (250 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 كيلوبت/ثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>بروتوكول الاتصالات RV-C (250 كيلو بت/ الثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>بروتوكول الاتصالات RV-C (250 كيلو بت/ الثانية)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>أعلى، لكن دون خدمات (250 كيلو بت/ ثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>أعلى، لكن دون خدمات (250 كيلو بت/ ثانية)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>أجهزة</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>أجهزة</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>مخرج NMEA2000</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>مخرج NMEA2000</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>رقم الهوية الوحيد لمحدد الهوية</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>رقم الهوية الوحيد لمحدد الهوية</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>من فضلك انتظر، عملية شحن وتدقيق الرقم الوحيد تستغرق بعض الوقت</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>من فضلك انتظر، عملية شحن وتدقيق الرقم الوحيد تستغرق بعض الوقت</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>تحدد أداة التحديد أعلاه الكتلة ذات أرقام التعريف الفريدة التي ستستخدم لأغراض أرقام تعريف الاسم الفريدة في حقل اسم PGN 60928. التغيير فقط عند استخدام عدة أجهزة GX في شبكة VE.Can واحدة.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>تحدد أداة التحديد أعلاه الكتلة ذات أرقام التعريف الفريدة التي ستستخدم لأغراض أرقام تعريف الاسم الفريدة في حقل اسم PGN 60928. التغيير فقط عند استخدام عدة أجهزة GX في شبكة VE.Can واحدة.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>تحدد أداة التحديد أعلاه مجموعة فريدة من أرقام التعريف للاستخدام مع رقم مسلسل في حقل DGN 60928 ADDRESS_CLAIM. التغيير فقط عند استخدام عدة أجهزة GX في شبكة RV-C واحدة.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>تحدد أداة التحديد أعلاه مجموعة فريدة من أرقام التعريف للاستخدام مع رقم مسلسل في حقل DGN 60928 ADDRESS_CLAIM. التغيير فقط عند استخدام عدة أجهزة GX في شبكة RV-C واحدة.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>تحقق من هوية الأرقام الفريدة</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>تحقق من هوية الأرقام الفريدة</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">اضغط للتحقق</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>يوجد جهاز آخر متصل بهذا الرقم الفريد، يرجى تحديد رقم جديد.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>يوجد جهاز آخر متصل بهذا الرقم الفريد، يرجى تحديد رقم جديد.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>جيد. ليس هناك أي جهاز متصل مع نفس هذا الرقم الفريد.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>جيد. ليس هناك أي جهاز متصل مع نفس هذا الرقم الفريد.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>حالة الشبكة</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>حالة الشبكة</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>سطوع تكيفي</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>سطوع تكيفي</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>السطوع</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>السطوع</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>وقت خفوت الشاشة</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>وقت خفوت الشاشة</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>عشرة ثواني</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>عشرة ثواني</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>ثلاثون ثانية</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>ثلاثون ثانية</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>دقيقة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>دقيقة</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>عشرة دقائق</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>عشرة دقائق</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>ثلاثون دقيقة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>ثلاثون دقيقة</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>أبدا</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>أبدا</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>نمط العرض</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>نمط العرض</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>غامق</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>غامق</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>فاتح</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>فاتح</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>مستويات عرض مختصر</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>مستويات عرض مختصر</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>اللغة</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>اللغة</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>تغيير اللغة</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>تغيير اللغة</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>عرض الطاقة الكهربائية</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>عرض الطاقة الكهربائية</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>الطاقة (وات)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>الطاقة (وات)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>التيار (أمبير)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>التيار (أمبير)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>الوحدات</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>الوحدات</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>المستوى %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>المستوى %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>مئوية</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>مئوية</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>فهرنهايت</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>فهرنهايت</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;تنبيه:&lt;/b&gt; يرجى قراءة الدليل قبل الضبط.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;تنبيه:&lt;/b&gt; يرجى قراءة الدليل قبل الضبط.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>حد جهد شحن البطارية المُدار</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>حد جهد شحن البطارية المُدار</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>أقصى جهد للشحن</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>أقصى جهد للشحن</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>مراقب الجهد الكهربائي المشارك</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>مراقب الجهد الكهربائي المشارك</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>مراقب الحرارة المشاركة</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>مراقب الحرارة المشاركة</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>مستشعر غير متوفر، اختر واحدا آخر</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>مستشعر غير متوفر، اختر واحدا آخر</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">مستشعر غير متوفر، اختر واحدا آخر</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>الحساس المستخدم</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>الحساس المستخدم</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - مراقب الجهد الكهربائي المشارك</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - مراقب الجهد الكهربائي المشارك</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>حالة مراقب التيار الكهربائي المشارك</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>حالة مراقب التيار الكهربائي المشارك</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>معطل (التحكم الخارجي)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>معطل (التحكم الخارجي)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>معطل (لا يوجد شواحن)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>معطل (لا يوجد شواحن)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>معطل (لا توجد شاشة بطارية)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>معطل (لا توجد شاشة بطارية)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>التحديد التلقائي</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>التحديد التلقائي</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>لا يوجد تحكم في BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>لا يوجد تحكم في BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>التحكم في BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>التحكم في BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>غير متوفر، عيّن آخر</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>غير متوفر، عيّن آخر</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>التحديد التلقائي</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>التحديد التلقائي</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">لا أحد</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>إقامة التاريخ/الوقت</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>إقامة التاريخ/الوقت</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>تحديثات مباشرة</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>تحديثات مباشرة</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>قم بتنصيب البرنامج المبيت من المايكرو إس دي/يو إس بي</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>قم بتنصيب البرنامج المبيت من المايكرو إس دي/يو إس بي</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>نسخة أمان مخزنة للبرنامج المبيت</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>نسخة أمان مخزنة للبرنامج المبيت</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>التحقق من التحديثات على الأسطوانة المدمجة/ يو إس بي</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>التحقق من التحديثات على الأسطوانة المدمجة/ يو إس بي</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>تم العثور على البرنامج المبيت</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>تم العثور على البرنامج المبيت</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>تثبيت %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>تثبيت %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">اضغط للتحديث إلى %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>اضغط للتحديث إلى %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>اضغط للتحديث إلى %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>تاريخ/وقت إنشاء البرنامج المبيت</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>تاريخ/وقت إنشاء البرنامج المبيت</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>تحديث آلي</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>تحديث آلي</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>التحقق فقط</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>التحقق فقط</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>التحقق والتحميل فقط</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>التحقق والتحميل فقط</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>التحقق والتحديث</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>التحقق والتحديث</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>تحديث التغذية</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>تحديث التغذية</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>نوع الصورة</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>نوع الصورة</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>عادي</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>عادي</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>عادي</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>عادي</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>تحقق من التحديثات</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>تحقق من التحديثات</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>التحديث متوفر</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>التحديث متوفر</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>تثبيت %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>تثبيت %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">جارٍ التثبيت %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>تحديث إقامة التاريخ/الوقت</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>تحديث إقامة التاريخ/الوقت</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>معاكسات</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>معاكسات</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>تم إيجاد معاكسات ضوئية</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>تم إيجاد معاكسات ضوئية</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>تم كشف عنوان آي بي</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>تم كشف عنوان آي بي</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>أضف عنوان آي بي يدويا</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>أضف عنوان آي بي يدويا</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>منفذ بروتوكول التحكم في الإرسال</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>منفذ بروتوكول التحكم في الإرسال</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>متعدد الاطوار</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>متعدد الاطوار</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>مرحلة-مجزأة (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>مرحلة-مجزأة (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>إظهار</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>إظهار</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1/&gt;</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1/&gt;</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1/&gt;</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1/&gt;</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1/&gt;</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>هل ترغب في إعادة مسح عناوين بروتوكول الإنترنت؟</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>هل ترغب في إعادة مسح عناوين بروتوكول الإنترنت؟</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>إعادة المسح الضوئي</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>إعادة المسح الضوئي</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>خلية آمنة على الشبكة المحلية</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>خلية آمنة على الشبكة المحلية</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>دعم عن بعد</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>دعم عن بعد</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>نفق داعم عن بعد</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>نفق داعم عن بعد</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>عنوان IP ومنفذ دعم عن بعد</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>عنوان IP ومنفذ دعم عن بعد</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">تسجيل خروج الآن</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>إعادة التشغيل الآن</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>إعادة التشغيل الآن</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">تم إعادة تشغيل الجهاز.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>إنذار مسموع</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>إنذار مسموع</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>وضعية استعراض</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>وضعية استعراض</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>نظام تخزين الطاقة تجريبي</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>نظام تخزين الطاقة تجريبي</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>قارب/منزل متنقل تجريبي 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>قارب/منزل متنقل تجريبي 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>قارب/منزل متنقل تجريبي21</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>قارب/منزل متنقل تجريبي21</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>البدء بوضعية الاستعراض يمكن أن يغير بعض الإعدادات ولن يتم التفاعل مع المستخدم لبعض الوقت.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>البدء بوضعية الاستعراض يمكن أن يغير بعض الإعدادات ولن يتم التفاعل مع المستخدم لبعض الوقت.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>حالة الوضعيات</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>حالة الوضعيات</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>الحد الأدنى لوقت التشغيل</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>الحد الأدنى لوقت التشغيل</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>وقت الإحماء</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>وقت الإحماء</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>وقت التبريد</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>وقت التبريد</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>تم كشف مولد في دخل التيار المتردد</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>تم كشف مولد في دخل التيار المتردد</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>لم يتم تعيين أي من مدخلات التيار المتردد إلى المولد. انتقل إلى صفحة إعادة ضبط النظام وقم بتعيين المدخل الصحيح للتيار المتردد إلى المولد حتى تتمكن من تفعيل هذه الوظيفة.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>لم يتم تعيين أي من مدخلات التيار المتردد إلى المولد. انتقل إلى صفحة إعادة ضبط النظام وقم بتعيين المدخل الصحيح للتيار المتردد إلى المولد حتى تتمكن من تفعيل هذه الوظيفة.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>سيتم تشغيل إنذار عندما لا يتم الكشف عن أي طاقة من المولد في مدخل التيار المتردد العاكس. تأكد من ضبط إدخال التيار المتردد الصحيح على المولد في صفحة إعادة ضبط النظام.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>سيتم تشغيل إنذار عندما لا يتم الكشف عن أي طاقة من المولد في مدخل التيار المتردد العاكس. تأكد من ضبط إدخال التيار المتردد الصحيح على المولد في صفحة إعادة ضبط النظام.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>وقت بدء ساعات السكون</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>وقت بدء ساعات السكون</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>انتهاء وقت ساعات السكون</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>انتهاء وقت ساعات السكون</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>وقت التشغيل والصيانة</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>وقت التشغيل والصيانة</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>إعادة ضبط أوقات التشغيل اليومية</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>إعادة ضبط أوقات التشغيل اليومية</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>عداد أوقات التشغيل اليومي تم ضبطه</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>عداد أوقات التشغيل اليومي تم ضبطه</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>لا يمكن تعديل العدادات بينما المولد قيد العمل</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>لا يمكن تعديل العدادات بينما المولد قيد العمل</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>مواعيد صيانة الموّلد (ساعات)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>مواعيد صيانة الموّلد (ساعات)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>تم ضبط الفترة الزمنية على %1ساعة. استخدم الزر "إعادة ضبط جهاز توقيت الخدمة" لإعادة ضبط جهاز توقيت الخدمة.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>تم ضبط الفترة الزمنية على %1ساعة. استخدم الزر &quot;إعادة ضبط جهاز توقيت الخدمة&quot; لإعادة ضبط جهاز توقيت الخدمة.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>إعادة ضبط مؤقت الصيانة</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>إعادة ضبط مؤقت الصيانة</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>إعدادات النظام الكوني لتحديد المواقع</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>إعدادات النظام الكوني لتحديد المواقع</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>الصيغة</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>الصيغة</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>سرعة الوحدة</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>سرعة الوحدة</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>كيلومتر في الساعة</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>كيلومتر في الساعة</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>متر في الثانية</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>متر في الثانية</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>ميل بالساعة</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>ميل بالساعة</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>عقد</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>عقد</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>لا يوجد مودم GSM متصل</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>لا يوجد مودم GSM متصل</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>إنترنت</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>إنترنت</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>شركة الجوال</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>شركة الجوال</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>قد يكون من الضروري ضبط إعدادات اسم نقطة الوصول في أدنى الصفحة. اتصل بالمشغل للحصول على التفاصيل
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>قد يكون من الضروري ضبط إعدادات اسم نقطة الوصول في أدنى الصفحة. اتصل بالمشغل للحصول على التفاصيل
 إذا لم ينجح هذا، فتححق من بطاقة وحدة تعريف المشترك SIM في الهاتف للتأكد من وجود رصيد و/أو وجود سجل لاستخدامه في البيانات.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>السماح بالتجوال</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>السماح بالتجوال</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>حالة Sim</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>حالة Sim</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM لم يتم إدخالها</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM لم يتم إدخالها</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>مطلوب PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>مطلوب PIN</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>مطلوب PUK</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>مطلوب PUK</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>فشل SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>فشل SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>بطاقة SIM مشغولة</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>بطاقة SIM مشغولة</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>بطاقة SIM خاطئة</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>بطاقة SIM خاطئة</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>دبوس الخطأ</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>دبوس الخطأ</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>جاهز</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>جاهز</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">خطأ غير معروف</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>رقم التعريف الشخصي</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>رقم التعريف الشخصي</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>اسم نقطة الوصول</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>اسم نقطة الوصول</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>خلل</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>خلل</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>استخدم APN الافتراضي</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>استخدم APN الافتراضي</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>اسم APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>اسم APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>توثيق الاستخدام</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>توثيق الاستخدام</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>اسم المستخدم</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>اسم المستخدم</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>الهوية الدولية لمعدات الاتصالات المحمول</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>الهوية الدولية لمعدات الاتصالات المحمول</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>استهلاك ذاتي</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>استهلاك ذاتي</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>لا يوجد مساعد لـ ESS</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>لا يوجد مساعد لـ ESS</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>قياس الشبكة</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>قياس الشبكة</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>عداد خارجي</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>عداد خارجي</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>معاكس/شاحن</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>معاكس/شاحن</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>خرج التيار المتردد للمعاكس طور الاستخدام</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>خرج التيار المتردد للمعاكس طور الاستخدام</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>ضبط الطور المتعدد</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>ضبط الطور المتعدد</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>العدد الكلي للأطوار</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>العدد الكلي للأطوار</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>طور وحيد</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>طور وحيد</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>يتم تنظيم كل طور بشكل فردي للوصول إلى نقطة ضبط الشبكة (تقل كفاءة النظام).
+        <translation>يتم تنظيم كل طور بشكل فردي للوصول إلى نقطة ضبط الشبكة (تقل كفاءة النظام).
 
 تنبيه: الاستخدام فقط حسب الاقتضاء بواسطة مقدم خدمات المرافق.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>يتم تنظيم إجمالي جميع الأطوار بشكل ذكي للوصول إلى نقطة ضبط الشبكة (تحسن كفاءة النظام).
+        <translation>يتم تنظيم إجمالي جميع الأطوار بشكل ذكي للوصول إلى نقطة ضبط الشبكة (تحسن كفاءة النظام).
 
 يتم الاستخدام ما لم يحظر بواسطة مقدم خدمات المرافق.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">غير نشط</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">نظام تخزين الطاقة الديناميكي (ESS)</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>الحد الأدنى لـ SoC (إلا إذا فشلت الشبكة)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>الحد الأدنى لـ SoC (إلا إذا فشلت الشبكة)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>الحد النشط لـ SoC</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>الحد النشط لـ SoC</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">ركيزة</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">الشحن</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>تخفيف الأحمال</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>تخفيف الأحمال</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>أعلى من الحد الأدنى لحالة الشحن فقط</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>أعلى من الحد الأدنى لحالة الشحن فقط</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>دائمًا</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>دائمًا</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>تفريغ الشحن معطل</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>تفريغ الشحن معطل</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>شحن بطيء</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>شحن بطيء</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>ركيزة</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>ركيزة</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>الشحن</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>الشحن</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>تحديد قدرة الشحن</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>تحديد قدرة الشحن</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>أقصى حد لقدرة الشحن</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>أقصى حد لقدرة الشحن</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>تحديد قدرة العاكس</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>تحديد قدرة العاكس</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>الحد الأقصى لقدرة العاكس</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>الحد الأقصى لقدرة العاكس</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>نقطة ضبط الشبكة</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>نقطة ضبط الشبكة</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>تغذية داخلية للشبكة</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>تغذية داخلية للشبكة</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>التيار المتردد / المعاكس الضوئي المقرون - تغذية زائدة</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>التيار المتردد / المعاكس الضوئي المقرون - تغذية زائدة</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>التيار المستمر / المعاكس الضوئي المقرون - تغذية زائدة</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>التيار المستمر / المعاكس الضوئي المقرون - تغذية زائدة</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>حد نظام التغذية</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>حد نظام التغذية</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>الحد الأعلى للتغذية الداخلية</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>الحد الأعلى للتغذية الداخلية</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>تحديد التغذية مفعل</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>تحديد التغذية مفعل</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>مدخلات تناظرية</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>مدخلات تناظرية</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>مدخلات رقمية</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>مدخلات رقمية</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>مدخل رقمي %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>مدخل رقمي %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>عداد النبض</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>عداد النبض</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>إنذار الباب</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>إنذار الباب</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>مضخة الماء الآسن</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>مضخة الماء الآسن</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>إنذار الماء الآسن</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>إنذار الماء الآسن</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>إنذار ضد السرقة</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>إنذار ضد السرقة</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>إنذار الدخان</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>إنذار الدخان</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>إنذار الحريق</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>إنذار الحريق</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>إنذار ثاني أكسيد الكربون</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>إنذار ثاني أكسيد الكربون</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>مستشعرات بلوتوث</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>مستشعرات بلوتوث</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>يرجى العلم أن هذه السمات لا تدعمها فيكترون بشكل رسمي. يرجى مراجعة الموقع الإلكتروني community.victronenergy.com إن كانت لديك أية أسئلة. 
+        <translation>يرجى العلم أن هذه السمات لا تدعمها فيكترون بشكل رسمي. يرجى مراجعة الموقع الإلكتروني community.victronenergy.com إن كانت لديك أية أسئلة. 
 
 Documentation على  https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>الإشارة K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>الإشارة K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>أداة التطوير Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>أداة التطوير Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>تمكين (الوضع الآمن)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>تمكين (الوضع الآمن)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>مؤجل بمقدار %1ثانية</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>مؤجل بمقدار %1ثانية</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>معرف بوابة VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>معرف بوابة VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>فترة التسجيل</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>فترة التسجيل</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>خمس دقائق</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>خمس دقائق</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 دقيقة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 دقيقة</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>ساعة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>ساعة</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>ساعتان</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>ساعتان</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>أربع ساعات</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>أربع ساعات</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 ساعة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 ساعة</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>يوم</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>يوم</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>استخدم اتصال آمن (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>استخدم اتصال آمن (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>آخر تواصل</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>آخر تواصل</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 نص استجابة غير متوقع</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 نص استجابة غير متوقع</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 رد HTTP غير متوقع</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 رد HTTP غير متوقع</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 انتهت مدة الاتصال</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 انتهت مدة الاتصال</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 خطأ في الاتصال</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 خطأ في الاتصال</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 عطل خدمة اسم النطاق</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 عطل خدمة اسم النطاق</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 خطأ في التوجيه </translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 خطأ في التوجيه </translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM غير متاح</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM غير متاح</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 خطأ غير معروف</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 خطأ غير معروف</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>رسالة خطأ 
+        <translation>رسالة خطأ 
 %1/&gt;</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>أعد تشفيل الجهاز إذا لم تجد اتصال</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>أعد تشفيل الجهاز إذا لم تجد اتصال</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>إذا لم تجد اتصال أعد ضبط المرحل (س:د)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>إذا لم تجد اتصال أعد ضبط المرحل (س:د)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>مكان التخزين</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>مكان التخزين</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>لا يوجج موازنة مفعلة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>لا يوجج موازنة مفعلة</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>تخزين داخلي</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>تخزين داخلي</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>يتم النقل</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>يتم النقل</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>التخزين الخارجي</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>التخزين الخارجي</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">خطأ غير معروف</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>لا يوجد خطأ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>لا يوجد خطأ</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>لم يتبقى مكان في التخزين</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>لم يتبقى مكان في التخزين</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>خطأ في المدخلات والمخرجات</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>خطأ في المدخلات والمخرجات</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>خطأ في التركيب</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>خطأ في التركيب</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>يحتوي على صورة البرامج المبيتة. لا يتم استخدامه.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>يحتوي على صورة البرامج المبيتة. لا يتم استخدامه.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>بطاقة إس دي / شريحة يو إس بي غير قابلة للكتابة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>بطاقة إس دي / شريحة يو إس بي غير قابلة للكتابة</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>مساحة حرة في القرص</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>مساحة حرة في القرص</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>بايت</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>بايت</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>بايتس</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>بايتس</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>السجلات المخزنة</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>السجلات المخزنة</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 سجلات</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 سجلات</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>أقدم عمر للسجل</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>أقدم عمر للسجل</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>فعل نمط المسار التجميعي / بروتوكول التحكم في الإرسال</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>فعل نمط المسار التجميعي / بروتوكول التحكم في الإرسال</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>لم يتم الإبلاغ عن أي أخطاء</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>لم يتم الإبلاغ عن أي أخطاء</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>وقت آخر خطأ</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>وقت آخر خطأ</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>خدمات متوفرة</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>خدمات متوفرة</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>رمز الوحدة: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>رمز الوحدة: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>الوظيفة (مرحل 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>الوظيفة (مرحل 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>وظيفة</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>وظيفة</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>إنذار المرحل</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>إنذار المرحل</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">مضخة الخزان</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">يدوي</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>قطبية مرحل الإنذار</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>قطبية مرحل الإنذار</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>فتح عادي</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>فتح عادي</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>مغلق في العادة</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>مغلق في العادة</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>مرحل 1 مشغل</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>مرحل 1 مشغل</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>مرحل مشغل</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>مرحل مشغل</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>الوظيفة (مرحل 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>الوظيفة (مرحل 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>مرحل 2 مشغل</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>مرحل 2 مشغل</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>قواعد التحكم في درجة الحرارة</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>قواعد التحكم في درجة الحرارة</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>تفعيل المرحل على درجة الحرارة</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>تفعيل المرحل على درجة الحرارة</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>لم يتم إعداد أي مرحل للتنشيط بواسطة درجة الحرارة. الانتقال إلى صفحة إعدادات المرحل في قائمة الإعدادات الرئيسية وضبط وظيفة المرحل على "درجة الحرارة".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>لم يتم إعداد أي مرحل للتنشيط بواسطة درجة الحرارة. الانتقال إلى صفحة إعدادات المرحل في قائمة الإعدادات الرئيسية وضبط وظيفة المرحل على &quot;درجة الحرارة&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>هذا الخيار يسمح لك بالتغيير بين النسخة الحالية والسابقة للبرنامج الثابت، ولا يحتاج لإنترنت أو ذاكرة إس دي.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>هذا الخيار يسمح لك بالتغيير بين النسخة الحالية والسابقة للبرنامج الثابت، ولا يحتاج لإنترنت أو ذاكرة إس دي.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>البرنامج الثابت %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>البرنامج الثابت %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>اضغط للتشغيل</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>اضغط للتشغيل</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">البرنامج الثابت %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>إعادة التشغيل إلى %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>إعادة التشغيل إلى %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>لا يمكن تبديل إصدار البرنامج الثابت عند ضبط التحديث التلقائي على "فحص وتحديث". اضبط التحديث التلقائي على \ "معطل" أو "تحقق فقط" لتمكين هذا الخيار.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>لا يمكن تبديل إصدار البرنامج الثابت عند ضبط التحديث التلقائي على &quot;فحص وتحديث&quot;. اضبط التحديث التلقائي على \ &quot;معطل&quot; أو &quot;تحقق فقط&quot; لتمكين هذا الخيار.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>نسخة أمان البرنامج المبيت غير متوفرة</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>نسخة أمان البرنامج المبيت غير متوفرة</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>نمط المسار التجميعي بروتوكول التحكم في الإرسال</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>وحدة التحكم والمراقبية على VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>نمط المسار التجميعي بروتوكول التحكم في الإرسال</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>ناقل شبكة التحكم في النطاق عبر بروتوكول التحكم في نقل البيانات/ بروتوكول الإنترنت (معالجة الأخطاء)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>ناقل شبكة التحكم في النطاق عبر بروتوكول التحكم في نقل البيانات/ بروتوكول الإنترنت (معالجة الأخطاء)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>دعم الطاقة</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>دعم الطاقة</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>مركبة</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>مركبة</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>قارب</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>قارب</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>اسم النظام</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>اسم النظام</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>آلي</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>آلي</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">الشبكة</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">آلي</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>مستخدم معرف</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>مستخدم معرف</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>اسم معرف من قبل المستخدم</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>اسم معرف من قبل المستخدم</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>مدخلات التيار المتردد 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>مدخلات التيار المتردد 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>مدخلات التيار المتردد 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>مدخلات التيار المتردد 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>قم برصد خطأ الشبكة</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>قم برصد خطأ الشبكة</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>ارصد لفصل الدعم</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>ارصد لفصل الدعم</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>تحديد تلقائي</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>تحديد تلقائي</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>يحوي نظام تيار مستمر</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>يحوي نظام تيار مستمر</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>مزامنة VE المسار التجميعي لحالة الشحن مع البطارية</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>مزامنة VE المسار التجميعي لحالة الشحن مع البطارية</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>استخدم الشاحن الضوئي الحالي لتحسين المسار التجميعي للمعاكس الضوئي لحالة الشحن</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>استخدم الشاحن الضوئي الحالي لتحسين المسار التجميعي للمعاكس الضوئي لحالة الشحن</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>منظم الجهد الكهربائي للشاحن الضوئي</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>منظم الجهد الكهربائي للشاحن الضوئي</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>منظم تيار الشاحن الضوئي</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>منظم تيار الشاحن الضوئي</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">التحكم بنظام إدارة البطارية</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>التحكم بنظام إدارة البطارية</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>التحكم بنظام إدارة البطارية</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>لم يتم تفعيل وظيفة تشغيل/ إيقاف مضخة الخزان. الانتقال إلى إعدادات المرحل وضبط الوظيفة على "مضخة الخزان".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>لم يتم تفعيل وظيفة تشغيل/ إيقاف مضخة الخزان. الانتقال إلى إعدادات المرحل وضبط الوظيفة على &quot;مضخة الخزان&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>حالة المضخة</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>حالة المضخة</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">آلي</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>حساس الخزان</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>حساس الخزان</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>مستوى التشغيل</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>مستوى التشغيل</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>مستوى التوقف</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>مستوى التوقف</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>اتصال مفقود</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>اتصال مفقود</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>مفصول</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>مفصول</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[مخفي]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[مخفي]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>اتصال بالشبكة؟</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>اتصال بالشبكة؟</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>اتصال</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>اتصال</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>نسيت الشبكة؟</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>نسيت الشبكة؟</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>نسيان</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>نسيان</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>هل أنت متأكد أنك تريد نسيان هذه الشبكة؟</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>هل أنت متأكد أنك تريد نسيان هذه الشبكة؟</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>عنوان MAC</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>عنوان MAC</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>هيئة بروبوكول الإنترنت</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>هيئة بروبوكول الإنترنت</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">يدوي</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">مطفأ</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>ثابت</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>ثابت</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>قناع الشبكة</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>قناع الشبكة</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>البوابة</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>البوابة</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>خادم نظام تسمية النطاقات (DNS)</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>خادم نظام تسمية النطاقات (DNS)</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>رابط محلي لعنوان بروتوكول الإنترنت</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>رابط محلي لعنوان بروتوكول الإنترنت</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>انتبه: بالنسبة لأنظمة ESS ، وكذلك الأنظمة ذات البطارية المُدارة ، يجب أن تظل نسخة جهاز ضابط مجال الشبكة-المسار التجميعي معينة على الصفر. راجع دليل GX لمزيد من المعلومات.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>انتبه: بالنسبة لأنظمة ESS ، وكذلك الأنظمة ذات البطارية المُدارة ، يجب أن تظل نسخة جهاز ضابط مجال الشبكة-المسار التجميعي معينة على الصفر. راجع دليل GX لمزيد من المعلومات.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>نسخة الجهاز</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>نسخة الجهاز</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>عنوان الشبكة</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>عنوان الشبكة</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>أجهزة VE.CAN </translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>أجهزة VE.CAN </translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>رقم الجهاز %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>رقم الجهاز %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>ليست هناك نقاط دخول</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>ليست هناك نقاط دخول</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>لا يوجد موائم Wi-Fi متصل</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>لا يوجد موائم Wi-Fi متصل</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>إنشاء نقطة توصيل</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>إنشاء نقطة توصيل</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>شبكات Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>شبكات Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>هل أنت متأكد من رغبتك في تعطيل نقطة التوصيل؟</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>هل أنت متأكد من رغبتك في تعطيل نقطة التوصيل؟</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>تاريخ/وقت التوقيت العالمي المنسق</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>تاريخ/وقت التوقيت العالمي المنسق</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>وقت/تاريخ محلي</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>وقت/تاريخ محلي</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>منطقة زمنية</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>منطقة زمنية</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>أفريقيا</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>أفريقيا</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>أمريكا</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>أمريكا</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>القارة القطبية الجنوبية</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>القارة القطبية الجنوبية</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>القطب الشمالي</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>القطب الشمالي</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>آسيا</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>آسيا</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>المحيط الأطلسي</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>المحيط الأطلسي</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>أستراليا</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>أستراليا</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>أوروبا</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>أوروبا</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>الهندي</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>الهندي</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>الهادئ</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>الهادئ</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>إلخ</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>إلخ</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>غير متصل %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>غير متصل %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>هل تريد إعادة التشغيل الآن؟</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>هل تريد إعادة التشغيل الآن؟</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>لن يتم تطبيق تغييرات نسخة VRM إلى أن يتم إعادة تشغيل الجهاز.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>لن يتم تطبيق تغييرات نسخة VRM إلى أن يتم إعادة تشغيل الجهاز.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>إعادة تشغيل الجهاز...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>إعادة تشغيل الجهاز...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>تم إعادة تشغيل الجهاز.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>تم إعادة تشغيل الجهاز.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>إنذار جهد البطارية المنخفض</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>إنذار جهد البطارية المنخفض</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>منبه جهد البطارية المرتفعة</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>منبه جهد البطارية المرتفعة</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>آخر خطأ</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>آخر خطأ</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>ثاني آخر خطأ</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>ثاني آخر خطأ</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>ثالث آخر خطأ</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>ثالث آخر خطأ</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>رابع آخر خطأ</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>رابع آخر خطأ</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>عبر الشبكة</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>عبر الشبكة</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>وضعية الإعداد</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>وضعية الإعداد</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>مستقل</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>مستقل</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">مستقل</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>تحميل</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>تحميل</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">التحكم الخارجي</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>شحن وموزع مركزي- 1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>شحن وموزع مركزي- 1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>نظام إدارة البطاريات</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>نظام إدارة البطاريات</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>شحن ونظام إدارة البطارية</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>شحن ونظام إدارة البطارية</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>التحكم الخارخي ونظام إدارة البطارية</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>التحكم الخارخي ونظام إدارة البطارية</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>شحن، موزع مركزي-1 ونظام إدارة البطارية</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>شحن، موزع مركزي-1 ونظام إدارة البطارية</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>إعداد الرئيسي</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>إعداد الرئيسي</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">تابع</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>تابع</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>تابع</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>رئيس المجموعة</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>رئيس المجموعة</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>رئيس الشحن</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>رئيس الشحن</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>رئيس الشحن والمجموعة</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>رئيس الشحن والمجموعة</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>الجهد الكهربائي للشحن</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>الجهد الكهربائي للشحن</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>إعادة ضبط</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>إعادة ضبط</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>يتم تفعيل نظام إدارة المبنى تلقائيًا عند تثبيت النظام. إعادة الضبط في حالة تغيير إعدادات النظام أو في حالة عدم تثبيت نظام إدارة المبنى.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>يتم تفعيل نظام إدارة المبنى تلقائيًا عند تثبيت النظام. إعادة الضبط في حالة تغيير إعدادات النظام أو في حالة عدم تثبيت نظام إدارة المبنى.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">إجمالي الطاقة الكهروضوئية</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>تحميل</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>تحميل</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 موجود</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 موجود</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 التاريخ</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 التاريخ</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 التاريخ</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>عملية عبر الشبكة</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>عملية عبر الشبكة</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>عرض الجدول</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>عرض الجدول</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>مخطط</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>مخطط</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>تحذير</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>تحذير</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">إنذار</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>إنذار</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>إنذار</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>الحجم</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>الحجم</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>حدثت دائرة قصر</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>حدثت دائرة قصر</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>قطبية معاكسة</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>قطبية معاكسة</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>محطات شحن المركبات الكهربائية</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>محطات شحن المركبات الكهربائية</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>جلسة</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>جلسة</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>الوقت</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>الوقت</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>نمط الشحن</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>نمط الشحن</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>بدء العملية وإيقافها بنفسك. استخدم ذلك في الشحن السريع والمراقبة الدقيقة.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>بدء العملية وإيقافها بنفسك. استخدم ذلك في الشحن السريع والمراقبة الدقيقة.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>يعتمد بدء التشغيل والإيقاف على مستوى شحن البطارية. نموذجي للشحن الليلي والممتد لتجنب الشحن الزائد.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>يعتمد بدء التشغيل والإيقاف على مستوى شحن البطارية. نموذجي للشحن الليلي والممتد لتجنب الشحن الزائد.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>أسعار الكهرباء الأقل في غير ساعات الذروة أو إن أردت التأكد من شحن مركبتك الكهربائية بالكامل والاستعداد للانطلاق في وقت محدد.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>أسعار الكهرباء الأقل في غير ساعات الذروة أو إن أردت التأكد من شحن مركبتك الكهربائية بالكامل والاستعداد للانطلاق في وقت محدد.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>تفعيل الشحن</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>تفعيل الشحن</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>قفل عرض الشاحن</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>قفل عرض الشاحن</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>عنوان المصدر</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>عنوان المصدر</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>إعادة ضبط</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>إعادة ضبط</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>رقم حالة الخط#%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>رقم حالة الخط#%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>نموذج الخط</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>نموذج الخط</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>نموذج الشاحن</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>نموذج الشاحن</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>نموذج العاكس</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>نموذج العاكس</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>رقم مصدر التيار المستمر #%1الحالة</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>رقم مصدر التيار المستمر #%1الحالة</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>نموذج مصدر التيار المباشر</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>نموذج مصدر التيار المباشر</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>رقم مصدر التيار المستمر #%1 الأولوية</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>رقم مصدر التيار المستمر #%1 الأولوية</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>أولوية مصدر التيار المباشر</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>أولوية مصدر التيار المباشر</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>نموذج الخزان</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>نموذج الخزان</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>أجهزة RV-C </translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>أجهزة RV-C </translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>تفعيل أداة التصوير المرئي لمعدل الإطار</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>تفعيل أداة التصوير المرئي لمعدل الإطار</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>غير مدعم</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>غير مدعم</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>افصل الأجهزة غير المتصلة</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>افصل الأجهزة غير المتصلة</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>تم إيجاد جهاز غير مدعوم</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>تم إيجاد جهاز غير مدعوم</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>عمل المرحل</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>عمل المرحل</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">إنذار</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>بدء/وقف الشاحن أو المولد</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>بدء/وقف الشاحن أو المولد</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">تحكم يدوي</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">انصهار متضخم</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>تحكم يدوي</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>تحكم يدوي</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>دائما مفتوح (عدم استخدام المرحل)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>دائما مفتوح (عدم استخدام المرحل)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>يرجى العلم أن تغيير إعدادات حالة الشحن المنخفض تغير كذلك إعداد وقت بدء التفريغ الأرضي في قائمة البطارية.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>يرجى العلم أن تغيير إعدادات حالة الشحن المنخفض تغير كذلك إعداد وقت بدء التفريغ الأرضي في قائمة البطارية.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>انصهار متضخم</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>انصهار متضخم</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>حالة الثنائيات الباعثة للضوء</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>حالة الثنائيات الباعثة للضوء</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">لا أحد</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>المبدل الرئيسي</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>المبدل الرئيسي</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>سخان</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>سخان</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>المروحة الداخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>المروحة الداخلية</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>علامات التحذير</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>علامات التحذير</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>علامات الإنذار</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>علامات الإنذار</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>مبدل</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>مبدل</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>القيام بالبدء</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>القيام بالبدء</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>إيقاف التشغيل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>إيقاف التشغيل</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>يتم التحديث</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>يتم التحديث</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>سيبدأ بالتشغيل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>سيبدأ بالتشغيل</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>وضعية ما قبل الشحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>وضعية ما قبل الشحن</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>تحقق من الموصل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>تحقق من الموصل</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>حالة الصلاحية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>حالة الصلاحية</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>حرارة البطارية</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>حرارة البطارية</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>حرارة الهواء</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>حرارة الهواء</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>مشغل التيار</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>مشغل التيار</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>الجهد الكهربائي للمسار التجميعي</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>الجهد الكهربائي للمسار التجميعي</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>الفرع الأعلى للتيار</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>الفرع الأعلى للتيار</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">خطأ في الاتصال</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">حالة الصلاحية</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">الجهد الكهربائي للمسار التجميعي</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>الفرع الأسفل للتيار</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>الفرع الأسفل للتيار</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>تباين نقطة الوسط</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>تباين نقطة الوسط</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>أمبير بالساعة مستهلك</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>أمبير بالساعة مستهلك</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>الوقت المتبقي للانطلاق</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>الوقت المتبقي للانطلاق</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>تفاصيل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>تفاصيل</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>تنبيهات مستوى الوحدة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>تنبيهات مستوى الوحدة</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>تشخيص</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>تشخيص</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>المصهرات</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>المصهرات</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>داخل/خارج</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>داخل/خارج</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>النظام</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>النظام</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>عامل متغير</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>عامل متغير</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>إعادة كشف البطارية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>إعادة كشف البطارية</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">اضغط لإعادة الكشف</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>اضغط لإعادة الكشف</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>اضغط لإعادة الكشف</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>إعادة كشف البطارية يتطلب قرابة 60 ثانية. خلال هذا الوقت اسم البطارية قد يكون خاطئا.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>إعادة كشف البطارية يتطلب قرابة 60 ثانية. خلال هذا الوقت اسم البطارية قد يكون خاطئا.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>تيار الشحنة عالية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>تيار الشحنة عالية</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>تيار التفريغ مرتفع</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>تيار التفريغ مرتفع</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>SoC منخفض</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>SoC منخفض</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">جهد البطارية مرتفع</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">SoC منخفض</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>جهد البادئ منخفض</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>جهد البادئ منخفض</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>جهد البادئ مرتفع</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>جهد البادئ مرتفع</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>مستشعر حرارة البطارية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>مستشعر حرارة البطارية</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>تيار نقطة الوسط</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>تيار نقطة الوسط</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">انصهار متضخم</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>الحرارة الداخلية مرتفعة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>الحرارة الداخلية مرتفعة</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>حرارة الشحن منخفضة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>حرارة الشحن منخفضة</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>حرارة الشحن مرتفعة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>حرارة الشحن مرتفعة</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>فشل داخلي</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>فشل داخلي</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>قاطع الدائرة تعثرت</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>قاطع الدائرة تعثرت</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>خلل في الخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>خلل في الخلية</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>الجهد الكهربائي المنخفض للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>الجهد الكهربائي المنخفض للخلية</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>الجهد الكهربائي الأدنى للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>الجهد الكهربائي الأدنى للخلية</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>الجهد الكهربائي الأعلى للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>الجهد الكهربائي الأعلى للخلية</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>الحرارة الأدنى للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>الحرارة الأدنى للخلية</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>الحرارة الأعلى للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>الحرارة الأعلى للخلية</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>وحدات البطارية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>وحدات البطارية</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 متصل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 متصل</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 غير متصل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 غير متصل</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>عدد الوحدات التي تمنع الشحن/ التفريغ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>عدد الوحدات التي تمنع الشحن/ التفريغ</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>منصبة / مساحة متوفرة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>منصبة / مساحة متوفرة</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>تفريغ عميق للشحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>تفريغ عميق للشحن</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>آخر تفريغ للشحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>آخر تفريغ للشحن</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>متوسط تفريغ الشحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>متوسط تفريغ الشحن</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>محصلة دورات الشحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>محصلة دورات الشحن</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>عدد كل تفريغات الشحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>عدد كل تفريغات الشحن</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>رسم تراكمي</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>رسم تراكمي</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>الحد الأدنى للجهد الكهربائي للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>الحد الأدنى للجهد الكهربائي للخلية</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>الحد الأعلى للجهد الكهربائي للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>الحد الأعلى للجهد الكهربائي للخلية</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>الوقت منذ آخر شحن كامل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>الوقت منذ آخر شحن كامل</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>حساب عملية التزامن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>حساب عملية التزامن</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>إنذارات انخفاض جهد بطارية بدء التشغيل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>إنذارات انخفاض جهد بطارية بدء التشغيل</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>الحد الأدنى لجهد بطارية بدء التشغيل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>الحد الأدنى لجهد بطارية بدء التشغيل</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>الحد الأقصى لجهد بطارية بدء التشغيل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>الحد الأقصى لجهد بطارية بدء التشغيل</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>الطاقة المفرغة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>الطاقة المفرغة</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>طاقة مشحونة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>طاقة مشحونة</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>حد جهد الشحن (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>حد جهد الشحن (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>حد تيار الشحن (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>حد تيار الشحن (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>حد إفراغ شحن التيار</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>حد إفراغ شحن التيار</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>الجهد الكهربائي المنخفض غير متصل (التجاهل دائما)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>الجهد الكهربائي المنخفض غير متصل (التجاهل دائما)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>مجموعة البطارية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>مجموعة البطارية</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>مرحل (في بطارية الشاشة)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>مرحل (في بطارية الشاشة)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>استعادة القيمة الافتراضية للمصنع</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>استعادة القيمة الافتراضية للمصنع</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>اضغط للعودة إلى الضبط الأصلي</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>اضغط للعودة إلى الضبط الأصلي</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>هل تريد استعادة القيم الافتراضية لضبط المصنع؟</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>هل تريد استعادة القيم الافتراضية لضبط المصنع؟</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>تفعيل بلوتوث</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>تفعيل بلوتوث</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>الجهد الاسمي</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>الجهد الاسمي</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 فولت</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 فولت</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 فولت</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 فولت</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 فولت</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 فولت</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>استيعاب</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>استيعاب</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">استيعاب</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>الجهد الكهربائي المشحون</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>الجهد الكهربائي المشحون</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>تيار ذيلي</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>تيار ذيلي</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>الكاشف الزمني للشحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>الكاشف الزمني للشحن</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>ترقية باوكرت</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>ترقية باوكرت</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>عامل كفاءة الشاحن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>عامل كفاءة الشاحن</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>عتبة التيار</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>عتبة التيار</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>فترة متوسط الوقت المتبقي للانطلاق</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>فترة متوسط الوقت المتبقي للانطلاق</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>الزمن للذهاب إلى دور التفريغ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>الزمن للذهاب إلى دور التفريغ</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>تيار معوض</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>تيار معوض</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>مزامنة حالة الشحن إلى 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>مزامنة حالة الشحن إلى 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>اضغط للمزامنة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>اضغط للمزامنة</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>معايرة التيار الصفري</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>معايرة التيار الصفري</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>اضغط للتحديد إلى 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>اضغط للتحديد إلى 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>الموزع %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>الموزع %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>لا توجد طاقة على قضيب التجميع</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>لا توجد طاقة على قضيب التجميع</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">اتصال مفقود</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
-        <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
-        <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
-        <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
-        <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
-        <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
+            <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
+            <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
+            <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
+            <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
+            <numerusform>%n احتراق المصهر/ المصهرات</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>لا توجد معلومات متاحة، انظر الصفحة السابقة للتعرف على حالة الموزع.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>لا توجد معلومات متاحة، انظر الصفحة السابقة للتعرف على حالة الموزع.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>المصهر %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>المصهر %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>غير مستخدم</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>غير مستخدم</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>محترق</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>محترق</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>إغلاق بسبب الأخطاء</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>إغلاق بسبب الأخطاء</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">آخر خطأ</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">ثاني آخر خطأ</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">ثالث آخر خطأ</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">رابع آخر خطأ</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>مبدل النظام</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>مبدل النظام</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>مرحل خارجي</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>مرحل خارجي</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>ملامس قابل للبرمجة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>ملامس قابل للبرمجة</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>بطاريات</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>بطاريات</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">استيعاب</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">بطاريات</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>المتوازيات</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>المتوازيات</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>السلسلة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>السلسلة</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>الحد الأدنى/الحد الأعلى للجهد الكهربائي للخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>الحد الأدنى/الحد الأعلى للجهد الكهربائي للخلية</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>الحد الأدنى/الحد الأعلى لحرارة الخلية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>الحد الأدنى/الحد الأعلى لحرارة الخلية</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">يقوم بالموازنة</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>يقوم بالموازنة</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>يقوم بالموازنة</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">مجهول</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>مخرج</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>مخرج</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>محرك المجال</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>محرك المجال</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>سرعة المحرك</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>سرعة المحرك</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>الجهد الكهربائي المساعد</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>الجهد الكهربائي المساعد</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>لا توجد إنذارات</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>لا توجد إنذارات</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>جهد منخفض</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>جهد منخفض</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>تيار مرتفع</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>تيار مرتفع</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>الجهد الكهربائي المساعد المنخفض</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>الجهد الكهربائي المساعد المنخفض</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>الجهد الكهربائي المساعد المرتفع</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>الجهد الكهربائي المساعد المرتفع</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>إنذارات الجهد الكهربائي المساعد المنخفض</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>إنذارات الجهد الكهربائي المساعد المنخفض</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>إنذارات الجهد الكهربائي المساعد المرتفع</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>إنذارات الجهد الكهربائي المساعد المرتفع</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>الحد الأدنى للجهد الكهربائي المساعد</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>الحد الأدنى للجهد الكهربائي المساعد</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>الحد الأعلى للجهد الكهربائي المساعد</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>الحد الأعلى للجهد الكهربائي المساعد</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>الطاقة المنتجة</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>الطاقة المنتجة</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>الطاقة المستهلكة</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>الطاقة المستهلكة</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>تفعيل الإنذار</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>تفعيل الإنذار</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>المستوى النشط</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>المستوى النشط</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>استعادة المستوى</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>استعادة المستوى</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>تأخير</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>تأخير</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>المستوى</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>المستوى</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>المتبقي</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>المتبقي</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">بطارية المستشعر</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>بطارية المستشعر</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>بطارية المستشعر</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>نوع جهاز الاستشعار</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>نوع جهاز الاستشعار</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>خلل</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>خلل</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>أوروبي (0 إلى 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>أوروبي (0 إلى 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>أمريكا (240 إلى 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>أمريكا (240 إلى 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>تخصيص</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>تخصيص</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">تخصيص</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>قيمة جهاز الاستشعار عندما يكون فارغًا</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>قيمة جهاز الاستشعار عندما يكون فارغًا</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>نوع السائل</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>نوع السائل</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>نسبة البيوتين</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>نسبة البيوتين</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>شكل مخصص</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>شكل مخصص</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>متوسط الوقت</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>متوسط الوقت</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>قيمة جهاز الاستشعار</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>قيمة جهاز الاستشعار</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>لم يتم تحديد شكل مخصص يمكنك تحديد نقطة واحدة حتى عشر نقاط. يرجى العلم أن 0% و100% مشمولة.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>لم يتم تحديد شكل مخصص يمكنك تحديد نقطة واحدة حتى عشر نقاط. يرجى العلم أن 0% و100% مشمولة.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>النقطة %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>النقطة %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>إضافة درجة</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>إضافة درجة</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>مستوى المستشعر</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>مستوى المستشعر</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">الحجم</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>لا يسمح بقيم مستوى الحساس المكررة.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>لا يسمح بقيم مستوى الحساس المكررة.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>يجب زيادة قيم الحجم.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>يجب زيادة قيم الحجم.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>مراقب التوقيت</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>مراقب التوقيت</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>مفتوح (كيلو فولت أمبير ساعة تفاعلية)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>مفتوح (كيلو فولت أمبير ساعة تفاعلية)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>مفتوح (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>مفتوح (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>مفتوح (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>مفتوح (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>مغلق</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>مغلق</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>تهيئة الطور</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>تهيئة الطور</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>موضع المفتاح</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>موضع المفتاح</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">طور مفرد</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2-طور</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2-طور</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3-طور</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3-طور</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">أجهزة</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>التيار المتردد</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>التيار المتردد</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>المحرك</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>المحرك</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">السرعة</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">تحميل</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>حرارة المبرد</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>حرارة المبرد</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>حرارة العادم</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>حرارة العادم</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>حرارة اللفيفة</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>حرارة اللفيفة</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>مشغل الجهد الكهربائي للبطارية</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>مشغل الجهد الكهربائي للبطارية</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>عدد مرات بدء التشغيل</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>عدد مرات بدء التشغيل</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">التحكم بنظام إدارة البطارية</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>قفل أداة التحديد الأمامية (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>قفل أداة التحديد الأمامية (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>لا يوجد خطأ (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>لا يوجد خطأ (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>التيار المتردد الكلي</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>التيار المتردد الكلي</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>طاقة L%1/&gt;</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>طاقة L%1/&gt;</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>مرحلة الطور</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>مرحلة الطور</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>نسخة مدير البيانات</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>نسخة مدير البيانات</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>محول التيار %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>محول التيار %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">لا أحد</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>يشير الثنائي الباعث للضوء الوامض إلى هذا CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>يشير الثنائي الباعث للضوء الوامض إلى هذا CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>أجهزة مسار Smappee</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>أجهزة مسار Smappee</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>شاحن ضوئي</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>شاحن ضوئي</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>تم تعطيل هذا الإعداد عند توصيل التحكم الرقمي المتعدد.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>تم تعطيل هذا الإعداد عند توصيل التحكم الرقمي المتعدد.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>تم تعطيل هذا الإعداد عند توصيل VE.Bus BMS.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>تم تعطيل هذا الإعداد عند توصيل VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>تشغيل مكيف الهواء %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>تشغيل مكيف الهواء %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>التيار المستمر</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>التيار المستمر</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>محول</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>محول</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">تفعيل الإنذار</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">محول</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>عكس منطق الإنذار</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>عكس منطق الإنذار</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>الإشعاع</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>الإشعاع</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>حرارة الخلية</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>حرارة الخلية</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>درجة الحرارة الخارجية (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>درجة الحرارة الخارجية (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>الحرارة الخارجية</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>الحرارة الخارجية</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>درجة الحرارة الخارجية (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>درجة الحرارة الخارجية (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>سرعة الرياح</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>سرعة الرياح</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>اكتشاف تلقائي</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>اكتشاف تلقائي</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>مستشعر سرعة الرياح</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>مستشعر سرعة الرياح</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>حساس الحرارة الخارجي</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>حساس الحرارة الخارجي</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>تجميع</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>تجميع</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>مضاعف</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>مضاعف</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>عداد ضبط النظام</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>عداد ضبط النظام</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">حدثت دائرة قصر</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">قطبية معاكسة</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>بطارية الحساس منخفضة</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>بطارية الحساس منخفضة</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>الرطوبة</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>الرطوبة</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>الضغط</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>الضغط</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">منخفض</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>إزاحة</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>إزاحة</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>مقياس</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>مقياس</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>الجهد الكهربائي للمستشعر</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>الجهد الكهربائي للمستشعر</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>إجمالي الطاقة الكهروضوئية</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>إجمالي الطاقة الكهروضوئية</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>صفحة المنتج</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>صفحة المنتج</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>حساس مكيف الهواء  %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>حساس مكيف الهواء  %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>تتاح نسخة جديدة من MK3. 
+        <translation>تتاح نسخة جديدة من MK3. 
 ملحوظة: قد يؤدي التحديث إلى إيقاف النظام بشكل مؤقت.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>تحديث MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>تحديث MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>اضغط للتحديث</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>اضغط للتحديث</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>تحديث MK3، ستظهر القيم مرة أخرى بعد استكمال التحديث</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>تحديث MK3، ستظهر القيم مرة أخرى بعد استكمال التحديث</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">شحن البطارية إلى 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>شحن البطارية إلى 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>شحن البطارية إلى 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">متقدم</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>قيد العمل</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>قيد العمل</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>اضغط للتوقف</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>اضغط للتوقف</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>اضغط للبدء</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>اضغط للبدء</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>شحن البطارية إلى 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>شحن البطارية إلى 100%</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>سيعود النظام إلى التشغيل الطبيعي، مع إعطاء الأولوية للطاقة المتجددة.
+        <translation>سيعود النظام إلى التشغيل الطبيعي، مع إعطاء الأولوية للطاقة المتجددة.
 هل ترغب في المتابعة؟</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>سيتم استخدام الطاقة البرية عند توفرها، وسيتم تجاهل الخيار 'الأولوية للطاقة الشمسية والرياح'. 
+        <translation>سيتم استخدام الطاقة البرية عند توفرها، وسيتم تجاهل الخيار &apos;الأولوية للطاقة الشمسية والرياح&apos;. 
 هل ترغب في المتابعة</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>سيتم استخدام الطاقة البرية لاكتمال شحن البطارية بالكامل مرة واحدة.
+        <translation>سيتم استخدام الطاقة البرية لاكتمال شحن البطارية بالكامل مرة واحدة.
 بعد اكتمال عملية الشحن، سيعود النظام إلى التشغيل العادي، مع إعطاء الأولوية للطاقة الشمسية والرياح.
 هل ترغب في المتابعة؟</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>جهد التيار المستمر</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>جهد التيار المستمر</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>التيار المستمر الحالي</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>التيار المستمر الحالي</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>متقدم</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>متقدم</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>إعادة ضبط الإنذار</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>إعادة ضبط الإنذار</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>المسار التجميعي VE لنظام إدارة البطارية تقوم بإيقاف النظام آليا عندما تحتاج إلى حماية البطارية. ومن ثم فالتحكم بالنظام عبر إعدادات الألوان غير متاح.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>المسار التجميعي VE لنظام إدارة البطارية تقوم بإيقاف النظام آليا عندما تحتاج إلى حماية البطارية. ومن ثم فالتحكم بالنظام عبر إعدادات الألوان غير متاح.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>المساعد المركب لنظام إدارة البطارية معد لمسار تجميعي لنظام إدارة البطارية ولكن لم يتم العثور على نظام إدارة البطارية للمسار التجميعي VE!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>المساعد المركب لنظام إدارة البطارية معد لمسار تجميعي لنظام إدارة البطارية ولكن لم يتم العثور على نظام إدارة البطارية للمسار التجميعي VE!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>المسار التجميعي لنظام إدارة البطارية VE</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>المسار التجميعي لنظام إدارة البطارية VE</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>تحذير: قد يؤدي تفعيل المعادلة في نظام ESS باستخدام أجهزة الشحن الشمسية إلى شحن البطارية بجهد عالٍ بتيار مرتفع جدًا.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>تحذير: قد يؤدي تفعيل المعادلة في نظام ESS باستخدام أجهزة الشحن الشمسية إلى شحن البطارية بجهد عالٍ بتيار مرتفع جدًا.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>سوف يتحول النظام تلقائيا إلى الوضع العائم بمجرد اكتمال شحن المعادلة.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>سوف يتحول النظام تلقائيا إلى الوضع العائم بمجرد اكتمال شحن المعادلة.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>معادلة التوقيف</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>معادلة التوقيف</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>المعادلة</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>المعادلة</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>يتم التوقيف...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>يتم التوقيف...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>البدء...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>البدء...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">البدء...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>اضغط للتوقف</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>اضغط للتوقف</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>التوقف وإعادة الامتصاص</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>التوقف وإعادة الامتصاص</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>التوقف والذهاب إلى التعويم</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>التوقف والذهاب إلى التعويم</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>التوقف</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>التوقف</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>عدم التوقف</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>عدم التوقف</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>إعادة اكتشاف نظام VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>إعادة اكتشاف نظام VE.Bus</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>القيام بإعادة الكشف...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>القيام بإعادة الكشف...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>إعادة تشغيل نظام VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>إعادة تشغيل نظام VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>إعادة التشغيل...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>إعادة التشغيل...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>اضغط لإعادة التشغيل</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>اضغط لإعادة التشغيل</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>تجاهل مدخلات التيار المتردد 1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>تجاهل مدخلات التيار المتردد 1</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>تجاهل مدخلات التيار المتردد 2</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>تجاهل مدخلات التيار المتردد 2</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>اختبار مرحل ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>اختبار مرحل ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">مكتمل</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">قيد الانتظار</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>مكتمل</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>مكتمل</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>قيد الانتظار</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>قيد الانتظار</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>تشخيصات المسار التجميعي للمعاكس الضوئي</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>تشخيصات المسار التجميعي للمعاكس الضوئي</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>طور L لعداد جودة الشبكة%1، الجهاز  %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>طور L لعداد جودة الشبكة%1، الجهاز  %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>خطأ VE.Bus تقرير 8 / 11</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>خطأ VE.Bus تقرير 8 / 11</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>منبه فقط</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>منبه فقط</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>إنذارات وتنبيهات</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>إنذارات وتنبيهات</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>خطاء في نظام إدارة البطاريات</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>خطاء في نظام إدارة البطاريات</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>الأرقام المسلسلة</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>الأرقام المسلسلة</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>آخر خطأ VE.Bus 11 تقرير رقم  #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>آخر خطأ VE.Bus 11 تقرير رقم  #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>اختبار سلامة BF قيد التنفيذ</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>اختبار سلامة BF قيد التنفيذ</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>نتيجة اختبار سلامة BF متوافقة</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>نتيجة اختبار سلامة BF متوافقة</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>عدم مطابقة AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>عدم مطابقة AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>خطأ في الاتصال</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>خطأ في الاتصال</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>عطل المرحل الأرضي</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>عطل المرحل الأرضي</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>عدم مطابقة UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>عدم مطابقة UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>عدم مطابقة الفترة الزمنية</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>عدم مطابقة الفترة الزمنية</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>عدم مطابقة تشغيل مرحل BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>عدم مطابقة تشغيل مرحل BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>خطأ: PE2 مفتوح</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>خطأ: PE2 مفتوح</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>خطأ: PE2 مغلق</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>خطأ: PE2 مغلق</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>خطوة خاطئة: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>خطوة خاطئة: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>طور L%1، الجهاز %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>طور L%1، الجهاز %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>خطأ 11 في المسار التجميعي للمعاكس الضوئي. المطلوب إيجاد نسخة 454 للبرنامج المبيت على الأقل.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>خطأ 11 في المسار التجميعي للمعاكس الضوئي. المطلوب إيجاد نسخة 454 للبرنامج المبيت على الأقل.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE المسار التجميعي ملتوي</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE المسار التجميعي ملتوي</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>طاقة</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>طاقة</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>طاقة</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>طاقة</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>الجهد الكهربائي</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>الجهد الكهربائي</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>التيار</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>التيار</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>الموقع</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>الموقع</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>الطور</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>الطور</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>دخل التيار المتردد نشط</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>دخل التيار المتردد نشط</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>تيار مستمر عالي التموج</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>تيار مستمر عالي التموج</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>جهد التيار المستمر عالي</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>جهد التيار المستمر عالي</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>التيار المستمر مرتفع</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>التيار المستمر مرتفع</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>خطأ في حساس الحرارة</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>خطأ في حساس الحرارة</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>خطأ في مستشعر الجهد</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>خطأ في مستشعر الجهد</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>حمل زائد</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>حمل زائد</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>تيار مستمر تموجي</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>تيار مستمر تموجي</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>حساس التيار</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>حساس التيار</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">تناوب المرحلة</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>تناوب المرحلة</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>تناوب المرحلة</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>نسخة المسار التجميعي VE</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>نسخة المسار التجميعي VE</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>جهاز MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>جهاز MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>نسخة MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>نسخة MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>نسخة المراقبة المتعددة</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>نسخة المراقبة المتعددة</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>نسخة المسار التجميعي VE لنظام إدارة البطارية</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>نسخة المسار التجميعي VE لنظام إدارة البطارية</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>ما لم تتعطل الشبكة</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>ما لم تتعطل الشبكة</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>مدخل التيار المناوب</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>مدخل التيار المناوب</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>مدخلات التيار المتردد</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>مدخلات التيار المتردد</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>مدخلات التيار المتردد 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>مدخلات التيار المتردد 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>مدخلات التيار المتردد 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>مدخلات التيار المتردد 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>الدور</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>الدور</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>تحميلات التيار المتردد</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>تحميلات التيار المتردد</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>مخرج التيار المناوب</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>مخرج التيار المناوب</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>خرج التيار المتردد</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>خرج التيار المتردد</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>طور التيار المناوب  L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>طور التيار المناوب  L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>حساس التيار المناوب %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>حساس التيار المناوب %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>حساسات التيار المناوب</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>حساسات التيار المناوب</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>نشط</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>نشط</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">إنذار</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">حمل زائد</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>حالة الإنذار</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>حالة الإنذار</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>منبهات</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>منبهات</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>السماح بالشحن</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>السماح بالشحن</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>السماح بالتفريغ</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>السماح بالتفريغ</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>مسح آلي</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>مسح آلي</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>بطارية</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>بطارية</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>تيار البطارية</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>تيار البطارية</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>الجهد الكهربائي للبطارية</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>الجهد الكهربائي للبطارية</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>تيار الشحن</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>تيار الشحن</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>يقوم بالشحن</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>يقوم بالشحن</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>محو الخطأ</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>محو الخطأ</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>مغلق</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>مغلق</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>متصل</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>متصل</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>التيار</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>التيار</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>محولات تيار</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>محولات تيار</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>اسم العميل</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>اسم العميل</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>معالج</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>معالج</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>الجهاز</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>الجهاز</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">معطل</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>يقوم بتفريغ الشحن</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>يقوم بتفريغ الشحن</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>منفصل</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>منفصل</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>مفعل</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>مفعل</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>مفعل</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>مفعل</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>طاقة</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>طاقة</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>خطأ</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>خطأ</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>خطأ:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>خطأ:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>خطأ بالرمز</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>خطأ بالرمز</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>نسخة البرنامج المبيت</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>نسخة البرنامج المبيت</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>مولد</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>مولد</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>حرارة البطارية مرتفعة</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>حرارة البطارية مرتفعة</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>إنذار مستوى مرتفع</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>إنذار مستوى مرتفع</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>جهد بطارية البادئ مرتفع</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>جهد بطارية البادئ مرتفع</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>حرارة مرتفعة</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>حرارة مرتفعة</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>تيار المنبهات مرتفع</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>تيار المنبهات مرتفع</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>تاريخ</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>تاريخ</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 ساعة/ ساعات</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 ساعة/ ساعات</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>ساكن</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>ساكن</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>غير نشط</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>غير نشط</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">محول التردد/ الشاحن</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>عنوان بروتوكول الإنترنت</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>عنوان بروتوكول الإنترنت</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>حرارة البطارية منخفضة</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>حرارة البطارية منخفضة</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>إنذار مستوى منخفض</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>إنذار مستوى منخفض</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>جهد بطارية البادئ منخفض</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>جهد بطارية البادئ منخفض</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>حالة الشحن منخفضة</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>حالة الشحن منخفضة</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>حرارة منخفضة</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>حرارة منخفضة</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>إنذارات الجهد المنخفض</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>إنذارات الجهد المنخفض</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>الشركة المصنعة</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>الشركة المصنعة</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>الحد الأقصى لدرجة الحرارة</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>الحد الأقصى لدرجة الحرارة</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>الحد الأعلى للجهد الكهربائي</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>الحد الأعلى للجهد الكهربائي</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>الحرارة الأدنى</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>الحرارة الأدنى</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>الحد الأدنى للجهد الكهربائي</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>الحد الأدنى للجهد الكهربائي</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>وضعية</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>وضعية</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>اسم الطراز</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>اسم الطراز</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>لا</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>لا</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>لا يوجد خطأ</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>لا يوجد خطأ</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>غير متوفر</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>غير متوفر</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>غير متصل</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>غير متصل</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>خارج الخط</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>خارج الخط</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>صحيح</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>صحيح</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>مشغل</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>مشغل</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>على الخط</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>على الخط</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>مفتوح</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>مفتوح</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>كلمة السر</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>كلمة السر</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>الطور</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>الطور</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>اضغط للمحو</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>اضغط للمحو</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>اضغط لإعادة الضبط</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>اضغط لإعادة الضبط</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>اضغط للمسح الضوئي</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>اضغط للمسح الضوئي</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>معاكس ضوئي</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>معاكس ضوئي</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>طاقة معاكس ضوئية</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>طاقة معاكس ضوئية</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>ساعات السكون</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>ساعات السكون</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>المرحل</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>المرحل</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>إعادة التشغيل</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>إعادة التشغيل</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>إزالة</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>إزالة</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>مشغل</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>مشغل</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>مسح %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>مسح %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>رقم السلسلة</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>رقم السلسلة</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>الإعدادات</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>الإعدادات</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>إعادة ضبط</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>إعادة ضبط</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>قوة الإشارة</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>قوة الإشارة</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>انتظار</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>انتظار</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>التشغيل بعد ما يصل الشرط إلى</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>التشغيل بعد ما يصل الشرط إلى</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>وقت البدء</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>وقت البدء</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>قيمة البدء خلال ساعات السكون</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>قيمة البدء خلال ساعات السكون</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>تشغيل عندما يكون التنبيه مفعلا ل</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>تشغيل عندما يكون التنبيه مفعلا ل</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>حالة الشحن</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>حالة الشحن</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>الحالة</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>بدء التشغيل (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>بدء التشغيل (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>قيمة التوقف خلال ساعات السكون</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>قيمة التوقف خلال ساعات السكون</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>الإيقاف بعد ما يصل الشرط إلى</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>الإيقاف بعد ما يصل الشرط إلى</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>متوقف</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>متوقف</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>الحرارة</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>الحرارة</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>حساس الحرارة</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>حساس الحرارة</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>اليوم</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>اليوم</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>المجموع</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>المجموع</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>المتعقب</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>المتعقب</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>النوع</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>النوع</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>رقم التعريف الفريد</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>رقم التعريف الفريد</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>مجهول</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>مجهول</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>خطأ في المسار التجميعي VE</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>خطأ في المسار التجميعي VE</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>الجهد الكهربائي</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>الجهد الكهربائي</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>نموذج VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>نموذج VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>عندما يختفي التنبيه توقف بعد</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>عندما يختفي التنبيه توقف بعد</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>نعم</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>نعم</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>الأمس</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>الأمس</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>المحصول</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>المحصول</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>حد قدرة التغذية الداخلة الصفرية</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>حد قدرة التغذية الداخلة الصفرية</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>ضبط التاريخ</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>ضبط التاريخ</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>التشغيل الآن</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>التشغيل الآن</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>التشغيل ذو الوقت المحدد</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>التشغيل ذو الوقت المحدد</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>بدء التشغيل الآن</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>بدء التشغيل الآن</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>وقت التشغيل الكلي</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>وقت التشغيل الكلي</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>ضبط الوقت %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>ضبط الوقت %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>سيستمر تشغيل المولد إن تم تلبية حالة التشغيل التلقائي.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>سيستمر تشغيل المولد إن تم تلبية حالة التشغيل التلقائي.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>وضع محول التردد/ الشاحن</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>وضع محول التردد/ الشاحن</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>تعيين</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>تعيين</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>إلغاء الأمر</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>إلغاء الأمر</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>إغلاق</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>إغلاق</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>ضبط الوقت</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>ضبط الوقت</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>قيد الاستخدام بالفعل</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>قيد الاستخدام بالفعل</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>خطأ في التبديل</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>خطأ في التبديل</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>استكمال التبديل</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>استكمال التبديل</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>نسخ جهاز التبديل</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>نسخ جهاز التبديل</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>نسخة الجهاز %1 قيد الاستخدام بالفعل%3'. هل ترغب في تبديل نسخ الجهاز وتخصيصها إلى %2؟</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>نسخة الجهاز %1 قيد الاستخدام بالفعل%3&apos;. هل ترغب في تبديل نسخ الجهاز وتخصيصها إلى %2؟</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>نسخة الجهاز %1 قيد الاستخدام بالفعل بواسطة جهاز آخر من ذات النوع. هل ترغب في تبديل نسخ الجهاز وتخصيصها إلى %2؟</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>نسخة الجهاز %1 قيد الاستخدام بالفعل بواسطة جهاز آخر من ذات النوع. هل ترغب في تبديل نسخ الجهاز وتخصيصها إلى %2؟</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>لا يمكن تبديل نسخ الجهاز: انتهت مدة العملية.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>لا يمكن تبديل نسخ الجهاز: انتهت مدة العملية.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>سيتم تنشيط نسخ الجهاز الجديدة عند إعادة التشغيل.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>سيتم تنشيط نسخ الجهاز الجديدة عند إعادة التشغيل.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>تبديل</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>تبديل</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>خطأ في أثناء التحقق من تحديثات البرنامج الثابت</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>خطأ في أثناء التحقق من تحديثات البرنامج الثابت</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>جارٍ تنزيل البرامج الثابتة وتثبيتها  %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>جارٍ تنزيل البرامج الثابتة وتثبيتها  %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>جار تثبيت البرامج الثابتة ...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>جار تثبيت البرامج الثابتة ...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>خطأ في أثناء تثبيت البرنامج الثابت</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>خطأ في أثناء تثبيت البرنامج الثابت</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>لا يوجد نسخة جديدة متوفرة</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>لا يوجد نسخة جديدة متوفرة</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>لم يتم إيجاد برنامج مبيت</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>لم يتم إيجاد برنامج مبيت</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>وقود</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>وقود</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>ماء نقي</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>ماء نقي</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>ماء فاسد</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>ماء فاسد</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>حيوية جيدة</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>حيوية جيدة</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>زيت</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>زيت</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>مياه سوداء</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>مياه سوداء</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>البنزين</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>البنزين</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>الديزل</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>الديزل</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>الغاز النفطي المسال</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>الغاز النفطي المسال</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>الغاز الطبيعي المسال</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>الغاز الطبيعي المسال</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>زيت هيدروليكي</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>زيت هيدروليكي</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>ماء غير معالج</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>ماء غير معالج</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>قفل الإعداد لمستوى الوصول</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>قفل الإعداد لمستوى الوصول</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>كلمة سر خاطئة</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>كلمة سر خاطئة</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>مختصر</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>مختصر</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>نظرة عامة</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>المستويات</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>المستويات</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>الإعلامات</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>الإعلامات</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>الآن</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>الآن</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1دقيقة مضت</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1دقيقة مضت</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1ساعة %2دقيقة مضت</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1ساعة %2دقيقة مضت</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>كل يوم</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>كل يوم</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>أيام الأسبوع</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>أيام الأسبوع</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>نهاية الأسبوع</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>نهاية الأسبوع</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>الاثنين</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>الاثنين</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>الثلاثاء</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>الثلاثاء</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>الأربعاء</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>الأربعاء</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>الخميس</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>الخميس</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>الجمعة</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>الجمعة</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>السبت</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>السبت</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>الأحد</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>الأحد</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 أو %4%</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 أو %4%</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>جدول %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>جدول %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>اليوم</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>اليوم</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>لم يتم الضبط</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>لم يتم الضبط</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>حد الـ SOC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>حد الـ SOC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>الاستهلاك الذاتي زائد عن الحد</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>الاستهلاك الذاتي زائد عن الحد</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">جهاز ضوئي</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>جهاز ضوئي</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>جهاز ضوئي</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>الخلايا الكهروضوئية والبطارية</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>الخلايا الكهروضوئية والبطارية</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>تدقيق...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>تدقيق...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>حالة المنبه</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>حالة المنبه</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">إنذار</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>محو التاريخ</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>محو التاريخ</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>جاري المحو</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>جاري المحو</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>الإلزام بالتشغيل</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>الإلزام بالتشغيل</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>الإلزام بالتعطيل</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>الإلزام بالتعطيل</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>حالة المرحل</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>حالة المرحل</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>إعادة ضبط التاريخ على الشاشة ذاتها</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>إعادة ضبط التاريخ على الشاشة ذاتها</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>اضغط للإخراج</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>اضغط للإخراج</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>يتم الإخراج، من فضلك انتظر</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>يتم الإخراج، من فضلك انتظر</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>تخزين غير موجود</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>تخزين غير موجود</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>مايكرو إس دي / تخزين يو إس بي</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>مايكرو إس دي / تخزين يو إس بي</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 مستشعر الحرارة</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 مستشعر الحرارة</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 حساس درجة الحرارة (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 حساس درجة الحرارة (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>حساس درجة الحرارة (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>حساس درجة الحرارة (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>لا توجد أي إجراءات:</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>لا توجد أي إجراءات:</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>تحذير: تم ضبط درجات حرارة التنشيط وإيقاف التنشيط على القيمة ذاتها. سيؤدي ذلك إلى تجاهل الحالة.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>تحذير: تم ضبط درجات حرارة التنشيط وإيقاف التنشيط على القيمة ذاتها. سيؤدي ذلك إلى تجاهل الحالة.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>الحالة %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>الحالة %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>تم تعطيل الوظيفة</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>تم تعطيل الوظيفة</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>لا شيء (تعطيل)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>لا شيء (تعطيل)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>مرحل 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>مرحل 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>مرحل 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>مرحل 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>تحذير: المرحل المحدد أعلاه لم يتم تكوينه على درجة الحرارة، وسوف يتم تجاهل هذا الشرط.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>تحذير: المرحل المحدد أعلاه لم يتم تكوينه على درجة الحرارة، وسوف يتم تجاهل هذا الشرط.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>قيمة التفعيل</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>قيمة التفعيل</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>وحدة الحجم</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>وحدة الحجم</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>متر مكعب</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>متر مكعب</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>لتر</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>لتر</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>غالون (أمريكي)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>غالون (أمريكي)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>غالون (بريطاني)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>غالون (بريطاني)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>أقل جهد كهربي</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>أقل جهد كهربي</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>أقصى جهد كهربي</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>أقصى جهد كهربي</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">أقصى جهد كهربي</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>أقصى تيار</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>أقصى تيار</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>زمن الشحن</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>زمن الشحن</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">كتلة</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">بالتعويم</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">ساعة</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>كتلة</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>كتلة</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>بالتعويم</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>بالتعويم</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>ساعة</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>ساعة</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 حدث عطل/ حدثت أعطال</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 حدث عطل/ حدثت أعطال</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>تحميل</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>تحميل</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>الثاني الأخير</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>الثاني الأخير</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>الثالث الأخير</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>الثالث الأخير</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>الرابع الأخير</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>الرابع الأخير</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>أقصى قدرة</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>أقصى قدرة</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>لا يمكن الاتصال</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>لا يمكن الاتصال</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>انقطع الاتصال، محاولة إعادة الاتصال</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>انقطع الاتصال، محاولة إعادة الاتصال</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>جاري الاتصال</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>جاري الاتصال</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">جاري الاتصال</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>تم الاتصال، بانتظار رسائل الوسيط</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>تم الاتصال، بانتظار رسائل الوسيط</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>تم الاتصال، استلام رسائل الوسيط</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>تم الاتصال، استلام رسائل الوسيط</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>تم الاتصال، تحميل واجهة المستخدم</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>تم الاتصال، تحميل واجهة المستخدم</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>نسخة البروتوكول غير صالحة</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>نسخة البروتوكول غير صالحة</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>رفض معرف العميل</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>رفض معرف العميل</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>خدمة الوسيط غير متاحة</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>خدمة الوسيط غير متاحة</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>اسم المستخدم غير صالح أو كلمة المرور غير صالحة</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>اسم المستخدم غير صالح أو كلمة المرور غير صالحة</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>العميل غير مصرح</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>العميل غير مصرح</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>خطأ اتصال النقل</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>خطأ اتصال النقل</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>خطأ انتهاك البروتوكول</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>خطأ انتهاك البروتوكول</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>خطأ المستوى الخامس من بروتوكول MQTT</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>خطأ المستوى الخامس من بروتوكول MQTT</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>إنذار صامت</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>إنذار صامت</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>إجمالي الطاقة</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>إجمالي الطاقة</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>دقيقة</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>دقيقة</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1h %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1h %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>فشل</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>فشل</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>استرجاع عنوان بروتوكول الإنترنت</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>استرجاع عنوان بروتوكول الإنترنت</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">متصل</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>فصل</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>فصل</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">منفصل</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>تحميلات التيار المتردد</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>تحميلات التيار المتردد</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>أحمال التيار المستمر</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>أحمال التيار المستمر</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>محطة شحن المركبة الكهربية</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>محطة شحن المركبة الكهربية</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>رياح</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>رياح</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>دعامة</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>دعامة</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>حد تيار الشبكة</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>حد تيار الشبكة</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>حد تيار المولد</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>حد تيار المولد</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>حد تيار الشاطئ</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>حد تيار الشاطئ</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">توقف</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>توقف</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>توقف</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 للانطلاق</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 للانطلاق</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 خزان (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 خزان (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>شاحن التيار المناوب</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>شاحن التيار المناوب</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>مولد</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>مولد</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>شاحن التيار المستمر</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>شاحن التيار المستمر</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>مولد التيار المستمر</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>مولد التيار المستمر</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>نظام التيار المستمر</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>نظام التيار المستمر</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>خلية الوقود</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>خلية الوقود</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>مولد باستخدام عمود الدوران</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>مولد باستخدام عمود الدوران</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>مولد باستخدام المياه</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>مولد باستخدام المياه</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>شاحن باستخدام الرياح</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>شاحن باستخدام الرياح</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>منخفض</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>منخفض</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>مرتفع</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>مرتفع</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>حافظ على أن تكون البطاريات مشحونة</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>حافظ على أن تكون البطاريات مشحونة</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>محسن مع عمر البطارية</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>محسن مع عمر البطارية</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>محسن دون عمر البطارية</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>محسن دون عمر البطارية</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">التحكم الخارجي</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>مشحون</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>مشحون</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>في انتظار الشمس</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>في انتظار الشمس</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>في انتظار تحديد تردد الراديو</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>في انتظار تحديد تردد الراديو</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>بانتظار بدء التشغيل</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>بانتظار بدء التشغيل</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>خطأ اختبار التوصيل الأرضي</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>خطأ اختبار التوصيل الأرضي</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>خطأ في اختبار مدخلات CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>خطأ في اختبار مدخلات CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>تم الكشف عن التيار المتبقي</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>تم الكشف عن التيار المتبقي</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>تم الكشف عن انخفاض الجهد</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>تم الكشف عن انخفاض الجهد</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>تم الكشف عن الجهد الزائد</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>تم الكشف عن الجهد الزائد</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>تم الكشف عن ارتفاع درجة الحرارة</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>تم الكشف عن ارتفاع درجة الحرارة</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>حد الشحن</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>حد الشحن</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>ابدأ الشحن</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>ابدأ الشحن</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">مجدول</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>مجدول</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>مجدول</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>إحماء المحرك</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>إحماء المحرك</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>التبريد</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>التبريد</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>المعاينة تعمل</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>المعاينة تعمل</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>تم البدء يدويا</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>تم البدء يدويا</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>تحميل إعادة التشغيل</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>تحميل إعادة التشغيل</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>قيد التشغيل (متتبع النقطة القصوة للطاقة)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>قيد التشغيل (متتبع النقطة القصوة للطاقة)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>مشفل (مسرع)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>مشفل (مسرع)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>مرحل %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>مرحل %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>خلل</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>خلل</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>امتصاص</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>امتصاص</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>تخزين</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>تخزين</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>معادلة</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>معادلة</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">التحكم الخارجي</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>قدرة منخفضة</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>قدرة منخفضة</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>حالة عطل</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>حالة عطل</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>الشحن المبدئي</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>الشحن المبدئي</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>شحن الامتصاص</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>شحن الامتصاص</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>الشحن المساند</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>الشحن المساند</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>وضع التخزين</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>وضع التخزين</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>موازنة الشحن</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>موازنة الشحن</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>تمرير</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>تمرير</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>عكس</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>عكس</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>مساندة</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>مساندة</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>وضع إمدادات الطاقة</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>وضع إمدادات الطاقة</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">ركيزة</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>تنبيه</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>تنبيه</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>امتصاص متكرر</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>امتصاص متكرر</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>موازنة تلقائية</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>موازنة تلقائية</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>آمان البطارية</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>آمان البطارية</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>الكشف عن الحمل</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>الكشف عن الحمل</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>محظور</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>محظور</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>معاينة</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>معاينة</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">نظام تخزين الطاقة الديناميكي (ESS)</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>نظام تخزين الطاقة الديناميكي (ESS)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>نظام تخزين الطاقة الديناميكي (ESS)</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>رئيس المجموعة</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>رئيس المجموعة</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>نموذج رئيسي</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>نموذج رئيسي</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>مجموعة ونموذج رئيسي</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>مجموعة ونموذج رئيسي</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>رئيس مجموعة وقائم بذاته</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>رئيس مجموعة وقائم بذاته</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>الشاحن فقط</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>الشاحن فقط</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>فقط المعاكس</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>فقط المعاكس</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">إنذار جهد البطارية المنخفض</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">منبه جهد البطارية المرتفعة</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>إنذار دائرة قصر</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>إنذار دائرة قصر</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>تعطيل نقطة التوصيل</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>تعطيل نقطة التوصيل</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>دخل التيار المستمر</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>دخل التيار المستمر</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>بالنسبة لبطاريات الليثيوم، لا يوصى بشحن أقل من 10%. بالنسبة لأنواع البطاريات الأخرى، تحقق من ورقة البيانات لمعرفة الحد الأدنى الموصى به من قبل الشركة المصنعة.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>بالنسبة لبطاريات الليثيوم، لا يوصى بشحن أقل من 10%. بالنسبة لأنواع البطاريات الأخرى، تحقق من ورقة البيانات لمعرفة الحد الأدنى الموصى به من قبل الشركة المصنعة.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>هل ترغب في تعطيل التشغيل الآلي؟</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>هل ترغب في تعطيل التشغيل الآلي؟</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>محول التردد/ الشاحن (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>محول التردد/ الشاحن (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>عرض استخدام وحدة المعالجة المركزية</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>عرض استخدام وحدة المعالجة المركزية</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>إلغاء التطبيق</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>إلغاء التطبيق</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>خروج</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>خروج</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>إصدار التطبيق</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>إصدار التطبيق</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>درجة حرارة الزيت</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>درجة حرارة الزيت</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>لاحظ أن تغيير إعداد أرضية التفريغ Time-to-go يؤدي أيضًا إلى تغيير إعداد حالة الشحن المنخفضة في قائمة الترحيل.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>لاحظ أن تغيير إعداد أرضية التفريغ Time-to-go يؤدي أيضًا إلى تغيير إعداد حالة الشحن المنخفضة في قائمة الترحيل.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>وقت التشغيل</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>وقت التشغيل</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>شحن أمبير/ ساعة</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>شحن أمبير/ ساعة</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>دورات البداية</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>دورات البداية</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>الدورات المستكملة</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>الدورات المستكملة</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>عدد مرات التشغيل</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>عدد مرات التشغيل</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>عدد مرات التفريغ العميق</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>عدد مرات التفريغ العميق</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>تاريخ دورة الشحن</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>تاريخ دورة الشحن</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>قيمة جهاز الاستشعار عندما يكون ممتلئ</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>قيمة جهاز الاستشعار عندما يكون ممتلئ</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>زمن الصيانة</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>زمن الصيانة</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>وظيفة التشغيل التلقائي</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>وظيفة التشغيل التلقائي</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>تأكد من عدم توصيل المولد بمدخل التيار المتردد %1 عند استخدام هذا الخيار</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>تأكد من عدم توصيل المولد بمدخل التيار المتردد %1 عند استخدام هذا الخيار</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>أعيد ضبط مؤقت الخدمة</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>أعيد ضبط مؤقت الخدمة</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>قد يتداخل المسح المستمر مع تشغيل الواي فاي.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>قد يتداخل المسح المستمر مع تشغيل الواي فاي.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>الحد الأدنى والحد الأقصى لنطاقات القياس</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>الحد الأدنى والحد الأقصى لنطاقات القياس</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">صفحة البدء</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>جارٍ إعادة تشغيل التطبيق...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>جارٍ إعادة تشغيل التطبيق...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>فشل في تغيير اللغة!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>فشل في تغيير اللغة!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">دقيقة</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">عشرة دقائق</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">ثلاثون دقيقة</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">أبدا</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>يرجى الانتظار بينما يتم تغيير اللغة.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>يرجى الانتظار بينما يتم تغيير اللغة.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>وحدة عرض مختصرة</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>وحدة عرض مختصرة</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>لا توجد بطاقات عنونة</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>لا توجد بطاقات عنونة</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>عرض أحجام الخزان</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>عرض أحجام الخزان</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>عرض النسب المئوية</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>عرض النسب المئوية</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>ملاحظة: إذا تعذر عرض التيار (على سبيل المثال، عند عرض المجموع لمصادر التيار المتردد (AC) والتيار المستمر (DC) مجتمعة)، فسيتم عرض القدرة بدلاً من ذلك.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>ملاحظة: إذا تعذر عرض التيار (على سبيل المثال، عند عرض المجموع لمصادر التيار المتردد (AC) والتيار المستمر (DC) مجتمعة)، فسيتم عرض القدرة بدلاً من ذلك.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>حدود تيار الشحن</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>حدود تيار الشحن</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>الإصدار الرسمي</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>الإصدار الرسمي</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>إصدار بيتا</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>إصدار بيتا</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>اختبار (فيكترون داخلي(</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>اختبار (فيكترون داخلي(</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>تطوير (فيكترون داخلي(</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>تطوير (فيكترون داخلي(</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>يقوم بإعادة التشغيل...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>يقوم بإعادة التشغيل...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>تمكين مؤشرات LED الخاصة بالحالة</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>تمكين مؤشرات LED الخاصة بالحالة</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>تهيئة وتبريد</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>تهيئة وتبريد</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>وقت إيقاف المولد</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>وقت إيقاف المولد</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>إنذار عندما لا يكون المولد في وضع التشغيل التلقائي</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>إنذار عندما لا يكون المولد في وضع التشغيل التلقائي</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>سيتم إطلاق إنذار عند ترك وظيفة التشغيل التلقائي معطلة لأكثر من 10 دقائق</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>سيتم إطلاق إنذار عند ترك وظيفة التشغيل التلقائي معطلة لأكثر من 10 دقائق</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>الاستهلاك الذاتي من البطارية</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>الاستهلاك الذاتي من البطارية</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>جميع أحمال النظام</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>جميع أحمال النظام</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>الأحمال الحرجة فقط</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>الأحمال الحرجة فقط</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">الحد الأدنى لـ SoC (إلا إذا فشلت الشبكة)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>حالة عمر البطارية</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>حالة عمر البطارية</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>قم بالوصول إلى الإشارة ك على http://venus.local:3000 وعبر VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>قم بالوصول إلى الإشارة ك على http://venus.local:3000 وعبر VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>قم بالوصول إلى Node-RED على https://venus.local:1881 وعبر VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>قم بالوصول إلى Node-RED على https://venus.local:1881 وعبر VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>قياسات البطارية</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>قياسات البطارية</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>حالة النظام</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>حالة النظام</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>قائمة الأجهزة</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>قائمة الأجهزة</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">إيثرنت</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>حالات جهاز VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>حالات جهاز VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>إنذار درجة حرارة مرتفعة</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>إنذار درجة حرارة مرتفعة</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>التحكم بنظام إدارة البطارية</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>التحكم بنظام إدارة البطارية</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>الإنذارات والأخطاء</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>الإنذارات والأخطاء</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>تتطلب هذه الميزة الإصدار 400 من البرنامج الثابت أو إصدارًا أعلى.  اتصل بمسئول التثبيت لتحديث Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>تتطلب هذه الميزة الإصدار 400 من البرنامج الثابت أو إصدارًا أعلى.  اتصل بمسئول التثبيت لتحديث Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>الشاحن غير جاهز، ولا يمكن بدء عملية التعادل</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>الشاحن غير جاهز، ولا يمكن بدء عملية التعادل</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>لا يمكن تفعيل التعادل في أثناء حالة الشحن المجمع</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>لا يمكن تفعيل التعادل في أثناء حالة الشحن المجمع</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>بيئة</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>بيئة</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>الحد الأقصى للتيار</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>الحد الأقصى للتيار</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>الطاقة القصوى</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>الطاقة القصوى</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>الحد الأدنى للتيار</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>الحد الأدنى للتيار</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">لا أحد</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">غير متوفر</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">مطفأ</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">صحيح</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>السجل الإجمالي</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>السجل الإجمالي</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">الإعدادات</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">مجهول</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>الناتج اليوم</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>الناتج اليوم</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>تم تثبيت البرامج الثابتة وإعادة تشغيل الجهاز</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>تم تثبيت البرامج الثابتة وإعادة تشغيل الجهاز</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>التحكم في الإدخال باللمس</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>التحكم في الإدخال باللمس</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>خطأ اختبار التلامسات الملحومة (تماس قصير)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>خطأ اختبار التلامسات الملحومة (تماس قصير)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>التحويل إلى ثلاثي الطور</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>التحويل إلى ثلاثي الطور</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>التحويل إلى أحادي الطور</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>التحويل إلى أحادي الطور</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>إيقاف الشحن</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>إيقاف الشحن</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>غير مستخدم/محجوز</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>غير مستخدم/محجوز</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>نمط محول التردد</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>نمط محول التردد</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>مخرج التيار المناوب يسار%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>مخرج التيار المناوب يسار%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>مدخل</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>مدخل</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>العبور</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>العبور</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>سيتم إعادة تحميل الصفحة تلقائيًا خلال عشر ثوانٍ لتحميل أحدث إصدار.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>سيتم إعادة تحميل الصفحة تلقائيًا خلال عشر ثوانٍ لتحميل أحدث إصدار.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>محول التردد(%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>محول التردد(%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>محول التردد/ الشاحن</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>محول التردد/ الشاحن</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>لم يتم العثور على عداد طاقة
+        <translation>لم يتم العثور على عداد طاقة
 
  يرجى العلم أن هذه القائمة تظهر عدادات كارلو غافاتسي المتصلة بـ RS485. لأي عداد آخر، بما في ذلك عدادات كارلو غافاتسي المتصلة بالإيثرنت، انظر قائمة أجهزة Mobdus TCP/UDP بدلاً من ذلك.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>التحديد التلقائي للنطاق</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>التحديد التلقائي للنطاق</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>عند التمكين، يتم ضبط الحد الأدنى والحد الأقصى لأجهزة القياس والرسوم تلقائيًا حسب القيم السابقة.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>عند التمكين، يتم ضبط الحد الأدنى والحد الأقصى لأجهزة القياس والرسوم تلقائيًا حسب القيم السابقة.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>إعادة تعيين كافة قيم النطاق إلى الصفر</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>إعادة تعيين كافة قيم النطاق إلى الصفر</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>إعادة ضبط نطاق القيم</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>إعادة ضبط نطاق القيم</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>هل أنت متأكد من أنك تريد إعادة تعيين جميع القيم إلى الصفر؟</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>هل أنت متأكد من أنك تريد إعادة تعيين جميع القيم إلى الصفر؟</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>الحد الأقصى للتيار: تيار متردد المدخل 1 متصل</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>الحد الأقصى للتيار: تيار متردد المدخل 1 متصل</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>الحد الأقصى للتيار: تيار متردد المدخل 2 متصل</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>الحد الأقصى للتيار: تيار متردد المدخل 2 متصل</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>الحد الأقصى للتيار: لا توجد مدخلات التيار المتردد</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>الحد الأقصى للتيار: لا توجد مدخلات التيار المتردد</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>خرج التيار المستمر</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>خرج التيار المستمر</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>شمسي</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>شمسي</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>عدد الدورات في الدقيقة للمحرك</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>عدد الدورات في الدقيقة للمحرك</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>حرارة المحرك</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>حرارة المحرك</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>درجة الحرارة المتحكم</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>درجة الحرارة المتحكم</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>دورة نشطة</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>دورة نشطة</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>دورة %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>دورة %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>فصل التيار المباشر</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>فصل التيار المباشر</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>فصل الطاقة</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>فصل الطاقة</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>تغيير الوظيفة</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>تغيير الوظيفة</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>تحديث البرنامج الثابت</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>تحديث البرنامج الثابت</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>إعادة ضبط البرمجيات</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>إعادة ضبط البرمجيات</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>غير كامل</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>غير كامل</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>الوقت المنقضي</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>الوقت المنقضي</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>شحن / حفظ (أمبير/ ساعة(</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>شحن / حفظ (أمبير/ ساعة(</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>البطارية (جهد&lt;sub&gt;&lt;1/&gt;البداية&lt;/sub&gt;/V&lt;sub&gt;النهاية(&lt;/sub&gt;</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>البطارية (جهد&lt;sub&gt;&lt;1/&gt;البداية&lt;/sub&gt;/V&lt;sub&gt;النهاية(&lt;/sub&gt;</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>الجهد الكهربائي لخرج التيار المتردد منخفض</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>الجهد الكهربائي لخرج التيار المتردد منخفض</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>الجهد الكهربائي لخرج التيار المتردد مرتفع</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>الجهد الكهربائي لخرج التيار المتردد مرتفع</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>الإنتاجية الكلية</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>الإنتاجية الكلية</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>إنتاجية النظام</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>إنتاجية النظام</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>السجل اليومي</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>السجل اليومي</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>لا توجد إنذارات يجب ضبطها</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>لا توجد إنذارات يجب ضبطها</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>الحد الأعلى لتيار الجهاز الضوئي</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>الحد الأعلى لتيار الجهاز الضوئي</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>الحد الأعلى لتيار البطارية</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>الحد الأعلى لتيار البطارية</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>الحد الأدنى لتيار البطارية</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>الحد الأدنى لتيار البطارية</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>خطأ في بنك البطارية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>خطأ في بنك البطارية</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>الجهد الكهربائي للبطارية غير مدعوم</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>الجهد الكهربائي للبطارية غير مدعوم</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>عدد البطاريات غير صحيح</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>عدد البطاريات غير صحيح</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>إعداد البطارية غير صالح</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>إعداد البطارية غير صالح</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>حالة الموّزع</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>حالة الموّزع</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>متوازن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>متوازن</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>اختلال التوازن</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>اختلال التوازن</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>استخدم هذا الاختيار في الأنظمة التي لا تقوم بوظيفة تخفيف الأحمال.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>استخدم هذا الاختيار في الأنظمة التي لا تقوم بوظيفة تخفيف الأحمال.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>استخدم هذا الخيار لتقليل استهلاك الطاقة خلال أوقات الذروة.</translation>
+        <translation>استخدم هذا الخيار لتقليل استهلاك الطاقة خلال أوقات الذروة.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>يتم ضبط حد تخفيف الحِمل أثناء الذروة باستخدام ضبط حد تيار إدخال التيار المتردد. للمزيد من المعلومات، راجع وثائق التشغيل.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>يتم ضبط حد تخفيف الحِمل أثناء الذروة باستخدام ضبط حد تيار إدخال التيار المتردد. للمزيد من المعلومات، راجع وثائق التشغيل.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>يمكن تغيير حدود الحِمل للذروة للوارد والصادر على هذه الشاشة. للمزيد من المعلومات، راجع وثائق التشغيل.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>يمكن تغيير حدود الحِمل للذروة للوارد والصادر على هذه الشاشة. للمزيد من المعلومات، راجع وثائق التشغيل.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>الحد من نظام التيار المناوب الوارد</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>الحد من نظام التيار المناوب الوارد</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>لاستخدام هذه الميزة، يجب ضبط قياس الشبكة على عداد خارجي، ويجب تثبيت مساعد ESS محدّث.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>لاستخدام هذه الميزة، يجب ضبط قياس الشبكة على عداد خارجي، ويجب تثبيت مساعد ESS محدّث.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>أقصى تيار وارد بالنظام (لكل طور(</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>أقصى تيار وارد بالنظام (لكل طور(</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>يجب ضبط قياس الشبكة على عداد خارجي لاستخدام هذه الميزة.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>يجب ضبط قياس الشبكة على عداد خارجي لاستخدام هذه الميزة.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>أقصى تيار صادر بالنظام (لكل طور(</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>أقصى تيار صادر بالنظام (لكل طور(</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>موصول بالأسلاك</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>موصول بالأسلاك</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">مختصر</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>حمل النظام مرتفع، يؤدي إغلاق اللوحة الجانبية لتقليل حمل وحدة المعالجة المركزية (CPU)</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>حمل النظام مرتفع، يؤدي إغلاق اللوحة الجانبية لتقليل حمل وحدة المعالجة المركزية (CPU)</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>حد تيار الدخل</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>حد تيار الدخل</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>دائرة قصر</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>دائرة قصر</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>شراء</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>شراء</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>بيع</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>بيع</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>الحالة المستهدفة الأمثل للبطارية</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>الحالة المستهدفة الأمثل للبطارية</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>التيار المتردد الصادر %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>التيار المتردد الصادر %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>متعقب</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>متعقب</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>أجهزة RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>أجهزة RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>توقف الرسوم المتحركة الإلكترونية </translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>توقف الرسوم المتحركة الإلكترونية </translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>السعة الإجمالية</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>السعة الإجمالية</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>عدد أنظمة إدارة البطاريات (BMSes)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>عدد أنظمة إدارة البطاريات (BMSes)</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>نظام إدارة البطاريات (BMS) باستخدام ناقل CAN منخفض الجهد (500 كيلوبت/ثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>نظام إدارة البطاريات (BMS) باستخدام ناقل CAN منخفض الجهد (500 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>نظام إدارة البطاريات (BMS) باستخدام ناقل CAN عالي الجهد (500 كيلوبت/ثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>نظام إدارة البطاريات (BMS) باستخدام ناقل CAN عالي الجهد (500 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>الحد من تيار النظام المناوب الصادر</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>الحد من تيار النظام المناوب الصادر</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>أجهزة Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>أجهزة Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>أضف جهازًا</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>أضف جهازًا</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>البحث عن الأجهزة</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>البحث عن الأجهزة</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>الأجهزة المحفوظة</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>الأجهزة المحفوظة</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>الأجهزة المكتشفة</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>الأجهزة المكتشفة</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>إضافة جهاز Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>إضافة جهاز Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>بروتوكول التحكم بالنقل (TCP)</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>بروتوكول التحكم بالنقل (TCP)</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>بروتوكول بيانات المستخدم (UDP)</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>بروتوكول بيانات المستخدم (UDP)</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>بروتوكول</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>بروتوكول</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>المنفذ</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>المنفذ</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>وحدة</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>وحدة</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>لم يتم حفظ أي أجهزة Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>لم يتم حفظ أي أجهزة Modbus</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>جهاز %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>جهاز %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>هل تريد إزالة جهاز Modbus؟</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>هل تريد إزالة جهاز Modbus؟</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>لم يتم اكتشاف أي أجهزة Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>لم يتم اكتشاف أي أجهزة Modbus</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>البطارية %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>البطارية %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>التيار المتردد الحالي</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>التيار المتردد الحالي</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>تشغيل/إيقاف المولد معطل</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>تشغيل/إيقاف المولد معطل</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>تم تعطيل وظيفة التشغيل عن بعد في المولد. لن يتمكن GX من تشغيل أو إيقاف المولد الآن. اجعله متاحا على لوحة تحكم المولد.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>تم تعطيل وظيفة التشغيل عن بعد في المولد. لن يتمكن GX من تشغيل أو إيقاف المولد الآن. اجعله متاحا على لوحة تحكم المولد.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>وظيفة البدء التلقائي</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>وظيفة البدء التلقائي</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">وقت التشغيل الحالي</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>حالة التحكم</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>حالة التحكم</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>حالة المولد</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>حالة المولد</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>وضع البدء عن بعد</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>وضع البدء عن بعد</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>ضغط الزيت</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>ضغط الزيت</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>مستويات الشحن المجدولة</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>مستويات الشحن المجدولة</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>نشط (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>نشط (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>التوقف اليدوي</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>التوقف اليدوي</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>دائرة مفتوحة</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>دائرة مفتوحة</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (غير متاح)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (غير متاح)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>الإدخال باللمس قيد التشغيل</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>الإدخال باللمس قيد التشغيل</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>الإدخال باللمس معطل</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>الإدخال باللمس معطل</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>تم تعطيل الإدخال باللمس</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>تم تعطيل الإدخال باللمس</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>إدارة التنبيهات</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>إدارة التنبيهات</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>رمز خطأ التحكم</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>رمز خطأ التحكم</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>استخدم هذه القائمة لتحديد بيانات البطارية التي تظهر عند النقر على أيقونة «البطارية» في صفحة «النظرة العامة». يظهر نفس الخيار على منصة VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>استخدم هذه القائمة لتحديد بيانات البطارية التي تظهر عند النقر على أيقونة «البطارية» في صفحة «النظرة العامة». يظهر نفس الخيار على منصة VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>جهد النظام</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>جهد النظام</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>معلومات الاتصال</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>معلومات الاتصال</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>برجاء الاختيار...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>برجاء الاختيار...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>مؤمنة</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>مؤمنة</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>محمي بكلمة مرور، والاتصال الشبكي مشفر</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>محمي بكلمة مرور، والاتصال الشبكي مشفر</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>ضعيفة</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>ضعيفة</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>محمي بكلمة مرور، والاتصال الشبكي غير مشفر</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>محمي بكلمة مرور، والاتصال الشبكي غير مشفر</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>غير مؤمنة</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>غير مؤمنة</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>لا توجد كلمة مرور والاتصال الشبكي غير مشفر</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>لا توجد كلمة مرور والاتصال الشبكي غير مشفر</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">يجب أن تحتوي كلمة المرور على الأقل على 8 رموز</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">إدخال كلمة المرور</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>يجب أن تحتوي كلمة المرور على الأقل على 8 رموز</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>يجب أن تحتوي كلمة المرور على الأقل على 8 رموز</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>اختر الملف «المؤمن»؟</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>اختر الملف «المؤمن»؟</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>اختر الملف «الضعيف»؟</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>اختر الملف «الضعيف»؟</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>اختر الملف «غير المؤمن»؟</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>اختر الملف «غير المؤمن»؟</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>• إن خدمات الشبكات المحلية مؤمنة بكلمة مرور/. إن الاتصال الشبكي مشفر/. تم تفعيل اتصال آمن بـVRM/. لا يمكن تفعيل الإعدادات غير الآمنة</translation>
+        <translation>• إن خدمات الشبكات المحلية مؤمنة بكلمة مرور/. إن الاتصال الشبكي مشفر/. تم تفعيل اتصال آمن بـVRM/. لا يمكن تفعيل الإعدادات غير الآمنة</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• إن خدمات الشبكات المحلية مؤمنة بكلمة مرور/. تم تفعيل الوصول غير المشفر للمواقع الإلكترونية المحلية أيضا (HTTP/HTTPS)</translation>
+        <translation>• إن خدمات الشبكات المحلية مؤمنة بكلمة مرور/. تم تفعيل الوصول غير المشفر للمواقع الإلكترونية المحلية أيضا (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• إن خدمات الشبكات المحلية لا تحتاج إلى كلمة مرور/. تم تفعيل الوصول غير المشفر للمواقع الإلكترونية المحلية أيضا (HTTP/HTTPS)</translation>
+        <translation>• إن خدمات الشبكات المحلية لا تحتاج إلى كلمة مرور/. تم تفعيل الوصول غير المشفر للمواقع الإلكترونية المحلية أيضا (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>كلمة المرور الرئيسية</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>كلمة المرور الرئيسية</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>تسجيل الخروج</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>تسجيل الخروج</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>تسجيل خروج الآن</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>تسجيل خروج الآن</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>تسجيل خروج؟</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>تسجيل خروج؟</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>سيؤدي هذا إلى قطع الاتصال بجميع الشبكات المحلية.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>سيؤدي هذا إلى قطع الاتصال بجميع الشبكات المحلية.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>تسجيل الخروج</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>تسجيل الخروج</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>للقراءة فقط</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>للقراءة فقط</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>ممتلئ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>ممتلئ</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>هل أنت متأكد؟</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>هل أنت متأكد؟</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>يؤدي تغيير هذا الإعداد إلى "للقراءة فقط" أو "إيقاف" إلى حظر وصولك إليه.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>يؤدي تغيير هذا الإعداد إلى &quot;للقراءة فقط&quot; أو &quot;إيقاف&quot; إلى حظر وصولك إليه.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>الوصول لـMQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>الوصول لـMQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>«%1» ليس رقماً.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>«%1» ليس رقماً.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>تأكيد</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>تأكيد</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>استخدم رقماً بـ %1 أرقام أو أقل.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>استخدم رقماً بـ %1 أرقام أو أقل.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>إن «%1» عنوان بروتوكول إنترنت غير صالح.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>إن «%1» عنوان بروتوكول إنترنت غير صالح.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>إن «%1» رقم منفذ غير صالح. استخدم رقماً بين 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>إن «%1» رقم منفذ غير صالح. استخدم رقماً بين 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>إن «%1» رقم وحدة غير صالح. استخدم رقماً بين 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>إن «%1» رقم وحدة غير صالح. استخدم رقماً بين 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>وقت التشغيل الحالي</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>وقت التشغيل الحالي</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>رمز خطأ المولد</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>رمز خطأ المولد</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>حرارة المصرف الحراري</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>حرارة المصرف الحراري</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">الجهد الكهربائي للشحن</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>يخضع الجهد الكهربائي للشحن حاليا لتحكم نظام إدارة البطاريات.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>يخضع الجهد الكهربائي للشحن حاليا لتحكم نظام إدارة البطاريات.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>حد تيار الشحن</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>حد تيار الشحن</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>التحكم بنظام إدارة البطارية</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>التحكم بنظام إدارة البطارية</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>التحكم بنظام إدارة البطارية مفعل بشكل آلي عندما يكون نظام إدارة البطارية موجودا. قم بإعادة ضبط إعدادات النظام إذا تم تغييرها أو إذا لم يكن نظام إدارة البطارية موجودا.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>التحكم بنظام إدارة البطارية مفعل بشكل آلي عندما يكون نظام إدارة البطارية موجودا. قم بإعادة ضبط إعدادات النظام إذا تم تغييرها أو إذا لم يكن نظام إدارة البطارية موجودا.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>إن خدمة موقت الخدمة معطلة.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>إن خدمة موقت الخدمة معطلة.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>مدخل VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>مدخل VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (الوصول إلى شبكة افتراضية خاصة عن بعد)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (الوصول إلى شبكة افتراضية خاصة عن بعد)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>حالة الشحن 1%</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>حالة الشحن 1%</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>يجب تكوين ملف أمني أولا قبل تشغيل خدمات الشبكات، انظر «الإعدادات» - «العام».</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>يجب تكوين ملف أمني أولا قبل تشغيل خدمات الشبكات، انظر «الإعدادات» - «العام».</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>استُبدل «%1» بـ «%2» لأنها تحتوي على رموز غير صالحة.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>استُبدل «%1» بـ «%2» لأنها تحتوي على رموز غير صالحة.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>يبدأ...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>يبدأ...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>الواجهة الخلفية قيد البدء...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>الواجهة الخلفية قيد البدء...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>توقفت الواجهة الخلفية.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>توقفت الواجهة الخلفية.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>تعذر الاتصال.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>تعذر الاتصال.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>سجل جهاز GX هذا خروج من Tailscale. يرجى الانتظار أو التأكد من اتصالك بالإنترنت.</translation>
+        <translation>سجل جهاز GX هذا خروج من Tailscale. يرجى الانتظار أو التأكد من اتصالك بالإنترنت.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>في انتظار الرد من Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>في انتظار الرد من Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>قم بتوصيل جهاز GX هذا بحساب Tailscale من خلال فتح هذا الرابط:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>قم بتوصيل جهاز GX هذا بحساب Tailscale من خلال فتح هذا الرابط:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>يرجى الانتظار أو التأكد من اتصالك بالإنترنت.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>يرجى الانتظار أو التأكد من اتصالك بالإنترنت.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>حالة غير معروفة: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>حالة غير معروفة: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>خطأ: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>خطأ: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>عطل Tailscale لتعديل هذه الإعدادات.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>عطل Tailscale لتعديل هذه الإعدادات.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>فعّل Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>فعّل Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>اسم الآلة</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>اسم الآلة</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>تسجيل خروج من حساب Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>تسجيل خروج من حساب Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>الوصول للشبكة المحلية</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>الوصول للشبكة المحلية</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>الوصول إلى شبكة إيثرنت المحلية</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>الوصول إلى شبكة إيثرنت المحلية</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>الوصول إلى شبكة واي فاي المحلية</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>الوصول إلى شبكة واي فاي المحلية</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>تخصيص الشبكة/ الشبكات</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>تخصيص الشبكة/ الشبكات</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>مثال: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>مثال: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>توضيح: هذه الخاصية التي تسميها Tailscale مسارات الشبكة الفرعية تتيح إمكانية الوصول عن بعد للأجهزة الأخرى داخل الشبكة/ الشبكات المحلية. يقبل حقل الشبكات المخصصة قائمة مفصولة بفواصل للشبكات الفرعية لتدوين CIDR. بعد إضافة/ تفعيل شبكة جديدة عليك أن توافق عليها في وحدة تحكم مشرف Tailscale لمرة واحدة.</translation>
+        <translation>توضيح: هذه الخاصية التي تسميها Tailscale مسارات الشبكة الفرعية تتيح إمكانية الوصول عن بعد للأجهزة الأخرى داخل الشبكة/ الشبكات المحلية. يقبل حقل الشبكات المخصصة قائمة مفصولة بفواصل للشبكات الفرعية لتدوين CIDR. بعد إضافة/ تفعيل شبكة جديدة عليك أن توافق عليها في وحدة تحكم مشرف Tailscale لمرة واحدة.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>تخصيص "tailscale up\ الحجج</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>تخصيص &quot;tailscale up\ الحجج</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>عنوان URL للخادم المخصص (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>عنوان URL للخادم المخصص (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>يتطلب جهاز التحكم في المولد الكهربائي هذا مرحل مساعد للتحكم فيه ولكن المرحل المساعد غير مهيأ. برجاء تكوين المرحل 1 من خلال الإعدادات - المرحل إلى / «المرحل المساعد للمولد الكهربائي المتصل/».</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>يتطلب جهاز التحكم في المولد الكهربائي هذا مرحل مساعد للتحكم فيه ولكن المرحل المساعد غير مهيأ. برجاء تكوين المرحل 1 من خلال الإعدادات - المرحل إلى / «المرحل المساعد للمولد الكهربائي المتصل/».</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>إنذارات ارتفاع جهد بطارية بدء التشغيل</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>إنذارات ارتفاع جهد بطارية بدء التشغيل</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>تخطي إحماء محرك مولد الكهرباء</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>تخطي إحماء محرك مولد الكهرباء</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>أعلى، لكن دون خدمات (500 كيلو بت/ ثانية)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>أعلى، لكن دون خدمات (500 كيلو بت/ ثانية)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>تم تغيير كلمة الكرور الرئيسية إلى %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>تم تغيير كلمة الكرور الرئيسية إلى %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>المرحل المساعد للمولد الكهربائي المتصل</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>المرحل المساعد للمولد الكهربائي المتصل</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>موقع حمولات التيار المتردد</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>موقع حمولات التيار المتردد</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>دخل وخرج التيار المتردد</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>دخل وخرج التيار المتردد</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>استخدم هذا الخيار عندما تكون جميع حمولات التيار المتردد موجودة على دخل المعاكس/الشاحن. استخدم هذا الخيار إذا لم تكن متأكد.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>استخدم هذا الخيار عندما تكون جميع حمولات التيار المتردد موجودة على دخل المعاكس/الشاحن. استخدم هذا الخيار إذا لم تكن متأكد.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>خرج التيار المتردد فقط</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>خرج التيار المتردد فقط</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>استخدم هذا الخيار عندما يستخدم النظام عداد الشبكة بينما جميع حمولات التيار المتردد على خرج المعاكس/الشاحن.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>استخدم هذا الخيار عندما يستخدم النظام عداد الشبكة بينما جميع حمولات التيار المتردد على خرج المعاكس/الشاحن.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>شهري</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>شهري</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>شاحن EV</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>شاحن EV</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>مضخة حرارية</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>مضخة حرارية</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>الأحمال الأساسية</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>الأحمال الأساسية</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>شغل وأوقف المولد حسب أوضاع التشغيل الآلي المحددة.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>شغل وأوقف المولد حسب أوضاع التشغيل الآلي المحددة.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>إعدادات مولد التيار المستمر</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>إعدادات مولد التيار المستمر</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>حرارة مولد التيار</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>حرارة مولد التيار</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>حرارة المحرك</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>حرارة المحرك</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>وقت التشغيل الكلي</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>وقت التشغيل الكلي</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>ملف تعريف أمن الشبكة</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>ملف تعريف أمن الشبكة</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>آخر %1 يوم</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>آخر %1 يوم</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>سيتوقف المولد خلال %1 ما لم تكن يتم تفعيل شروط التشغيل الآلي إلى الاستمرار قيد التشغيل.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>سيتوقف المولد خلال %1 ما لم تكن يتم تفعيل شروط التشغيل الآلي إلى الاستمرار قيد التشغيل.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>سيظل المولد قيد التشغيل حتى إيقافه يدويا، ما لم تكن يتم تفعيل شروط التشغيل الآلي إلى الاستمرار قيد التشغيل.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>سيظل المولد قيد التشغيل حتى إيقافه يدويا، ما لم تكن يتم تفعيل شروط التشغيل الآلي إلى الاستمرار قيد التشغيل.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>واجهة المستخدم الكلاسيكية</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>واجهة المستخدم الكلاسيكية</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>واجهة مستخدم جديدة</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>واجهة مستخدم جديدة</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>تم تغيير اللغة بنجاح!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>تحديد الطاقة</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>تم تغيير اللغة بنجاح!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>بالنسبة لأجهزة Multi-RS وHS19، تتوفر إعدادات ESS على صفحة منتج نظام RS.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>بالنسبة لأجهزة Multi-RS وHS19، تتوفر إعدادات ESS على صفحة منتج نظام RS.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>بدء/ توقف المولد</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>بدء/ توقف المولد</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>لا يمكن تبديل نسخة البرنامج الثابت دون تحديد "ملف تعريف أمن الشبكة" في "الإعدادات / عام".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>لا يمكن تبديل نسخة البرنامج الثابت دون تحديد &quot;ملف تعريف أمن الشبكة&quot; في &quot;الإعدادات / عام&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>المدة</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>المدة</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>نظام الإنذارات</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>نظام الإنذارات</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>إيقاف نظام الإنذارات</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>إيقاف نظام الإنذارات</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>العودة</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>العودة</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>ما الجديد</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>ما الجديد</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>تخطي</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>تخطي</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>مرحبا!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>مرحبا!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>نحن سعداء لتقديم واجهة مصممة بشكل كامل تعزز كل من سهولة الاستخدام والجمالية لجهاز GX الخاص بك. مع التنقل المبسط والشكل الجديد، أصبح كل ما تحبه الآن أكثر سهولة للوصول إليه وأكثر جاذبية من الناحية البصرية.</translation>
+        <translation>نحن سعداء لتقديم واجهة مصممة بشكل كامل تعزز كل من سهولة الاستخدام والجمالية لجهاز GX الخاص بك. مع التنقل المبسط والشكل الجديد، أصبح كل ما تحبه الآن أكثر سهولة للوصول إليه وأكثر جاذبية من الناحية البصرية.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>وضع غامق - فاتح</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>وضع غامق - فاتح</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>تتطلب البيئات المختلفة إعدادات عرض مختلفة. تضمن أوضاع الغامق والفاتح أفضل تجربة مشاهدة بغض النظر عن مكانك.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>تتطلب البيئات المختلفة إعدادات عرض مختلفة. تضمن أوضاع الغامق والفاتح أفضل تجربة مشاهدة بغض النظر عن مكانك.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>جميع المعلومات الرئيسية التي تحتاجها، مقدمة بتصميم واضح وبسيط. العنصر المركزي هو عنصر واجهة قابلة للتخصيص يتميز بحلقات، مما يمنحك وصولاً سريعًا إلى رؤى نظامك بنظرة سريعة.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>جميع المعلومات الرئيسية التي تحتاجها، مقدمة بتصميم واضح وبسيط. العنصر المركزي هو عنصر واجهة قابلة للتخصيص يتميز بحلقات، مما يمنحك وصولاً سريعًا إلى رؤى نظامك بنظرة سريعة.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>احصل على تحكم أكبر مع لوحة العرض المحدثة لدينا، التي تحتوي على بيانات النظام في الزمن الفعلي — كل ذلك في مكان واحد لمراقبة سهلة.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>احصل على تحكم أكبر مع لوحة العرض المحدثة لدينا، التي تحتوي على بيانات النظام في الزمن الفعلي — كل ذلك في مكان واحد لمراقبة سهلة.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>التحكمات</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>التحكمات</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>تم دمج جميع عناصر التحكم اليومية الآن في لوحة التحكم الجديدة. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">تم دمج جميع عناصر التحكم اليومية الآن في لوحة التحكم الجديدة. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>الوات والأمبير</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>الوات والأمبير</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>يمكنك الآن التبديل بين الوات والأمبير. اختر الوحدة الأمثل لك.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>يمكنك الآن التبديل بين الوات والأمبير. اختر الوحدة الأمثل لك.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>اعرف المزيد</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>اعرف المزيد</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>يمكنك زيارة الرابط أدناه لمعرفة المزيد حول واجهة المستخدم المجددة.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>يمكنك زيارة الرابط أدناه لمعرفة المزيد حول واجهة المستخدم المجددة.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>امسح رمز الاستجابة السريعة QR لمعرفة المزيد حول واجهة المستخدم المجددة.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>امسح رمز الاستجابة السريعة QR لمعرفة المزيد حول واجهة المستخدم المجددة.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>تم</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>تم</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>التالي</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>التالي</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>خطأ: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>خطأ: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>خطأ نشط</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>خطأ نشط</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>مجمل وقت تشغيل المولد (ساعات)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>مجمل وقت تشغيل المولد (ساعات)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>صفحة البدء</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>صفحة البدء</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>واجهة المستخدم</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>واجهة المستخدم</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>واجهة المستخدم (وحدة التحكم عن بعد)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>واجهة المستخدم (وحدة التحكم عن بعد)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1محدث</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1محدث</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>ستتبدل واجهة المستخدم إلى %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>ستتبدل واجهة المستخدم إلى %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>تم ضبط %1 إلى %2.</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>يدعم المعاكس الضوئي تحديد الطاقة. عطل هذه الخاصية إذا كانت تتداخل مع التشغيل العادي.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>تم ضبط %1 إلى %2.</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>اضغط على «نعم» لإعادة التشغيل</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>اضغط على «نعم» لإعادة التشغيل</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>إعادة ضبط المصنع لأداة التطوير Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>إعادة ضبط المصنع لأداة التطوير Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>هل أنت متأكد أنك تريد إعادة ضبط المصنع لأداة التطوير Node-RED؟ سيحذف هذا كل التدفقات الخاصة بك.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>هل أنت متأكد أنك تريد إعادة ضبط المصنع لأداة التطوير Node-RED؟ سيحذف هذا كل التدفقات الخاصة بك.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>حالة الاتصال</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>حالة الاتصال</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>حالة الاتصال (قناة HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>حالة الاتصال (قناة HTTPS)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>حالة الاتصال (قناة HTTP)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>حالة الاتصال (قناة HTTP)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>حالة الاتصال (قناة MQTT في الوقت الفعلي)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>حالة الاتصال (قناة MQTT في الوقت الفعلي)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>حالة الاتصال (قناة MQTT RPC)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>حالة الاتصال (قناة MQTT RPC)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>بدأ التشغيل تلقائيا• %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>بدأ التشغيل تلقائيا• %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>قيمة إلغاء التفعيل</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>قيمة إلغاء التفعيل</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>لا يعمل</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>لا يعمل</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>فقد الاتصال</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>فقد الاتصال</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>حالة مستوى شحن البطارية</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>حالة مستوى شحن البطارية</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>حالة حمل التيار المتردد</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>حالة حمل التيار المتردد</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>حالة تيار البطارية</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>حالة تيار البطارية</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>حالة الجهد الكهربائي للبطارية</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>حالة الجهد الكهربائي للبطارية</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>حالة الحمل الزائد في المعاكس</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>حالة الحمل الزائد في المعاكس</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>الديناميكي %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>الديناميكي %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>الديناميكي %1 التحميل/ تفريغ الشحن معطل</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>الديناميكي %1 التحميل/ تفريغ الشحن معطل</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>الديناميكي %1التحميل معطل</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>الديناميكي %1التحميل معطل</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>الديناميكي %1 تفريغ الشحن معطل</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>الديناميكي %1 تفريغ الشحن معطل</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">مختصر</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>مختصر (اللوحة الجانبية مفتوحة)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>مختصر (اللوحة الجانبية مفتوحة)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">نظرة عامة</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>المستويات (الخزانات)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>المستويات (الخزانات)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>المستويات (البيئة)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>المستويات (البيئة)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>قائمة البطارية</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>قائمة البطارية</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>تم تحديث جهاز GX</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>تم تحديث جهاز GX</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>بعد %n دقيقة/دقائق</numerusform>
-        <numerusform>بعد %n دقيقة/دقائق</numerusform>
-        <numerusform>بعد %n دقيقة/دقائق</numerusform>
-        <numerusform>بعد %n دقيقة/دقائق</numerusform>
-        <numerusform>بعد %n دقيقة/دقائق</numerusform>
-        <numerusform>بعد %n دقيقة/دقائق</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>بعد %n دقيقة/دقائق</numerusform>
+            <numerusform>بعد %n دقيقة/دقائق</numerusform>
+            <numerusform>بعد %n دقيقة/دقائق</numerusform>
+            <numerusform>بعد %n دقيقة/دقائق</numerusform>
+            <numerusform>بعد %n دقيقة/دقائق</numerusform>
+            <numerusform>بعد %n دقيقة/دقائق</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>انتقل إلى هذه الصفحة حينما يبدأ التطبيق في العمل.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>انتقل إلى هذه الصفحة حينما يبدأ التطبيق في العمل.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>انتهاء المهلة</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>انتهاء المهلة</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>اذهب إلى صفحة البدء عندما يكون التطبيق غير نشط.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>اذهب إلى صفحة البدء عندما يكون التطبيق غير نشط.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>بعد دقيقة من عدم النشاط اختر الصفحة الحالية لتكون صفحة البدء إذا كانت في هذه القائمة.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>بعد دقيقة من عدم النشاط اختر الصفحة الحالية لتكون صفحة البدء إذا كانت في هذه القائمة.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>حد التيار مثبت في تكوين النظام. لا يمكن تعديله.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>حد التيار مثبت في تكوين النظام. لا يمكن تعديله.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>الوضع مثبت في تكوين النظام. لا يمكن تعديله.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>الوضع مثبت في تكوين النظام. لا يمكن تعديله.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>وظيفة التشغيل/التوقيف للمولد غير مفعلة، اذهب إلى إعدادات المرحل واختر وظيفة "تشغيل/توقيف المولد"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>التوقيت المعياري للمغرب</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>التوقيت المعياري لغرب وسط أفريقيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>التوقيت المعياري لجنوب أفريقيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>التوقيت المعياري لناميبيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>التوقيت المعياري لمصر</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>التوقيت المعياري لشرق أفريقيا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>التوقيت المعياري للأرجنتين</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>التوقيت المعياري لشرق جنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>التوقيت المعياري لجرينلاند</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>التوقيت المعياري لمونتفيدو</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>التوقيت المعياري لنيوفاوندلاند</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>التوقيت المعياري المنطقة الشرقية لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>التوقيت المعياري للأطلسي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>التوقيت المعياري لوسط البرازيل</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>التوقيت المعياري لباراغواي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>التوقيت المعياري لفنزويلا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>التوقيت المعياري للشرق</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>التوقيت المعياري لشرق الولايات المتحدة</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>التوقيت المعياري لوسط الكندا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>التوقيت المعياري لوسط أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>التوقيت المعياري للوسط (المكسيك)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>التوقيت المعياري للوسط</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>التوقيت المعياري للجبل (المكسيك)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>التوقيت المعياري للجبل</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>التوقيت المعياري لجبل الولايات المتحدة</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>التوقيت المعياري للهادئ (المكسيك)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>التوقيت المعياري للهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>التوقيت المعياري لألاسكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>التوقيت المعياري لهاواي-إليوتينس</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>التوقيت المعياري لنيوزيلندا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>التوقيت المعياري لوسط الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>التوقيت المعياري لغرب الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>التوقيت المعياري لغرب أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>التوقيت المعياري لوسط آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>التوقيت المعياري لغرب آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>التوقيت المعياري لشرق أفريقيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>التوقيت المعياري لغرب أوروبا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>التوقيت المعياري لكامشاتكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>التوقيت المعياري لماجادان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>التوقيت المعياري لفلاديفوستوك</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>التوقيت المعياري لياكتسك</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>التوقيت المعياري لطوكيو</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>التوقيت المعياري لكوريا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>التوقيت المعياري لسنغافورة</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>التوقيت المعياري لأولان باتور</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>التوقيت المعياري لتايبيه</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>التوقيت المعياري لشمال شرق آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>التوقيت المعياري للصين</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>التوقيت المعياري لشمال آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>التوقيت المعياري لبورما</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>التوقيت المعياري لشمال وسط آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>التوقيت المعياري لوسط آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>التوقيت المعياري لبنغلاديش</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>التوقيت المعياري للنيبال</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>التوقيت المعياري لسريلانكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>التوقيت المعياري للهند</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>التوقيت المعياري لغرب آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>التوقيت المعياري لباكستان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>التوقيت المعياري ليكترينبورغ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>التوقيت المعياري لجورجيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>التوقيت المعياري للقوقاز</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>التوقيت المعياري لأذربجان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>التوقيت المعياري العربي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>التوقيت المعياري أفغانستان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>التوقيت المعياري لإيران</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>التوقيت المعياري العربي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>التوقيت المعياري العربي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>التوقيت المعياري لسوريا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>التوقيت المعياري للشرق الأوسط</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>التوقيت المعياري للأردن</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>التوقيت المعياري لإسرائيل</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>التوقيت المعياري لغرينتش</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>التوقيت المعياري للأزور</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>التوقيت المعياري للرأس الأخضر</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>التوقيت المعياري لتاسمانيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>التوقيت المعياري لشرق أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>التوقيت المعياري لشرق أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>التوقيت المعياري لوسط أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>التوقيت المعياري لوسط أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>التوقيت المعياري لغرب أستراليا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>توقيت غرنتش +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>التوقيت المعياري لوسط الأطلسي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>توقيت غرينتش -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>التوقيت المعياري لخط التاريخ</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>التوقيت المعياري لغرينتش</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>التوقيت المعياري لوسط أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>التوقيت المعياري لوسط أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>التوقيت المعياري لوسط أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>التوقيت المعياري لغرب أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>التوقيت المعياري لشرق أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>التوقيت المعياري لفنلندا ليتوانيا إستونيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>التوقيت المعياري لليونان تركيا بلغاريا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>التوقيت المعياري لبلاروسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>التوقيت المعياري لروسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>التوقيت المعياري لتركيا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>التوقيت المعياري لموريشيوس</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>الوقت المعياري لجزيرة كريسماس</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>التوقيت المعياري لتونغا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>التوقيت المعياري لفيجي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>التوقيت المعياري لنيوزيلندا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>التوقيت المعياري لوسط الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>التوقيت المعياري لغرب الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>التوقيت المعياري لساموا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>التوقيت المعياري لهاواي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>الوقت المعياري لجزيرة الفصح</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>وظيفة التشغيل/التوقيف للمولد غير مفعلة، اذهب إلى إعدادات المرحل واختر وظيفة &quot;تشغيل/توقيف المولد&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">مجهول</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">إنتاج الطاقة الشمسية</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">دخل التيار المستمر</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">تحميلات التيار المتردد</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">أحمال التيار المستمر</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">نظرة عامة</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">الحالة</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">جهاز ضوئي</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">الإنتاجية الكلية</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">إنتاجية النظام</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">منبه فقط</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">إنذارات وتنبيهات</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">تحذير</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>لا يوجد خطأ</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>لا يوجد خطأ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>خطأ غير معروف: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>خطأ غير معروف: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>لا يوجد خطأ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>لا يوجد خطأ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>خطأ في بدء تشغيل البطارية</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>خطأ في بدء تشغيل البطارية</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>ليس هناك بطاريات متصلة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>ليس هناك بطاريات متصلة</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>بطارية مجهولة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>بطارية مجهولة</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>اختلاف في أنواع البطاريات</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>اختلاف في أنواع البطاريات</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>عدد البطاريات خاطئ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>عدد البطاريات خاطئ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>تحويلة لينكس غير موجودة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>تحويلة لينكس غير موجودة</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>قياس البطارية خاطئ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>قياس البطارية خاطئ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>خطأ في الحساب الداخلي</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>خطأ في الحساب الداخلي</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>عدد البطاريات المتسلسل خاطئ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>عدد البطاريات المتسلسل خاطئ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>خطأ في المكونات المادية</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>خطأ في المكونات المادية</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>خطأ في المراقب</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>خطأ في المراقب</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>جهد كهربائي زائد</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>جهد كهربائي زائد</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>تيار منخفض</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>تيار منخفض</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>درجة حرارة زائدة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>درجة حرارة زائدة</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>درجة حرارة منخفضة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>درجة حرارة منخفضة</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>في حالة انتظار بسبب قلة شحن البطارية</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>في حالة انتظار بسبب قلة شحن البطارية</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>خطأ في ADC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>خطأ في ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>خطأ في اتصال البطارية</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>خطأ في اتصال البطارية</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>خطأ ما قبل الشحن</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>خطأ ما قبل الشحن</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>خطأ في حماية الملامس</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>خطأ في حماية الملامس</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>خطأ في تحديث البطارية</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>خطأ في تحديث البطارية</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>خطأ في كابل نظام إدارة المبنى (BMS)</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>خطأ في كابل نظام إدارة المبنى (BMS)</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>عطل في الجهد المرجعي</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>عطل في الجهد المرجعي</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>جهد النظام خاطئ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>جهد النظام خاطئ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>انتهاء مهلة ما قبل الشحن</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>انتهاء مهلة ما قبل الشحن</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>عطل ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>عطل ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>بيانات المعايرة مفقودة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>بيانات المعايرة مفقودة</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>إعدادات غير صالحة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>إعدادات غير صالحة</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>تعشيق</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>تعشيق</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>توقف لأمر طارئ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>توقف لأمر طارئ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>مهلة الاتصال</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>مهلة الاتصال</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>قفل الأمان</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>قفل الأمان</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>المحطة تجاوزت درجة الحرارة</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>المحطة تجاوزت درجة الحرارة</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>لا يوجد خطأ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>بطارية مرتفعة الحرارة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>بطارية مرتفعة التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>حساس حرارة الشاحن غير متصل</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>مستشعر حرارة البطارية مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>خطأ في مستشعر فولت البطارية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>مستشعر فولت البطارية مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>فقدان السلك العالي للبطارية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>الجهد الكهربائي للبطارية منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>بطاربة ذات جهد كهربائي عالي التموج</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>بطارية في وضعية منخفضة من الشحن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>إشكال في الجهد الكهربائي المتوسط للبطارية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>درجة حرارة البطارية منخفضة جدًا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>حرارة البطارية العليا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>تيار الشاحن زائد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>تيار الشاحن بالسالب</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>كتلة الشاحن منتهي الصلاحية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>مشكلة حساس تيار الشاحن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>حساس الحرارة الداخلي غير متصل</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>مستشعر الحرارة الداخلي مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>مروحة الشاحن غير مكتشفة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>مروحة الشاحن زائدة عن التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>ارتفاع في حرارة النهاية الطرفية للشاحن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>شاحن انقطاع التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>مشكلة في مرحلة قدرة الشاحن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>حماية ضد الشحن الزائد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>مدخل تيار عالي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>مدخلات التيار زائدة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>زيادة قدرة الدخل</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>مشكلة في المدخلات القطبية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>جهد الدخل غير موجود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>إيقاف الدخل (دون إعادة محاولة)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>إيقاف التشغيل (إعادة المحاولة)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>عطل داخلي في الدخل</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>فشل عزل الخلايا الكهروضوئية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>تم كشف خطأ في المؤرض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>إفراط في تحيمل المعاكس</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>حرارة المعاكس عالية جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>تيار الذروة للمعاكس</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>مستوى التيار المستمر الداخلي للمعاكس</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>خطأ في مخرج التيار المتردد للمعاكس</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>خطأ في وضعية قوة المعاكس</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>المعاكس متصل بالتيار المتردد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>خطأ في اختبار مرحل ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>خطأ في اختبار مرحل ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>جهاز مختفي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>جهاز غير متوافق</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>اتصال إدارة نظام البطاريات مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>خطأ في تركيبة الشبكة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>تناوب المرحلة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>مداخل تيار متردد متعددة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>حمل زائد على المرحلة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>خطأ في كتابة الذاكرة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>حرارة وحدة التشغيل المركزية مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>اتصال مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>بيانات المعايرة مفقودة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>البرامج الثابتة غير متوافقة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>المكونات المادية غير متوافقة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>إعدادات غير صالحة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>فشل في مقياس الجهد الكهربائي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>فشل في معاين الاختبار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>السجل غير صالح</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>عدادات كيلووات ساعة غير صالحة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>خطأ في جهد التيار المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>خطأ في مستشعر قاطع دارة الأعطال الأرضية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>خطأ في تغذية 3 فولت 3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>خطأ في تغذية 5 فولت</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>خطأ في تغذية 12 فولت</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>خطأ في تغذية 15 فولت</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>إغلاق المدخلات الكهروضوئية</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>اضبط المفتاح في وضع إلغاء القفل لتعديل الإعدادات.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>استخدم مصدر بيانات D-Bus: اتصل بعنوان D-Bus المحدد.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>عنوان</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>استخدم مصدر بيانات D-Bus: اتصل بعنوان D-Bus الافتراضي</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>استخدم مصدر بيانات MQTT: اتصل بعنوان وسيط MQTT المحدد.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>عنوان</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>معرف بوابة جهاز مصدر بيانات MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>معرّف البوابة</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>جزء مضيف الويب MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>جزء</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>اسم مستخدم مصدر بيانات MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>مستخدم</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>كلمة مرور مصدر بيانات MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>اجتياز</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>رمز مصدر بيانات MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>رمز</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>تمكين عداد FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>تخطي شاشة البداية</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>استخدم مصدر بيانات وهميًا للاختبار.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>الجهاز مطفأ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>جديد/قديم MK2 مخلوط</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>أخطاء أجهزة مرتقبة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>ليست هناك أجهزة أخرى مكتشفة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>تيار زائد في التيار المتردد الخارج</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>خطأ في برنامج DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>نظام إدارة البطارية للمسار التجميعي VE بدون مساعد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>اختبار مرحل المؤرض قد فشل</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>خطأ في تزامن وقت النظام</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>خطأ في فحص مرحل الشبكة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>الإعدادات لا تتطابق مع المتحكم الدقيق الثاني</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>خطأ في مراسلة الجهاز</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>قيد انتظار التكوين أو أن الدونجل مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>الوحدة الرئيسية للطور مفقودة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>قد حصل إفراط بالتيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>التابع ليس لديه تيار متردد داخل!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>هذا الجهاز لا يكون تابعا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>حماية النظام بدأت</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>عدم التوافق في البرامج المبيتة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>خطأ داخلي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>يحول فشل اختبار التتابع دون الاتصال</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>خطأ في المسار التجميعي VE</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>خطأ غير معروف:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>خطأ داخلي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>لا يوجد خطأ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>بطارية مرتفعة الحرارة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>بطارية مرتفعة التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>الجهد الكهربائي للبطارية منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>جهد البطارية تجاوز الحد الأقصى المحدد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>ارتفاع درجة حرارة مولد التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>ارتفاع عدد دورات مولد التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>ارتفاع درجة حرارة ترانزستور المجال المؤثر لمحرك المجال</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>الحساس المطلوب مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>انخفاض الجهد الكهربي لمولد التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>تعديل الجهد الكهربي المرتفع لمولد التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>تجاوز الجهد الكهربي لمولد التيار الحد الأقصى المحدد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>مولد التيار ذو الجهد العالي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>فصل البطارية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>فصل البطارية عالية الجهد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>البطارية خارج النطاق</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>عدد كبير للغاية من BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>البطارية على وشك الفصل</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>عدد كبير للغاية من الأجهزة التي يتعين تتبعها</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>فصل البطارية منخفضة الجهد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>فصل البطارية مرتفعة التيار</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>فصل البطارية ذات درجة الحرارة المرتفعة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>فصل البطارية ذات درجة الحرارة المنخفضة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>اتصال إدارة نظام البطاريات مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>تعطيل ATC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>محول الجهد المستمر غير جاهز</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>ارتفاع الجهد الكهربي الرئيسي للجهد المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>انخفاض الجهد الكهربي الرئيسي للجهد المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>ارتفاع الجهد الكهربي الثانوي للجهد المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>انخفاض الجهد الكهربي الثانوي للجهد المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>ارتفاع درجة حرارة الجهد المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>خطأ إعداد الجهد المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>مستشعر درجة حرارة البطارية معيب</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>خطأ غير معروف:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>خطأ غير معروف:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>لا يوجد خطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>بطارية مرتفعة الحرارة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>بطارية مرتفعة التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>حساس حرارة الشاحن غير متصل</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>مستشعر حرارة البطارية مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>خطأ في مستشعر فولت البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>مستشعر فولت البطارية مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>فقدان السلك العالي للبطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>الجهد الكهربائي للبطارية منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>بطاربة ذات جهد كهربائي عالي التموج</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>بطارية في وضعية منخفضة من الشحن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>إشكال في الجهد الكهربائي المتوسط للبطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>درجة حرارة البطارية منخفضة جدًا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>حرارة البطارية العليا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>تيار الشاحن زائد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>تيار الشاحن بالسالب</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>كتلة الشاحن منتهي الصلاحية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>مشكلة حساس تيار الشاحن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>حساس الحرارة الداخلي غير متصل</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>مستشعر الحرارة الداخلي مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>مروحة الشاحن غير مكتشفة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>مروحة الشاحن زائدة عن التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>ارتفاع في حرارة النهاية الطرفية للشاحن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>شاحن انقطاع التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>مشكلة في مرحلة قدرة الشاحن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>حماية ضد الشحن الزائد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>مدخل تيار عالي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>مدخلات التيار زائدة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>زيادة قدرة الدخل</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>مشكلة في المدخلات القطبية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>جهد الدخل غير موجود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>إيقاف الدخل (دون إعادة محاولة)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>إيقاف التشغيل (إعادة المحاولة)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>عطل داخلي في الدخل</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>فشل عزل الخلايا الكهروضوئية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>تم كشف خطأ في المؤرض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>إفراط في تحيمل المعاكس</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>حرارة المعاكس عالية جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>تيار الذروة للمعاكس</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>مستوى التيار المستمر الداخلي للمعاكس</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>خطأ في مخرج التيار المتردد للمعاكس</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>خطأ في وضعية قوة المعاكس</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>المعاكس متصل بالتيار المتردد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>خطأ في اختبار مرحل ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>خطأ في اختبار مرحل ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>جهاز مختفي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>جهاز غير متوافق</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>اتصال إدارة نظام البطاريات مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>خطأ في تركيبة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>تناوب المرحلة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>مداخل تيار متردد متعددة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>حمل زائد على المرحلة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>خطأ في كتابة الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>حرارة وحدة التشغيل المركزية مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>اتصال مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>بيانات المعايرة مفقودة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>البرامج الثابتة غير متوافقة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>المكونات المادية غير متوافقة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>إعدادات غير صالحة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>فشل في مقياس الجهد الكهربائي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>فشل في معاين الاختبار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>السجل غير صالح</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>عدادات كيلووات ساعة غير صالحة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>خطأ في جهد التيار المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>خطأ في مستشعر قاطع دارة الأعطال الأرضية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>خطأ في تغذية 3 فولت 3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>خطأ في تغذية 5 فولت</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>خطأ في تغذية 12 فولت</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>خطأ في تغذية 15 فولت</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>إغلاق المدخلات الكهروضوئية</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>خطأ غير معروف:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>خطأ غير معروف:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>خطأ غير معروف:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>خطأ غير معروف:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>لا يوجد خطأ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>الجهد الكهربائي L1 للتيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>الجهد الكهربائي للتيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>الجهد الكهربائي L1 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>الجهد الكهربائي للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>تردد L1 للتيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>تردد التيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>تردد L1 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>تردد التيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>تيار L1 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>التيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>طاقة L1 للتيار المتردد مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>طاقة التيار المتردد مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>توقف لأمر طارئ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>تيار المعزز مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>ضغط الزيت منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>ضغط الزيت مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>حرارة المحرك منخفضة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>حرارة الآلة مرتفة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>حرارة اللفيفة منخفضة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>حرارة اللفيفة مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>حرارة العادم منخفضة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>حرارة العادم مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>الحرارة الإلكترونية منخفضة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>الحرارة الإلكترونية مرتفعة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>جهد البادئ منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>تيار البادء مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>جهد التوهج منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>تيار التوهج مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>جهد مساعد بدء التشغيل البارد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>تيار مساعد بدء التشغيل البارد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>جهد المغناطيس الضابط للوقود منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>تيار المغناطيس الضابط للوقود منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>جهد المحث الضابط للملف الكهربائي للتوقف منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>تيار المحث الضابط للملف الكهربائي للتوقف مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>جهد المحث الساحب للملف الكهربائي للتوقف منخفض جدا </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>تيار المحث الساحب للملف الكهربائي للتوقف مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>جهد مضخة المروحة/ الماء منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>تيار مضخة المروحة/ الماء مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>تيار الجهد الكهربائي للمستشعر منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>تيار مستشعر التيار مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>الجهد الكهربائي لخرج التعزيز منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>التيار الخارج المعزز مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>جهد تغذية الناقل منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>تيار تغذية الناقل مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>الجهد الكهربائي لبطارية البادئ منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>الجهد الكهربائي لمشغل البطارية مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>التناوب منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>التناوب مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>توقف/ مشكلة مفاجئة في إمداد الوقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>جهد ملامس القدرة منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>تيار ملامس القدرة مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>الجهد الكهربائي L2 للتيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>الجهد الكهربائي L2 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>تردد L2 للتيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>تردد L2 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>تيار L2 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>قدرة L2 للتيار المتردد مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>الجهد الكهربائي L3 للتيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>الجهد الكهربائي L3 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>تردد L3 للتيار المتردد منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>تردد L3 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>تيار L3 للتيار المتردد مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>طاقة L3 للتيار المتردد مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>جهد خرج المحول العكسي منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>تيار خرج المحول العكسي مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>جهد الخرج الشامل (1A) منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>تيار الخرج الشامل (1A) مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>جهد الخرج الشامل (5A) منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>تيار الخرج الشامل (5A) مرتفع جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>جهد التيار المستمر AGT 1 منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>جهد التيار المستمر AGT 1 مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>تيار التيار المستمر AGT 1 منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>تيار التيار المستمر AGT 1 مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>جهد التيار المستمر AGT 2 منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>جهد التيار المستمر AGT 2 مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>تيار التيار المستمر AGT 2 منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>تيار التيار المستمر AGT 2 مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>مبرد AGT B6 منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>مبرد AGT B6 مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>قضيب(-) AGT B6 منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>قضيب(-) AGT B6 مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>قضيب(+) AGT B6 منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>قضيب(+) AGT B6 مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>حرارة الوقود منخفضة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>حرارة الوقود مرتفعة جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>مستوى الوقود منخفض جدا</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>فقدت وحدة التحكم</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>فقدت اللوحة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>خدمة محتاجة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>تم فقد لوحة 3-طور</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>تم فقد وحدة AGT</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>فشل في التزامن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>فقد وحدة التحكم الإلكترونية الخارجية ECU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>فلتر هواء السحب</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>رسالة تشخيصية (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>فقدت وحدة التزامن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>فشل في توازن الحمل</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>وضعية التزامن معطلة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>ضوء التوقف الأحمر (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>ضوء التحذير الأصفر (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>ضوء مؤشر العطل (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>ضوء الحماية (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>تدوير الحقل خاطئ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>فقد حساس مستوى الوقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>البدء بدون محول</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>الناقل #1 متوقف</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>تم رفض طلب البدء</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>تم رفض البدء عن بعد</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>تبديل الإيقاف القسري للمرحّل التحميلي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>وحدة التزامن مفصولة عن الشبكة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>نظام إدارة البطاريات مفقود</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>جهد رابط وحدة محول التيار المستمر منخفض/عكسي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>تيار رابط وحدة محول التيار المستمر منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>جهد الشحن المسبق لوحدة التيار المستمر منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>جهد الشحن المسبق لوحدة التيار المستمر مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>خطأ في محرك محول IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>خطأ في حلقة التحكم بالطاقة للمحول</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>كشف تردد التيار المتردد في المحول</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>فشل في قيمة تحكم المحول</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>تم تغيير إعدادات المصنع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>تم تغيير المعامل في وضع الإدارة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>تدخل يدوي (نظام خارجي)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>فشل في البدء</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>مراقب التوقيت</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>درجة حرارة محول التردد مرتفعة L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>درجة حرارة محول التردد مرتفعة L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>درجة حرارة محول التردد مرتفعة L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>درجة حرارة محول التردد مرتفعة برابط التيار المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>إفراط في تحيمل المعاكس</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>فقد الاتصال بالمعاكس</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>إفراط في تحميل التيار المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>جهد كهربائي زائد في التيار المستمر</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>ليس هناك اتصال</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>لا يوجد خطأ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>خطأ غير معروف: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>خطأ غير معروف:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>ضغط الزيت</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>ارتفاع درجة حرارة الرأس الاسطوانية</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>التحكم في الشحن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>السرعة أعلى من المتوقع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>سرعة مرتفعة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>حرارة الزيت أعلى من المتوقع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>دائرة مفتوحة/ قصر في الطاقة في درجة حرارة الزيت</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>قصر درجة حرارة الزيت إلى الأرض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>نقطة ضبط تماثلية عالية/ بها قصر في الطاقة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>نقطة ضبط تماثلية منخفضة/ بها قصر إلى الأرض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>انتهاء وقت تلقي الرسالة TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>انتهاء وقت تلقي الرسالة CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>الجهد الكهربائي للبطارية مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>الجهد الكهربائي للبطارية منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>خلل في سرعة الإشارة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>إمداد الاستشعار الداخلي بجهد 5 فولت مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>إمداد الاستشعار الداخلي بجهد 5 فولت منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>الضغط الجوي مرتفع</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>الضغط الجوي منخفض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>قصر مخرج مضخة الوقود إلى الطاقة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>قصر في مخرج مضخة الوقود إلى الأرض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>قصر مخرج شمعة الإشعال إلى الطاقة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>قصر مخرج شمعة الإشعال إلى الأرض</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>دائرة مفتوحة/ قصر في الجانب المنخفض إلى الأرض في الحاقن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>قصر داخلي في ملف الحاقن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>قصر في الطاقة في مقاومة الجانب المنخفض للحاقن</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>انتهاء صلاحية ساعات الخدمة</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>فشل في التشغيل</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>خطأ غير معروف:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>بطارية</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>بطارية</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>المبرد</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>المبرد</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>عام</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>عام</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>غرفة</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>غرفة</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>الخارج</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>الخارج</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>سخان الماء</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>سخان الماء</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>ثلاجة تجميد</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>ثلاجة تجميد</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>خطأ غير معروف:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>لا يوجد خطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>الجهد الكهربائي L1 للتيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>الجهد الكهربائي للتيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>الجهد الكهربائي L1 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>الجهد الكهربائي للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>تردد L1 للتيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>تردد التيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>تردد L1 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>تردد التيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>تيار L1 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>التيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>طاقة L1 للتيار المتردد مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>طاقة التيار المتردد مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>توقف لأمر طارئ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>تيار المعزز مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>ضغط الزيت منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>ضغط الزيت مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>حرارة المحرك منخفضة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>حرارة الآلة مرتفة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>حرارة اللفيفة منخفضة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>حرارة اللفيفة مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>حرارة العادم منخفضة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>حرارة العادم مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>الحرارة الإلكترونية منخفضة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>الحرارة الإلكترونية مرتفعة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>جهد البادئ منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>تيار البادء مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>جهد التوهج منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>تيار التوهج مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>جهد مساعد بدء التشغيل البارد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>تيار مساعد بدء التشغيل البارد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>جهد المغناطيس الضابط للوقود منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>تيار المغناطيس الضابط للوقود منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>جهد المحث الضابط للملف الكهربائي للتوقف منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>تيار المحث الضابط للملف الكهربائي للتوقف مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>جهد المحث الساحب للملف الكهربائي للتوقف منخفض جدا </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>تيار المحث الساحب للملف الكهربائي للتوقف مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>جهد مضخة المروحة/ الماء منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>تيار مضخة المروحة/ الماء مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>تيار الجهد الكهربائي للمستشعر منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>تيار مستشعر التيار مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>الجهد الكهربائي لخرج التعزيز منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>التيار الخارج المعزز مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>جهد تغذية الناقل منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>تيار تغذية الناقل مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>الجهد الكهربائي لبطارية البادئ منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>الجهد الكهربائي لمشغل البطارية مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>التناوب منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>التناوب مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>توقف/ مشكلة مفاجئة في إمداد الوقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>جهد ملامس القدرة منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>تيار ملامس القدرة مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>الجهد الكهربائي L2 للتيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>الجهد الكهربائي L2 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>تردد L2 للتيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>تردد L2 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>تيار L2 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>قدرة L2 للتيار المتردد مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>الجهد الكهربائي L3 للتيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>الجهد الكهربائي L3 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>تردد L3 للتيار المتردد منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>تردد L3 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>تيار L3 للتيار المتردد مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>طاقة L3 للتيار المتردد مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>جهد خرج المحول العكسي منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>تيار خرج المحول العكسي مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>جهد الخرج الشامل (1A) منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>تيار الخرج الشامل (1A) مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>جهد الخرج الشامل (5A) منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>تيار الخرج الشامل (5A) مرتفع جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>جهد التيار المستمر AGT 1 منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>جهد التيار المستمر AGT 1 مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>تيار التيار المستمر AGT 1 منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>تيار التيار المستمر AGT 1 مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>جهد التيار المستمر AGT 2 منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>جهد التيار المستمر AGT 2 مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>تيار التيار المستمر AGT 2 منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>تيار التيار المستمر AGT 2 مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>مبرد AGT B6 منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>مبرد AGT B6 مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>قضيب(-) AGT B6 منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>قضيب(-) AGT B6 مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>قضيب(+) AGT B6 منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>قضيب(+) AGT B6 مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>حرارة الوقود منخفضة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>حرارة الوقود مرتفعة جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>مستوى الوقود منخفض جدا</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>فقدت وحدة التحكم</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>فقدت اللوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>خدمة محتاجة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>تم فقد لوحة 3-طور</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>تم فقد وحدة AGT</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>فشل في التزامن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>فقد وحدة التحكم الإلكترونية الخارجية ECU</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>فلتر هواء السحب</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>رسالة تشخيصية (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>فقدت وحدة التزامن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>فشل في توازن الحمل</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>وضعية التزامن معطلة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>ضوء التوقف الأحمر (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>ضوء التحذير الأصفر (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>ضوء مؤشر العطل (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>ضوء الحماية (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>تدوير الحقل خاطئ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>فقد حساس مستوى الوقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>البدء بدون محول</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>الناقل #1 متوقف</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>تم رفض طلب البدء</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>تم رفض البدء عن بعد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>تبديل الإيقاف القسري للمرحّل التحميلي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>وحدة التزامن مفصولة عن الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>نظام إدارة البطاريات مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>جهد رابط وحدة محول التيار المستمر منخفض/عكسي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>تيار رابط وحدة محول التيار المستمر منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>جهد الشحن المسبق لوحدة التيار المستمر منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>جهد الشحن المسبق لوحدة التيار المستمر مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>خطأ في محرك محول IGBT/MOSFET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>خطأ في حلقة التحكم بالطاقة للمحول</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>كشف تردد التيار المتردد في المحول</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>فشل في قيمة تحكم المحول</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>تم تغيير إعدادات المصنع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>تم تغيير المعامل في وضع الإدارة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>تدخل يدوي (نظام خارجي)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>فشل في البدء</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>مراقب التوقيت</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>درجة حرارة محول التردد مرتفعة L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>درجة حرارة محول التردد مرتفعة L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>درجة حرارة محول التردد مرتفعة L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>درجة حرارة محول التردد مرتفعة برابط التيار المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>إفراط في تحيمل المعاكس</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>فقد الاتصال بالمعاكس</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>إفراط في تحميل التيار المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>جهد كهربائي زائد في التيار المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>ليس هناك اتصال</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>لا يوجد خطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>خطأ غير معروف: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>خطأ غير معروف:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>ضغط الزيت</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>ارتفاع درجة حرارة الرأس الاسطوانية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>التحكم في الشحن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>السرعة أعلى من المتوقع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>سرعة مرتفعة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>حرارة الزيت أعلى من المتوقع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>دائرة مفتوحة/ قصر في الطاقة في درجة حرارة الزيت</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>قصر درجة حرارة الزيت إلى الأرض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>نقطة ضبط تماثلية عالية/ بها قصر في الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>نقطة ضبط تماثلية منخفضة/ بها قصر إلى الأرض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>انتهاء وقت تلقي الرسالة TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>انتهاء وقت تلقي الرسالة CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>الجهد الكهربائي للبطارية مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>الجهد الكهربائي للبطارية منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>خلل في سرعة الإشارة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>إمداد الاستشعار الداخلي بجهد 5 فولت مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>إمداد الاستشعار الداخلي بجهد 5 فولت منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>الضغط الجوي مرتفع</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>الضغط الجوي منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>قصر مخرج مضخة الوقود إلى الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>قصر في مخرج مضخة الوقود إلى الأرض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>قصر مخرج شمعة الإشعال إلى الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>قصر مخرج شمعة الإشعال إلى الأرض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>دائرة مفتوحة/ قصر في الجانب المنخفض إلى الأرض في الحاقن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>قصر داخلي في ملف الحاقن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>قصر في الطاقة في مقاومة الجانب المنخفض للحاقن</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>انتهاء صلاحية ساعات الخدمة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>فشل في التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>اضبط المفتاح في وضع إلغاء القفل لتعديل الإعدادات.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>استخدم مصدر بيانات D-Bus: اتصل بعنوان D-Bus المحدد.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>عنوان</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>استخدم مصدر بيانات D-Bus: اتصل بعنوان D-Bus الافتراضي</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>استخدم مصدر بيانات MQTT: اتصل بعنوان وسيط MQTT المحدد.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>عنوان</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>معرف بوابة جهاز مصدر بيانات MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>معرّف البوابة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>جزء مضيف الويب MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>جزء</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>اسم مستخدم مصدر بيانات MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>مستخدم</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>كلمة مرور مصدر بيانات MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>اجتياز</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>رمز مصدر بيانات MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>رمز</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>تمكين عداد FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>تخطي شاشة البداية</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>استخدم مصدر بيانات وهميًا للاختبار.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>التوقيت المعياري للمغرب</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>التوقيت المعياري لغرب وسط أفريقيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>التوقيت المعياري لجنوب أفريقيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>التوقيت المعياري لناميبيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>التوقيت المعياري لمصر</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>التوقيت المعياري لشرق أفريقيا</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>التوقيت المعياري للأرجنتين</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>التوقيت المعياري لشرق جنوب أمريكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>التوقيت المعياري لجرينلاند</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>التوقيت المعياري لمونتفيدو</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>التوقيت المعياري لنيوفاوندلاند</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>التوقيت المعياري المنطقة الشرقية لجنوب أمريكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>التوقيت المعياري للأطلسي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>التوقيت المعياري لوسط البرازيل</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>التوقيت المعياري لباراغواي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>التوقيت المعياري لفنزويلا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>التوقيت المعياري للشرق</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>التوقيت المعياري لشرق الولايات المتحدة</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>التوقيت المعياري لوسط الكندا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>التوقيت المعياري لوسط أمريكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>التوقيت المعياري للوسط (المكسيك)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>التوقيت المعياري للوسط</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>التوقيت المعياري للجبل (المكسيك)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>التوقيت المعياري للجبل</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>التوقيت المعياري لجبل الولايات المتحدة</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>التوقيت المعياري للهادئ (المكسيك)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>التوقيت المعياري للهادئ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>التوقيت المعياري لألاسكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>التوقيت المعياري لهاواي-إليوتينس</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>التوقيت المعياري لنيوزيلندا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>التوقيت المعياري لوسط الهادئ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>التوقيت المعياري لغرب الهادئ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>التوقيت المعياري لغرب أستراليا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>التوقيت المعياري لوسط آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>التوقيت المعياري لغرب آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>التوقيت المعياري لشرق أفريقيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>التوقيت المعياري لغرب أوروبا</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>التوقيت المعياري لكامشاتكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>التوقيت المعياري لماجادان</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>التوقيت المعياري لفلاديفوستوك</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>التوقيت المعياري لياكتسك</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>التوقيت المعياري لطوكيو</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>التوقيت المعياري لكوريا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>التوقيت المعياري لسنغافورة</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>التوقيت المعياري لأولان باتور</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>التوقيت المعياري لتايبيه</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>التوقيت المعياري لشمال شرق آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>التوقيت المعياري للصين</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>التوقيت المعياري لشمال آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>التوقيت المعياري لبورما</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>التوقيت المعياري لشمال وسط آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>التوقيت المعياري لوسط آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>التوقيت المعياري لبنغلاديش</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>التوقيت المعياري للنيبال</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>التوقيت المعياري لسريلانكا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>التوقيت المعياري للهند</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>التوقيت المعياري لغرب آسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>التوقيت المعياري لباكستان</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>التوقيت المعياري ليكترينبورغ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>التوقيت المعياري لجورجيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>التوقيت المعياري للقوقاز</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>التوقيت المعياري لأذربجان</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>التوقيت المعياري العربي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>التوقيت المعياري أفغانستان</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>التوقيت المعياري لإيران</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>التوقيت المعياري العربي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>التوقيت المعياري العربي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>التوقيت المعياري لسوريا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>التوقيت المعياري للشرق الأوسط</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>التوقيت المعياري للأردن</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>التوقيت المعياري لإسرائيل</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>التوقيت المعياري لغرينتش</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>التوقيت المعياري للأزور</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>التوقيت المعياري للرأس الأخضر</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>التوقيت المعياري لتاسمانيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>التوقيت المعياري لشرق أستراليا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>التوقيت المعياري لشرق أستراليا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>التوقيت المعياري لوسط أستراليا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>التوقيت المعياري لوسط أستراليا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>التوقيت المعياري لغرب أستراليا</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>توقيت غرنتش +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>التوقيت المعياري لوسط الأطلسي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>توقيت غرينتش -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>التوقيت المعياري لخط التاريخ</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>التوقيت المعياري لغرينتش</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>التوقيت المعياري لوسط أوروبا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>التوقيت المعياري لوسط أوروبا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>التوقيت المعياري لوسط أوروبا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>التوقيت المعياري لغرب أوروبا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>التوقيت المعياري لشرق أوروبا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>التوقيت المعياري لفنلندا ليتوانيا إستونيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>التوقيت المعياري لليونان تركيا بلغاريا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>التوقيت المعياري لبلاروسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>التوقيت المعياري لروسيا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>التوقيت المعياري لتركيا</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>التوقيت المعياري لموريشيوس</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>الوقت المعياري لجزيرة كريسماس</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>التوقيت المعياري لتونغا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>التوقيت المعياري لفيجي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>التوقيت المعياري لنيوزيلندا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>التوقيت المعياري لوسط الهادئ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>التوقيت المعياري لغرب الهادئ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>التوقيت المعياري لساموا</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>التوقيت المعياري لهاواي</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>الوقت المعياري لجزيرة الفصح</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">خطأ داخلي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>خطأ غير معروف:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>خطأ داخلي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>لا يوجد خطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>بطارية مرتفعة الحرارة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>بطارية مرتفعة التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>الجهد الكهربائي للبطارية منخفض</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>جهد البطارية تجاوز الحد الأقصى المحدد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>ارتفاع درجة حرارة مولد التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>ارتفاع عدد دورات مولد التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>ارتفاع درجة حرارة ترانزستور المجال المؤثر لمحرك المجال</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>الحساس المطلوب مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>انخفاض الجهد الكهربي لمولد التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>تعديل الجهد الكهربي المرتفع لمولد التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>تجاوز الجهد الكهربي لمولد التيار الحد الأقصى المحدد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>مولد التيار ذو الجهد العالي</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>فصل البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>فصل البطارية عالية الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>البطارية خارج النطاق</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>عدد كبير للغاية من BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>البطارية على وشك الفصل</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>عدد كبير للغاية من الأجهزة التي يتعين تتبعها</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>فصل البطارية منخفضة الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>فصل البطارية مرتفعة التيار</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>فصل البطارية ذات درجة الحرارة المرتفعة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>فصل البطارية ذات درجة الحرارة المنخفضة</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>اتصال إدارة نظام البطاريات مفقود</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>تعطيل ATC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>محول الجهد المستمر غير جاهز</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>ارتفاع الجهد الكهربي الرئيسي للجهد المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>انخفاض الجهد الكهربي الرئيسي للجهد المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>ارتفاع الجهد الكهربي الثانوي للجهد المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>انخفاض الجهد الكهربي الثانوي للجهد المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>ارتفاع درجة حرارة الجهد المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>خطأ إعداد الجهد المستمر</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>مستشعر درجة حرارة البطارية معيب</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_cs.ts
+++ b/i18n/venus-gui-v2_cs.ts
@@ -1,7384 +1,8025 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="cs">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Deaktivováno</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Deaktivováno</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Přetížení měniče</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Přetížení měniče</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Výkon</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Výkon</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Vypnuto</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Vypnuto</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Auto</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Baterie</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Připojeno</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Odpojeno</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generátor</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Vysoké napětí baterie</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Vysoké napětí baterie</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Měnič / nabíječka</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Měnič / nabíječka</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Nízké napětí baterie</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Nízké napětí baterie</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manuální</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manuální</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Žádný</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Žádný</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Pozice</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Pozice</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Rychlost</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Rychlost</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Stav</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Stav</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instaluji %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instaluji %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Neznámá chyba</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Neznámá chyba</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Minimální SOC</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Minimální SOC</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Neznámý</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Zadejte heslo</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Zadejte heslo</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Stisknout pro kontrolu</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Stisknout pro kontrolu</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Síť</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Síť</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Solární výnos</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Solární výnos</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Externí ovládání</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Externí ovládání</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Nádrže</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Nádrže</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Prostředí</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Prostředí</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Žádná aktuální upozornění</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Žádná aktuální upozornění</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Všeobecný</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Všeobecný</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Datum a čas</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Datum a čas</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Nastavení systému</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Nastavení systému</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Zobrazení a jazyk</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Zobrazení a jazyk</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM online portál</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM online portál</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Měřiče energie</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Měřiče energie</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>FV měniče</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>FV měniče</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM modem</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM modem</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Spuštění/zastavení generátoru</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Spuštění/zastavení generátoru</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Čerpadlo nádrže</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Čerpadlo nádrže</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Zákaznický servis</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Zákaznický servis</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Funkce zařízení Venus OS Large</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Funkce zařízení Venus OS Large</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Omezení životnosti baterie: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Omezení životnosti baterie: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Automatické spuštění</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Funkce Autostart bude zakázána a generátor se nebude automaticky spouštět na základě nakonfigurovaných podmínek.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Funkce Autostart bude zakázána a generátor se nebude automaticky spouštět na základě nakonfigurovaných podmínek.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Ruční zastavení</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Ruční zastavení</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>MANUÁLNÍ SPUŠTĚNÍ</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>MANUÁLNÍ SPUŠTĚNÍ</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Pozice</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Automatické spuštění</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Automatické spuštění</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Přepínače</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Přepínače</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Úroveň přístupu</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Úroveň přístupu</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Uživatel</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Uživatel</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Uživatel a technik</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Uživatel a technik</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superuživatel</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superuživatel</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Servis</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Servis</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Po vypnutí DVCC nezapomeňte také resetovat systém VE.Bus.</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Po vypnutí DVCC nezapomeňte také resetovat systém VE.Bus.</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Omezení nabíjecího proudu</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Omezení nabíjecího proudu</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Maximální nabíjecí proud</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Maximální nabíjecí proud</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Použít %1 hodnotu pro start/stop</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Použít %1 hodnotu pro start/stop</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Spustit, když %1 je vyšší než</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Spustit, když %1 je vyšší než</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Spustit, když %1 je nižší než</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Spustit, když %1 je nižší než</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Zastavit, když %1 je vyšší než</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Zastavit, když %1 je vyšší než</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Zastavit, když %1 je nižší než</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Zastavit, když %1 je nižší než</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Odstranění IP adresy?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Odstranění IP adresy?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Připojení</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Připojení</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Výrobek</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Výrobek</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Název</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Název</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Název</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>Identifikace výrobku</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>Identifikace výrobku</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Verze hardwaru</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Verze hardwaru</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Název zařízení</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Název zařízení</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Deaktivován Vzdálený spínač chodu</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Deaktivován Vzdálený spínač chodu</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Generátor v chybovém stavu</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Generátor v chybovém stavu</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Na AC vstupu není detekován generátor</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Na AC vstupu není detekován generátor</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Celková doba chodu od posledního testu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Celková doba chodu od posledního testu</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Doba do dalšího testu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Doba do dalšího testu</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Nyní v chodu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Nyní v chodu</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>MANUÁLNÍ SPUŠTĚNÍ</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>MANUÁLNÍ SPUŠTĚNÍ</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Spustit generátor</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Spustit generátor</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Doba chodu za den</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Doba chodu za den</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Hodnota musí být vyšší než hodnota zastavení</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Hodnota musí být vyšší než hodnota zastavení</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Hodnota musí být nižší než spouštěcí hodnota</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Hodnota musí být nižší než spouštěcí hodnota</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>AC výstup</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>AC výstup</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">AC výstup</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Použít AC zátěž pro start/stop</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Použít AC zátěž pro start/stop</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Měření</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Měření</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Celková spotřeba</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Celková spotřeba</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Celkový AC výstup měniče</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Celkový AC výstup měniče</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>AC out měniče nejvyšší fáze</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>AC out měniče nejvyšší fáze</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Start když výkon je vyšší než</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Start když výkon je vyšší než</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Zastavit, když je výkon nižší než</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Zastavit, když je výkon nižší než</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Monitor baterie</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Monitor baterie</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Nedostupný monitor, nastavte jiný</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Nedostupný monitor, nastavte jiný</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Monitor baterie</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Nedostupný monitor, nastavte jiný</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Při ztrátě komunikace</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Při ztrátě komunikace</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Zastavit generátor</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Zastavit generátor</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Udržujte generátor v chodu</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Udržujte generátor v chodu</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Zastavení generátoru, když je k dispozici vstup AC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Zastavení generátoru, když je k dispozici vstup AC</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>SOC baterie</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>SOC baterie</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Vysoká teplota měniče</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Vysoká teplota měniče</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Vysoká teplota měniče</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Spustit při upozornění na vysokou teplotu</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Spustit při upozornění na vysokou teplotu</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Spustit při upozornění na přetížení</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Spustit při upozornění na přetížení</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Pravidelný chod</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Pravidelný chod</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Interval provozu</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Interval provozu</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 den(y)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 den(y)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Přeskočit zkušební provoz, pokud byl proveden</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Přeskočit zkušební provoz, pokud byl proveden</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Vždy spustit</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Vždy spustit</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Počáteční datum intervalu zkušebního provozu</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Počáteční datum intervalu zkušebního provozu</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Délka zkušebního provozu (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Délka zkušebního provozu (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Chod do doby než bude baterie plně nabitá</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Chod do doby než bude baterie plně nabitá</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (fix)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (fix)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS připojeno, ale žádné GPS fix</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS připojeno, ale žádné GPS fix</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Není připojeno žádné GPS</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Není připojeno žádné GPS</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Zeměpisná šířka</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Zeměpisná šířka</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Zeměpisná délka</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Zeměpisná délka</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Směr</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Směr</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Nadmořská výška</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Nadmořská výška</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Počet satelitů</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Počet satelitů</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Hodnota síťového odběru</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Hodnota síťového odběru</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Bod nastavení AC-In</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Bod nastavení AC-In</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Aktuální: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Aktuální: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Napětí: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Napětí: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Limity (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Limity (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Náboj: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Náboj: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Udělení absolutoria: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Udělení absolutoria: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Limity (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Limity (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Viditelný</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Viditelný</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Schovaný</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Schovaný</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Pomocné měření)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Pomocné měření)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Výstup %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Výstup %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Aktivní monitor baterie</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Aktivní monitor baterie</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Název</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Zadejte jméno</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Zadejte jméno</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Zadejte jméno</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Průběžné skenování</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Průběžné skenování</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Adaptéry Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Adaptéry Bluetooth</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>PIN kód</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>PIN kód</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Před připojením může být nutné odstranit stávající spárování.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Před připojením může být nutné odstranit stávající spárování.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Typ fáze</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Typ fáze</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Jedna fáze</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Jedna fáze</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Více fází</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Více fází</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>FV invertor na fázi 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>FV invertor na fázi 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>FV invertor na pozici fáze 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>FV invertor na pozici fáze 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>CAN-bus profil</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>CAN-bus profil</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deaktivováno</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Nahoře, ale bez služeb (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Nahoře, ale bez služeb (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Zařízení</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Zařízení</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000-out</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000-out</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Volič unikátního identifikačního čísla</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Volič unikátního identifikačního čísla</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Vyčkejte prosím, změna a kontrola unikátního čísla vyžaduje určitý čas</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Vyčkejte prosím, změna a kontrola unikátního čísla vyžaduje určitý čas</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Výše uvedený selektor nastavuje, který blok jedinečných identifikačních čísel se má použít pro jedinečná identifikační čísla NAME v poli PGN 60928 NAME. Změňte pouze při použití více zařízení GX v jedné síti VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Výše uvedený selektor nastavuje, který blok jedinečných identifikačních čísel se má použít pro jedinečná identifikační čísla NAME v poli PGN 60928 NAME. Změňte pouze při použití více zařízení GX v jedné síti VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Výše uvedený selektor nastavuje, který blok jedinečných identifikačních čísel se má použít pro sériové číslo v poli DGN 60928 ADDRESS_CLAIM. Změňte pouze při použití více zařízení GX v jedné síti RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Výše uvedený selektor nastavuje, který blok jedinečných identifikačních čísel se má použít pro sériové číslo v poli DGN 60928 ADDRESS_CLAIM. Změňte pouze při použití více zařízení GX v jedné síti RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Zkontrolovat unikátní identifikační čísla</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Zkontrolovat unikátní identifikační čísla</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Stisknout pro kontrolu</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>K tomuto jedinečnému číslu je připojeno jiné zařízení, vyberte prosím nové číslo.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>K tomuto jedinečnému číslu je připojeno jiné zařízení, vyberte prosím nové číslo.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: Žádné jiné zařízení není spojeno s tímto unikátním číslem.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: Žádné jiné zařízení není spojeno s tímto unikátním číslem.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Paralelní status</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Paralelní status</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Adaptivní jas</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Adaptivní jas</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Jas</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Jas</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Doba zapnutí displeje</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Doba zapnutí displeje</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 sekund</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 sekund</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 sekund</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 sekund</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 minuta</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 minuta</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 minut</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 minut</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 minut</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 minut</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Nikdy</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Nikdy</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Režim zobrazení</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Režim zobrazení</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Tmavý</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Tmavý</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Světlý</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Světlý</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Stručné úrovně zobrazení</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Stručné úrovně zobrazení</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Jazyk</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Jazyk</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Změna jazyka</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Změna jazyka</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Zobrazení elektrického výkonu</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Zobrazení elektrického výkonu</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Výkon (ve wattech)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Výkon (ve wattech)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Proud (ampéry)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Proud (ampéry)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Jednotky</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Jednotky</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Úroveň %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Úroveň %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>°F</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>°F</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;UPOZORNĚNÍ:&lt;/b&gt; Před nastavením si přečtěte návod k obsluze.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;UPOZORNĚNÍ:&lt;/b&gt; Před nastavením si přečtěte návod k obsluze.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Limit nabíjecího napětí spravované baterie</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Limit nabíjecího napětí spravované baterie</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Maximální nabíjecí napětí:</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Maximální nabíjecí napětí:</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS – sdílený snímač napětí</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS – sdílený snímač napětí</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS – sdílený snímač teploty</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS – sdílený snímač teploty</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Nedostupný snímač, nastavte jiný</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Nedostupný snímač, nastavte jiný</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Nedostupný snímač, nastavte jiný</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Použitý senzor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Použitý senzor</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS – sdílený snímač proudu</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS – sdílený snímač proudu</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Stav SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Stav SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Deaktivováno (Externí ovládání)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Deaktivováno (Externí ovládání)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Deaktivováno (žádná nabíječka)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Deaktivováno (žádná nabíječka)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Deaktivováno (žádný monitor baterie)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Deaktivováno (žádný monitor baterie)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Automatický výběr</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Automatický výběr</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Žádné řízení BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Žádné řízení BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Kontrolní systém BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Kontrolní systém BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Není dostupný, nastavte jiný</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Není dostupný, nastavte jiný</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Automatická volba</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Automatická volba</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Žádný</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Datum a čas aktualizace</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Datum a čas aktualizace</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>On-line aktualizace</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>On-line aktualizace</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Instalace firmwaru z SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Instalace firmwaru z SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Úschova záložního firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Úschova záložního firmware</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Kontrola aktualizací na SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Kontrola aktualizací na SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Firmware nalezen</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Firmware nalezen</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instalace %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instalace %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Stiskněte pro aktualizaci %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Stiskněte pro aktualizaci %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Stiskněte pro aktualizaci %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Datum a čas instalace firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Datum a čas instalace firmware</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Automatická aktualizace</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Automatická aktualizace</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Pouze zkontrolovat</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Pouze zkontrolovat</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Pouze zkontrolovat a stáhnout</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Pouze zkontrolovat a stáhnout</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Zkontrolovat a aktualizovat</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Zkontrolovat a aktualizovat</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Zdroj aktualizace</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Zdroj aktualizace</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Typ zobrazení</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Typ zobrazení</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normální</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normální</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Velké</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Velké</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Provést kontrolu aktualizací</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Provést kontrolu aktualizací</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Je k dispozici aktualizace</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Je k dispozici aktualizace</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Instaluji %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Instaluji %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Instaluji %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Datum a čas aktualizace</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Datum a čas aktualizace</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Měniče</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Měniče</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Nalézt FV měniče</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Nalézt FV měniče</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Detekovány IP adresy</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Detekovány IP adresy</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Přidat IP adresu ručně</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Přidat IP adresu ručně</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>TCP port</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>TCP port</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Vícefázové</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Vícefázové</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Rozdělená fáze (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Rozdělená fáze (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Ukázat</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Ukázat</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Vyhledávání IP adres?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Vyhledávání IP adres?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Znovu vyhledat</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Znovu vyhledat</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH na LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH na LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Vzdálená podpora</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Vzdálená podpora</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Tunel vzdálené podpory</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Tunel vzdálené podpory</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>IP a port vzdálené podpory</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>IP a port vzdálené podpory</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Odhlásit se</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Restartovat nyní</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Restartovat nyní</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Zařízení bylo restartováno.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Akustický alarm</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Akustický alarm</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Demo režim</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Demo režim</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>Demo ESS</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>Demo ESS</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Demo pro loď / obytné auto 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Demo pro loď / obytné auto 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Demo pro loď / obytné auto 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Demo pro loď / obytné auto 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Spuštění demo režimu změní některá nastavení a uživatelské rozhraní nebude v dané chvíli reagovat.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Spuštění demo režimu změní některá nastavení a uživatelské rozhraní nebude v dané chvíli reagovat.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Podmínky</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Podmínky</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Minimální doba chodu</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Minimální doba chodu</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Doba zahřívání</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Doba zahřívání</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Doba ochlazení</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Doba ochlazení</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Prověřit generátor na AC vstupu</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Prověřit generátor na AC vstupu</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Žádný z AC vstupů není nastaven na generátor. Jdi na stránku systémového nastavení a nastav správný AC vstup na generátor pro umožnění této funkce.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Žádný z AC vstupů není nastaven na generátor. Jdi na stránku systémového nastavení a nastav správný AC vstup na generátor pro umožnění této funkce.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Alarm bude spuštěn pokud nebude zjištěn žádný výkon z generátor na AC vstupu. Ujistěte se že je nastaven správný AC vstup pro generátor v sekci systémového nastavení.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Alarm bude spuštěn pokud nebude zjištěn žádný výkon z generátor na AC vstupu. Ujistěte se že je nastaven správný AC vstup pro generátor v sekci systémového nastavení.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Počáteční čas nočního klidu</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Počáteční čas nočního klidu</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Koncový čas nočního klidu</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Koncový čas nočního klidu</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Doba provozu a servis</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Doba provozu a servis</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Resetovat čítače času denního chodu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Resetovat čítače času denního chodu</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Čítač denního chodu byl resetován</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Čítač denního chodu byl resetován</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Není možné upravit čítače, pokud je generátor v chodu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Není možné upravit čítače, pokud je generátor v chodu</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Servisní interval generátoru (v hodinách)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Servisní interval generátoru (v hodinách)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Servisní časový interval nastaven na %1h. Tlačítkem "Resetovat servisní časovač" resetujete servisní časovač.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Servisní časový interval nastaven na %1h. Tlačítkem &quot;Resetovat servisní časovač&quot; resetujete servisní časovač.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Resetování servisního časovače</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Resetování servisního časovače</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Nastavení GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Nastavení GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Formát</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Formát</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Jednotka rychlosti</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Jednotka rychlosti</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilometry za hodinu</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilometry za hodinu</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Metry za sekundu</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Metry za sekundu</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Mil za hodinu</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Mil za hodinu</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Uzlů</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Uzlů</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Není připojen žádný GSM modem</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Není připojen žádný GSM modem</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internetu</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internetu</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Operátor</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Operátor</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Níže na této stránce možná budete muset provést konfiguraci nastavení APN, pro podrobnější informace kontaktujte prosím svého operátora.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Níže na této stránce možná budete muset provést konfiguraci nastavení APN, pro podrobnější informace kontaktujte prosím svého operátora.
 Pokud to nefunguje, zkontrolujte kartu SIM v telefonu a ujistěte se, že na ní máte dostatečný kredit a / nebo že je registrována pro datové použití.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Povolit roaming</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Povolit roaming</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Stav Sim</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Stav Sim</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM není vložena</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM není vložena</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>Je vyžadován kód PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>Je vyžadován kód PIN</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>Je vyžadován kód PUK</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>Je vyžadován kód PUK</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Selhání SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Selhání SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM busy</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM busy</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Špatná SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Špatná SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Špatný kód PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Špatný kód PIN</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Připraveno</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Připraveno</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Neznámá chyba</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>Kód PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>Kód PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Tovární nastavení</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Tovární nastavení</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Použijte výchozí APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Použijte výchozí APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Název APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Název APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Použít autentizaci</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Použít autentizaci</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Jméno uživatele</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Jméno uživatele</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Vlastní spotřeba</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Vlastní spotřeba</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>ESS asistent nebyl nalezen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>ESS asistent nebyl nalezen</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Síťová měření</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Síťová měření</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Externí měřič</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Externí měřič</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Měnič / nabíječka</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Měnič / nabíječka</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Na AC výstupu měniče zátěž</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Na AC výstupu měniče zátěž</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Vícefázová regulace</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Vícefázová regulace</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Celkem všech fází</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Celkem všech fází</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Individuální fáze</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Individuální fáze</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Každá fáze je regulována tak, aby individuálně dosáhla žádané hodnoty sítě (účinnost systému se snižuje).
+        <translation>Každá fáze je regulována tak, aby individuálně dosáhla žádané hodnoty sítě (účinnost systému se snižuje).
 
 UPOZORNĚNÍ: Používejte pouze v případě, že to vyžaduje dodavatel elektrické energie.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Součet všech fází je inteligentně regulován tak, aby bylo dosaženo žádané hodnoty sítě (účinnost systému je optimalizována).
+        <translation>Součet všech fází je inteligentně regulován tak, aby bylo dosaženo žádané hodnoty sítě (účinnost systému je optimalizována).
 
 Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Neaktivní</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamická ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Minimální hodnota stavu nabití (síť přítomna)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Minimální hodnota stavu nabití (síť přítomna)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Aktuální hodnota limitu SOC</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Aktuální hodnota limitu SOC</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Udržování</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Nabíjení</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Špičkové holení</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Špičkové holení</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Pouze nad minimální SOC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Pouze nad minimální SOC</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Vždy</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Vždy</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Vybití deaktivováno</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Vybití deaktivováno</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Pomalé nabíjení</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Pomalé nabíjení</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Udržování</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Udržování</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Nabíjení</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Nabíjení</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Limit nabíjecího výkonu</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Limit nabíjecího výkonu</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Maximální nabíjecí výkon</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Maximální nabíjecí výkon</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Omezení výkonu měniče</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Omezení výkonu měniče</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Maximální odběr z baterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Maximální odběr z baterie</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Hodnota síťového odběru</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Hodnota síťového odběru</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Přívod do mřížky</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Přívod do mřížky</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>FV připojené k AC - dodávka přebytků do sítě</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>FV připojené k AC - dodávka přebytků do sítě</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>FV připojené k DC - dodávka přebytků do sítě</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>FV připojené k DC - dodávka přebytků do sítě</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Omezení dodávky do sítě systému</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Omezení dodávky do sítě systému</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Maximální dodávka do sítě</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Maximální dodávka do sítě</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Omezení dodávky do sítě je aktivní</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Omezení dodávky do sítě je aktivní</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Analogové vstupy</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Analogové vstupy</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Digitální vstupy</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Digitální vstupy</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Digitální vstup %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Digitální vstup %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Pulzní měřič</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Pulzní měřič</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Alarm dveří</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Alarm dveří</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Bilge pumpa</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Bilge pumpa</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Bilge alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Bilge alarm</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Alarm proti vloupání</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Alarm proti vloupání</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Alarm kouře</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Alarm kouře</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Požární alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Požární alarm</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>CO2 alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>CO2 alarm</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Bluetooth senzory</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Bluetooth senzory</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Všimněte si, že tyto funkce nejsou oficiálně podporovány společností Victron. V případě dotazů se prosím obraťte na stránky community.victronenergy.com.
+        <translation>Všimněte si, že tyto funkce nejsou oficiálně podporovány společností Victron. V případě dotazů se prosím obraťte na stránky community.victronenergy.com.
 
 Dokumentaci najdete na stránce https://ve3.nl/vol.</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Server Signál K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Server Signál K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Server Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Server Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Povoleno (bezpečný režim)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Povoleno (bezpečný režim)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Odloženo o %1 sekund</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Odloženo o %1 sekund</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID VRM portálu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID VRM portálu</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Interval načítání dat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Interval načítání dat</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 minut</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 minut</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 minut</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 minut</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 hodina</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 hodina</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 hodiny</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 hodiny</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 hodiny</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 hodiny</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 hodin</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 hodin</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 den</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 den</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Použití bezpečnostního připojení (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Použití bezpečnostního připojení (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Poslední kontakt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Poslední kontakt</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Neočekávaný text odpovědi</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Neočekávaný text odpovědi</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Neočekávaná odpověď HTTP</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Neočekávaná odpověď HTTP</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Časový limit připojení</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Časový limit připojení</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Chyba připojení</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Chyba připojení</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Selhání DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Selhání DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Chyba směrování</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Chyba směrování</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM není k dispozici</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM není k dispozici</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Neznámá chyba</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Neznámá chyba</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Chybová zpráva:
+        <translation>Chybová zpráva:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Restartovat zařízení, když nedochází ke kontaktu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Restartovat zařízení, když nedochází ke kontaktu</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Odložení resetování při nepřítomnosti kontaktu (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Odložení resetování při nepřítomnosti kontaktu (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Umístění paměti</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Umístění paměti</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Žádná vyrovnávací paměť není aktivní</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Žádná vyrovnávací paměť není aktivní</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Interní paměť</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Interní paměť</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Přenos</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Přenos</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Externí paměť</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Externí paměť</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Neznámá chyba</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Žádná chyba</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Žádná chyba</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>V paměti není žádné místo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>V paměti není žádné místo</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Chyba IO</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Chyba IO</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Chyba montáže</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Chyba montáže</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Obsahuje obrázek firmwaru. Nepoužívá se.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Obsahuje obrázek firmwaru. Nepoužívá se.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD karta / fleška není zapisovatelná</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD karta / fleška není zapisovatelná</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Volné místo na disku</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Volné místo na disku</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>bit</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>bit</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>byty</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>byty</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Uložené záznamy</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Uložené záznamy</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 záznamů</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 záznamů</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Nejstarší záznam</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Nejstarší záznam</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Aktivovat Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Aktivovat Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Žádné nahlášené chyby</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Žádné nahlášené chyby</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Čas zaznamenání poslední chyby</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Čas zaznamenání poslední chyby</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Dostupné služby</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Dostupné služby</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>ID jednotky: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>ID jednotky: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Funkce (relé 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Funkce (relé 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Funkce</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Funkce</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Alarmové relé</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Alarmové relé</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Čerpadlo nádrže</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuální</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polarita relé alarmu</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polarita relé alarmu</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normálně rozpojeno</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normálně rozpojeno</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normálně sepnuto</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normálně sepnuto</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relé 1 zapnuto</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relé 1 zapnuto</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relé zapnuto</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relé zapnuto</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Funkce (relé 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Funkce (relé 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relé 2 zapnuto</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relé 2 zapnuto</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Pravidla řízení teploty</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Pravidla řízení teploty</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Aktivace relé při teplotě</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Aktivace relé při teplotě</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Žádné relé není nakonfigurováno tak, aby bylo aktivováno teplotou. Přejděte na stránku nastavení relé, která se nachází v hlavní nabídce nastavení, a nastavte funkci relé na "Teplota".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Žádné relé není nakonfigurováno tak, aby bylo aktivováno teplotou. Přejděte na stránku nastavení relé, která se nachází v hlavní nabídce nastavení, a nastavte funkci relé na &quot;Teplota&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Tato volba umožňuje přepínat mezi aktuální a předchozí verzí firmwaru. Internet nebo SDkarta není nutná.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Tato volba umožňuje přepínat mezi aktuální a předchozí verzí firmwaru. Internet nebo SDkarta není nutná.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Stiskněte pro načtení</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Stiskněte pro načtení</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Restartování na %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Restartování na %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Přepnutí verze firmwaru není možné, pokud je automatická aktualizace nastavena na "Kontrola a aktualizace". Chcete-li tuto možnost povolit, nastavte automatickou aktualizaci na " Vypnuto" nebo "Pouze kontrola".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Přepnutí verze firmwaru není možné, pokud je automatická aktualizace nastavena na &quot;Kontrola a aktualizace&quot;. Chcete-li tuto možnost povolit, nastavte automatickou aktualizaci na &quot; Vypnuto&quot; nebo &quot;Pouze kontrola&quot;.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Záložní firmware není k dispozici</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Záložní firmware není k dispozici</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Panel na VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-bus přes TCP/IP (ladění)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-bus přes TCP/IP (ladění)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Napájení ze sítě</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Napájení ze sítě</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Vozidlo</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Vozidlo</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Loď</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Loď</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Název systému</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Název systému</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatický</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatický</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Síť</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatický</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Dle uživatele</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Dle uživatele</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Název definovaný uživatelem</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Název definovaný uživatelem</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>AC vstup 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>AC vstup 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>AC vstup 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>AC vstup 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Vyhledat selhání sítě</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Vyhledat selhání sítě</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Sledování odpojení od pobřežní sítě</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Sledování odpojení od pobřežní sítě</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Automaticky vybrané</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Automaticky vybrané</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Jsou přítomny DC spotřebiče</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Jsou přítomny DC spotřebiče</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Synchronizovat VE.Bus SOC s baterií</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Synchronizovat VE.Bus SOC s baterií</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Zlepšit SOC VE.Bus prostřednictvím solárního nabíjecího proudu</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Zlepšit SOC VE.Bus prostřednictvím solárního nabíjecího proudu</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Řízení napětí solárního regulátoru</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Řízení napětí solárního regulátoru</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Řízení proudu solárního regulátoru</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Řízení proudu solárního regulátoru</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS řízení</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS řízení</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS řízení</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Funkce spuštění/zastavení čerpadla nádrže není povolena. Přejděte do nastavení relé a nastavte funkci na "Čerpadlo nádrže".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Funkce spuštění/zastavení čerpadla nádrže není povolena. Přejděte do nastavení relé a nastavte funkci na &quot;Čerpadlo nádrže&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Stav čerpadla</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Stav čerpadla</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Čidlo nádrže</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Čidlo nádrže</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Úroveň startu</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Úroveň startu</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Úroveň zastavení</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Úroveň zastavení</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Ztráta připojení</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Ztráta připojení</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Odpojeno</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Odpojeno</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Skryté]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Skryté]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Připojit k síti?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Připojit k síti?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Připojení</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Připojení</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Zapomenutá síť?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Zapomenutá síť?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Zapomeňte na</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Zapomeňte na</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Opravdu chcete na tuto síť zapomenout?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Opravdu chcete na tuto síť zapomenout?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>Adresa MAC</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>Adresa MAC</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>IP konfigurace</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>IP konfigurace</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuální</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Vypnuto</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Fixní</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Fixní</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Maska sítě</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Maska sítě</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Brána</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Brána</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS server</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS server</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Link-local IP adresa</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Link-local IP adresa</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Pozor, pro systémy ESS a systémy se spravovanou baterií musí instance zařízení CAN-bus zůstat nakonfigurována na 0. Další informace naleznete v návodu zařízení GX.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Pozor, pro systémy ESS a systémy se spravovanou baterií musí instance zařízení CAN-bus zůstat nakonfigurována na 0. Další informace naleznete v návodu zařízení GX.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Instance zařízení</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Instance zařízení</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Síťová adresa</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Síťová adresa</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Zařízení VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Zařízení VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Zařízení# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Zařízení# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Žádné přístupové body</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Žádné přístupové body</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Není připojen žádný Wi-Fi adaptér</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Není připojen žádný Wi-Fi adaptér</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Vytvořit přístupový bod</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Vytvořit přístupový bod</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Wi-Fi sítě</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Wi-Fi sítě</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Opravdu chcete deaktivovat přístupový bod?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Opravdu chcete deaktivovat přístupový bod?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Datum a čas UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Datum a čas UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Místní datum a čas</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Místní datum a čas</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Časové pásmo</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Časové pásmo</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afrika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afrika</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Amerika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Amerika</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antartica</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antartica</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Artic</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Artic</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asie</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asie</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantik</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantik</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Austrálie</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Austrálie</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Evropa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Evropa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indie</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indie</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pacifik</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pacifik</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Atd</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Atd</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Nepřipojeno %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Nepřipojeno %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Restartovat nyní?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Restartovat nyní?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Změny instance VRM se použijí až po restartování zařízení.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Změny instance VRM se použijí až po restartování zařízení.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Zařízení se restartuje...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Zařízení se restartuje...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Zařízení bylo restartováno.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Zařízení bylo restartováno.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Alarm nízkého napětí baterie</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Alarm nízkého napětí baterie</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Alarm vysokého napětí baterie</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Alarm vysokého napětí baterie</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Poslední chyba</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Poslední chyba</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Předposlední chyba</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Předposlední chyba</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3. poslední chyba</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3. poslední chyba</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4. poslední chyba</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4. poslední chyba</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Paralelní chod</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Paralelní chod</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Nastavení režimu</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Nastavení režimu</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Samostatný</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Samostatný</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Samostatný</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Zátěž</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Zátěž</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Externí ovládání</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Nabíjet a HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Nabíjet a HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Nabíjet a BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Nabíjet a BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Externí ovládání a BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Externí ovládání a BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Nabíjet, Hub-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Nabíjet, Hub-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Nastavení masteru</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Nastavení masteru</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Podřízený</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Podřízený</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Podřízený</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Skupinový master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Skupinový master</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Master nabíjení</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Master nabíjení</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Master skupiny a nabíjení</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Master skupiny a nabíjení</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Nabíjecí napětí</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Nabíjecí napětí</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Reset</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Reset</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Řízení BMS se aktivuje automaticky, pokud je BMS přítomna. Resetujte, pokud se změnila konfigurace systému nebo pokud není přítomna žádná BMS.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Řízení BMS se aktivuje automaticky, pokud je BMS přítomna. Resetujte, pokud se změnila konfigurace systému nebo pokud není přítomna žádná BMS.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Celkový FV výkon</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Zátěž</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Zátěž</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>Nalezeno %1</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>Nalezeno %1</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Historie</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Historie</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Historie</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Paralelní fungování</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Paralelní fungování</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Zobrazení tabulky</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Zobrazení tabulky</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Graf</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Graf</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Upozornění</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Upozornění</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarm</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Objem</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Objem</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Zkrat</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Zkrat</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Obrácená polarita</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Obrácená polarita</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Nabíjecí stanice pro elektromobily</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Nabíjecí stanice pro elektromobily</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Relace</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Relace</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Čas</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Čas</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Režim nabíjení</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Režim nabíjení</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Proces můžete spustit a zastavit sami. Tuto funkci použijte pro rychlé nabíjení a pečlivé sledování.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Proces můžete spustit a zastavit sami. Tuto funkci použijte pro rychlé nabíjení a pečlivé sledování.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Spouští a zastavuje se podle úrovně nabití baterie. Optimální pro noční a dlouhodobé nabíjení, aby se zabránilo přebíjení.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Spouští a zastavuje se podle úrovně nabití baterie. Optimální pro noční a dlouhodobé nabíjení, aby se zabránilo přebíjení.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Nižší sazby za elektřinu v době mimo špičku nebo pokud chcete mít jistotu, že bude váš elektromobil v určitou dobu plně nabitý a připravený k jízdě.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Nižší sazby za elektřinu v době mimo špičku nebo pokud chcete mít jistotu, že bude váš elektromobil v určitou dobu plně nabitý a připravený k jízdě.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Povolit nabíjení</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Povolit nabíjení</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Zámek displeje nabíječky</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Zámek displeje nabíječky</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Adresa zdroje</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Adresa zdroje</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Nastavení</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Nastavení</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Instance řádku #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Instance řádku #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Instance linky</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Instance linky</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Instance nabíječky</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Instance nabíječky</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Instance invertoru</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Instance invertoru</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Zdroj DC #%1 instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Zdroj DC #%1 instance</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Instance zdroje stejnosměrného proudu</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Instance zdroje stejnosměrného proudu</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Zdroj stejnosměrného proudu #%1 priorita</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Zdroj stejnosměrného proudu #%1 priorita</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Priorita zdroje stejnosměrného proudu</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Priorita zdroje stejnosměrného proudu</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Instance nádrže</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Instance nádrže</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Zařízení RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Zařízení RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Povolení vizualizéru snímkové frekvence</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Povolení vizualizéru snímkové frekvence</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Není podporováno</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Není podporováno</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Odstranit odpojená zařízení</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Odstranit odpojená zařízení</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Detekováno nepodporované zařízení</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Detekováno nepodporované zařízení</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Funkce relé</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Funkce relé</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Spuštění/zastavení nabíječky nebo generátoru</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Spuštění/zastavení nabíječky nebo generátoru</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Ruční řízení</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Spálená pojistka</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Ruční řízení</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Ruční řízení</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Vždy otevřeno (nepoužívat relé)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Vždy otevřeno (nepoužívat relé)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Všimněte si, že změnou nastavení nízkého stavu nabití se změní také nastavení dolní meze doby vybíjení v nabídce baterie.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Všimněte si, že změnou nastavení nízkého stavu nabití se změní také nastavení dolní meze doby vybíjení v nabídce baterie.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Spálená pojistka</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Spálená pojistka</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Stavové LED kontrolky</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Stavové LED kontrolky</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Žádný</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Hlavní spínač</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Hlavní spínač</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Ohřev</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Ohřev</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Vnitřní ventilátor</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Vnitřní ventilátor</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Varovací ikony</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Varovací ikony</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Alarmové ikony</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Alarmové ikony</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Spínač</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Spínač</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Inicializace</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Inicializace</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Vypnutí</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Vypnutí</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Aktualizace</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Aktualizace</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Uvedení do chodu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Uvedení do chodu</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Předběžné nabíjení</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Předběžné nabíjení</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Kontrola stykače</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Kontrola stykače</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Stav životnosti</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Stav životnosti</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Teplota baterie</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Teplota baterie</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Teplota vzduchu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Teplota vzduchu</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Napětí startovací baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Napětí startovací baterie</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Napětí sběrnice</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Napětí sběrnice</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Napětí horní sekce</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Napětí horní sekce</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Chyba komunikace</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Stav životnosti</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Napětí sběrnice</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Napětí spodní sekce</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Napětí spodní sekce</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Středová odchylka</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Středová odchylka</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Spotřebované ampérhodiny</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Spotřebované ampérhodiny</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Zbývající čas</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Zbývající čas</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Detaily</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Detaily</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarmy na úrovni modulu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarmy na úrovni modulu</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnostika</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostika</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Pojistky</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Pojistky</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>Systém</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>Systém</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parametry</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parametry</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Opakovat detekci baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Opakovat detekci baterie</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Stisknout</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Stisknout</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Stisknout</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Detekce baterie může trvat až 60 sekund. Během tohoto procesu může být název baterie nesprávný.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Detekce baterie může trvat až 60 sekund. Během tohoto procesu může být název baterie nesprávný.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Vysoký nabíjecí proud</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Vysoký nabíjecí proud</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Vysoký vybíjecí proud</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Vysoký vybíjecí proud</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Nízký stav nabití baterie</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Nízký stav nabití baterie</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Vysoké napětí baterie</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Nízký stav nabití baterie</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Nízké napětí startovací baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Nízké napětí startovací baterie</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Vysoké napětí startovací baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Vysoké napětí startovací baterie</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Čidlo teploty baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Čidlo teploty baterie</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Střední napětí</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Střední napětí</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Spálená pojistka</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Vysoká vnitřní teplota</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Vysoká vnitřní teplota</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Teplota nízkého stavu nabití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Teplota nízkého stavu nabití</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Teplota vysokého stavu nabití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Teplota vysokého stavu nabití</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Vnitřní chyba</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Vnitřní chyba</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Vypnutí jističe</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Vypnutí jističe</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Nevyrovnané články</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Nevyrovnané články</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Nízké napětí článku</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Nízké napětí článku</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Nejnižší napětí článku</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Nejnižší napětí článku</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Nejvyšší napětí článku</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Nejvyšší napětí článku</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Minimální teplota článku</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Minimální teplota článku</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Maximální teplota článku</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Maximální teplota článku</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Moduly baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Moduly baterie</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Počet modulů blokujících nabíjení / vybíjení</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Počet modulů blokujících nabíjení / vybíjení</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Instalovaná / dostupná kapacita</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Instalovaná / dostupná kapacita</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Nejhlubší vybití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Nejhlubší vybití</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Poslední vybití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Poslední vybití</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Průměrné vybití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Průměrné vybití</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Celkový počet nabíjecích cyklů</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Celkový počet nabíjecích cyklů</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Počet kompletních vybití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Počet kompletních vybití</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Celková spotřeba Ah</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Celková spotřeba Ah</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Minimální napětí článků</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Minimální napětí článků</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Maximální napětí článků</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Maximální napětí článků</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Doba od posledního plného nabití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Doba od posledního plného nabití</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Počet synchronizací</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Počet synchronizací</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarmy nízkého napětí startovací baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarmy nízkého napětí startovací baterie</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Minimální napětí startovací baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Minimální napětí startovací baterie</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Maximální napětí startovací baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Maximální napětí startovací baterie</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Vybitá energie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Vybitá energie</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Nabitá energie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Nabitá energie</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Limit nabíjecího napětí (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Limit nabíjecího napětí (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Limit nabíjecího proudu (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Limit nabíjecího proudu (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Limit vybíjecího proudu (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Limit vybíjecího proudu (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Odpojení při nízkém napětí (vždy ignorováno)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Odpojení při nízkém napětí (vždy ignorováno)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>PowerBanka</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>PowerBanka</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relé (na monitoru baterie)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relé (na monitoru baterie)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Obnovit standardní tovární nastavení</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Obnovit standardní tovární nastavení</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Stisknout pro obnovu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Stisknout pro obnovu</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Obnovení továrního nastavení?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Obnovení továrního nastavení?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth povoleno</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth povoleno</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Jmenovité napětí</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Jmenovité napětí</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 V</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 V</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 voltů</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 voltů</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 voltů</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 voltů</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Kapacita</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Kapacita</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapacita</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Napětí nabité baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Napětí nabité baterie</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Zbytkový proud</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Zbytkový proud</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Doba detekce nabití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Doba detekce nabití</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Peukertův exponent</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Peukertův exponent</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Faktor účinnosti nabití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Faktor účinnosti nabití</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Prahová hodnota proudu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Prahová hodnota proudu</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Průměrovací doba zbývajícího času</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Průměrovací doba zbývajícího času</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Zbývající čas do vybití</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Zbývající čas do vybití</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Kompenzace proudu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Kompenzace proudu</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Synchronizovat stav nabití na 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Synchronizovat stav nabití na 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Stisknout pro synchronizaci</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Stisknout pro synchronizaci</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Kalibrovat nulový proud</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Kalibrovat nulový proud</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Stisknout pro nastavení 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Stisknout pro nastavení 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Rozvaděč %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Rozvaděč %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Na sběrnicové liště není napájení</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Na sběrnicové liště není napájení</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Ztráta připojení</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
-        <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
-        <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
-        <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
+            <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
+            <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Nejsou k dispozici žádné informace, stav rozvaděče viz předchozí strana.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Nejsou k dispozici žádné informace, stav rozvaděče viz předchozí strana.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Pojistka %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Pojistka %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Nepoužívá se</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Nepoužívá se</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Přepálené</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Přepálené</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Zastavení provozu z důvodu chyby</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Zastavení provozu z důvodu chyby</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Poslední chyba</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">Předposlední chyba</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">3. poslední chyba</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">4. poslední chyba</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Spuštění systému</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Spuštění systému</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Externí relé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Externí relé</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Nastavitelný kontakt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Nastavitelný kontakt</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Baterie</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Baterie</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapacita</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Baterie</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Paralelně</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Paralelně</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>V sérii</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>V sérii</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Min/max napětí článku</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Min/max napětí článku</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Min/max teplota článku</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Min/max teplota článku</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Vyrovnávání</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Vyrovnávání</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Vyrovnávání</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Neznámý</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Výstup</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Výstup</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Polní pohon</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Polní pohon</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Otáčky motoru</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Otáčky motoru</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Pomocné napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Pomocné napětí</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Žádné alarmy</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Žádné alarmy</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Nízké napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Nízké napětí</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Vysoké napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Vysoké napětí</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Nízké pomocné napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Nízké pomocné napětí</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Vysoké pomocné napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Vysoké pomocné napětí</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Alarm nízkého pomocného napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Alarm nízkého pomocného napětí</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Alarm vysokého pomocného napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Alarm vysokého pomocného napětí</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Minimální pomocné napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Minimální pomocné napětí</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Maximální pomocné napětí</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Maximální pomocné napětí</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Vyrobená energie</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Vyrobená energie</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Spotřebovaná energie</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Spotřebovaná energie</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Aktivace alarmu</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Aktivace alarmu</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Aktivní úroveň</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Aktivní úroveň</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Úroveň pro obnovení</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Úroveň pro obnovení</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Prodleva</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Prodleva</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Úroveň</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Úroveň</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Zbývající</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Zbývající</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Bateriový senzor</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Bateriový senzor</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Bateriový senzor</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Typ čidla</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Typ čidla</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Tovární nastavení</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Tovární nastavení</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Evropský (0 až 180 Ohmů)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Evropský (0 až 180 Ohmů)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>US (240 až 30 Ohmů)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>US (240 až 30 Ohmů)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Vlastní</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Vlastní</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Vlastní</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Hodnota čidla, když je nádrž prázdná</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Hodnota čidla, když je nádrž prázdná</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Druh kapaliny</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Druh kapaliny</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Poměr butanu</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Poměr butanu</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Vlastní tvar</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Vlastní tvar</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Průměrný čas</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Průměrný čas</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Hodnota čidla</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Hodnota čidla</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Není definován žádný vlastní tvar. Můžete definovat jeden s maximálně deseti body. Všimněte si, že 0 % a 100 % jsou implicitní.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Není definován žádný vlastní tvar. Můžete definovat jeden s maximálně deseti body. Všimněte si, že 0 % a 100 % jsou implicitní.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Bod %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Bod %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Přidat bod</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Přidat bod</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Úroveň snímače</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Úroveň snímače</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Objem</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Duplicitní hodnoty úrovně snímače nejsou povoleny.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Duplicitní hodnoty úrovně snímače nejsou povoleny.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Hodnoty objemu se musí zvyšovat.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Hodnoty objemu se musí zvyšovat.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Hlídací pes</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Hlídací pes</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Odemčeno (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Odemčeno (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Odemčeno (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Odemčeno (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Odemčeno (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Odemčeno (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Uzamčeno</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Uzamčeno</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Nastavení fáze</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Nastavení fáze</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Poloha spínače</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Poloha spínače</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Jedna fáze</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2 fáze</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2 fáze</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3 fáze</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3 fáze</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Zařízení</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Rychlost</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Zátěž</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Teplota chladicí kapaliny</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Teplota chladicí kapaliny</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Teplota výfuku</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Teplota výfuku</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Teplota větru</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Teplota větru</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Napětí startovací baterie</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Napětí startovací baterie</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Počet startů</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Počet startů</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS řízení</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Přední volič je zablokován (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Přední volič je zablokován (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Žádná chyba (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Žádná chyba (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC celkem</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC celkem</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energie L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energie L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Fázová sekvence</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Fázová sekvence</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Verze správce dat</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Verze správce dat</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Žádný</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Blikající LED indikuje tento CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Blikající LED indikuje tento CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Smappee sběrnice zařízení</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Smappee sběrnice zařízení</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>FV regulátor</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>FV regulátor</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Toto nastavení je vypnuto, pokud je připojen digitální multifunkční ovladač.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Toto nastavení je vypnuto, pokud je připojen digitální multifunkční ovladač.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Toto nastavení je zakázáno, pokud je připojena sběrnicová jednotka BMS VE.Bus.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Toto nastavení je zakázáno, pokud je připojena sběrnicová jednotka BMS VE.Bus.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC v %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC v %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Invertovaný</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Invertovaný</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Aktivace alarmu</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Invertovaný</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Invert. logiku alarmu</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Invert. logiku alarmu</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Ozáření</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Ozáření</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Teplota článku</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Teplota článku</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Vnější teplota (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Vnější teplota (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Vnější teplota</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Vnější teplota</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Vnější teplota (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Vnější teplota (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Rychlost větru</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Rychlost větru</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Automatická detekce</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Automatická detekce</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Měřič rychlosti větru</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Měřič rychlosti větru</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Externí teplotní čidlo</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Externí teplotní čidlo</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Sdružený</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Sdružený</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Násobený</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Násobený</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Reset počítání</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Reset počítání</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Zkrat</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Obrácená polarita</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Nízký stav baterie snímače</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Nízký stav baterie snímače</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Vlhkost</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Vlhkost</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Tlak</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Tlak</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Nízko</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Korekce</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Korekce</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Měřítko</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Měřítko</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Napětí snímače</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Napětí snímače</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Celkový FV výkon</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Celkový FV výkon</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Stránka produktu</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Stránka produktu</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Snímač střídavého proudu %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Snímač střídavého proudu %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>K dispozici je nová verze MK3.
+        <translation>K dispozici je nová verze MK3.
 POZNÁMKA: Aktualizace může dočasně zastavit systém.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Aktualizace MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Aktualizace MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Stiskněte tlačítko pro aktualizaci</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Stiskněte tlačítko pro aktualizaci</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Aktualizuji MK3, hodnoty se znovu objeví po dokončení aktualizace.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Aktualizuji MK3, hodnoty se znovu objeví po dokončení aktualizace.</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Nabíjení baterie na 100 %</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Nabíjení baterie na 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Nabíjení baterie na 100 %</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Pokročilé</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>Probíhá</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>Probíhá</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Stisknutím zastavíte</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Stisknutím zastavíte</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Stiskněte pro start</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Stiskněte pro start</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Nabijte baterii na 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Nabijte baterii na 100 %</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Systém se vrátí do normálního provozu a upřednostní obnovitelné zdroje energie.
+        <translation>Systém se vrátí do normálního provozu a upřednostní obnovitelné zdroje energie.
 Chcete pokračovat?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Pokud je k dispozici, použije se energie z pobřeží a možnost "Solar &amp; wind priority" se ignoruje.
+        <translation>Pokud je k dispozici, použije se energie z pobřeží a možnost &quot;Solar &amp; wind priority&quot; se ignoruje.
 Chcete pokračovat?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>K jednorázovému úplnému nabití akumulátoru se použije energie z břehu.
+        <translation>K jednorázovému úplnému nabití akumulátoru se použije energie z břehu.
 Po dokončení nabíjení se systém vrátí k normálnímu provozu a upřednostní solární a větrnou energii.
 Chcete pokračovat?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>DC napětí</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>DC napětí</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>DC proud</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>DC proud</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Pokročilé</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Pokročilé</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Nastavení alarmu</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Nastavení alarmu</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>VE.Bus BMS automaticky vypne systém, pokud je nutné ochránit baterii. Řízení systému z Color Control není proto možné.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>VE.Bus BMS automaticky vypne systém, pokud je nutné ochránit baterii. Řízení systému z Color Control není proto možné.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>BMS assistent je nainstalován a nakonfigurován for VE.Bus BMS, ale VE.Bus BMS není nalezeno!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>BMS assistent je nainstalován a nakonfigurován for VE.Bus BMS, ale VE.Bus BMS není nalezeno!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Varování: Aktivace vyrovnávání v systému ESS zahrnujícím solární nabíječky může způsobit nabíjení baterie při vysokém napětí a příliš vysokým proudem.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Varování: Aktivace vyrovnávání v systému ESS zahrnujícím solární nabíječky může způsobit nabíjení baterie při vysokém napětí a příliš vysokým proudem.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Systém se automaticky přepne na režim plovoucího nabíjení, jakmile bude dokončena fáze vyrovnávacího nabíjení.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Systém se automaticky přepne na režim plovoucího nabíjení, jakmile bude dokončena fáze vyrovnávacího nabíjení.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Přerušit vyrovnávání</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Přerušit vyrovnávání</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Vyrovnávání</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Vyrovnávání</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Probíhá přerušení...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Probíhá přerušení...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Spouštím...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Spouštím...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Spouštím...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Stiskněte pro přerušení</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Stiskněte pro přerušení</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Přerušit a restartovat absorpční nabíjení</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Přerušit a restartovat absorpční nabíjení</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Přerušit a přejít do režimu plovoucího nabíjení</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Přerušit a přejít do režimu plovoucího nabíjení</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Přerušit</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Přerušit</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Nepřerušovat</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Nepřerušovat</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>RedetekceVE.Bus systému</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>RedetekceVE.Bus systému</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Opakování detekce...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Opakování detekce...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Restartujte systém VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Restartujte systém VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Restartuji...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Restartuji...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Stisknutím tlačítka restartujte</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Stisknutím tlačítka restartujte</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>AC vstup 1 ignorován</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>AC vstup 1 ignorován</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>AC vstup 2 ignorován</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>AC vstup 2 ignorován</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Kontrola ESS relé</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Kontrola ESS relé</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Hotovo</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Čekající</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Hotovo</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Hotovo</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Čekající</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Čekající</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Diagnostika VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Diagnostika VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Čítač kvality sítě Fáze L%1, zařízení %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Čítač kvality sítě Fáze L%1, zařízení %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>Hlášení VE.Bus Error 8 / 11</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>Hlášení VE.Bus Error 8 / 11</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Pouze alarm</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Pouze alarm</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarmy a upozornění</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarmy a upozornění</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Chyba BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Chyba BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Výrobní čísla</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Výrobní čísla</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Poslední hlášení VE.Bus Error 11 #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Poslední hlášení VE.Bus Error 11 #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Probíhající bezpečnostní test BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Probíhající bezpečnostní test BF</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Bezpečnostní test BF OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Bezpečnostní test BF OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Nesoulad AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Nesoulad AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Chyba komunikace</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Chyba komunikace</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>Chyba relé GND</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>Chyba relé GND</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Nesoulad UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Nesoulad UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Období Časový nesoulad</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Období Časový nesoulad</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Nesoulad pohonu relé BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Nesoulad pohonu relé BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Chyba: PE2 otevřen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Chyba: PE2 otevřen</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Chyba: PE2 uzavřen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Chyba: PE2 uzavřen</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Neúspěšný krok: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Neúspěšný krok: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Fáze L%1, zařízení %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Fáze L%1, zařízení %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Odesílání chybových zpráv VE.Bus Error 11 vyžaduje VE.Bus firmware minimálně verze 454.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Odesílání chybových zpráv VE.Bus Error 11 vyžaduje VE.Bus firmware minimálně verze 454.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus Quirks</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus Quirks</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energie</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energie</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Výkon</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Výkon</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Napětí</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Napětí</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Proud</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Proud</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>umístění</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>umístění</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Fáze</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Fáze</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Aktivní AC vstup</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Aktivní AC vstup</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Vysoké DC zvlnění</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Vysoké DC zvlnění</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Vysoké DC napětí</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Vysoké DC napětí</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Vysoký DC proud</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Vysoký DC proud</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Chyba teplotního čidla</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Chyba teplotního čidla</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Chyba čidla napětí</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Chyba čidla napětí</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Přetížení</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Přetížení</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>DC zvlnění</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>DC zvlnění</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Čidlo napětí</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Čidlo napětí</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Otáčení fáze</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Otáčení fáze</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Otáčení fáze</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Verze VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Verze VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2 zařízení</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2 zařízení</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Verze MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Verze MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Verze Multi Control</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Verze Multi Control</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Verze VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Verze VE.Bus BMS</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Pokud síť neselže</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Pokud síť neselže</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>AC In</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>AC In</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC VSTUP</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC VSTUP</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>AC vstup 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>AC vstup 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>AC vstup 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>AC vstup 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Role</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Role</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC zatěž</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC zatěž</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>AC Out</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>AC Out</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>AC výstup</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>AC výstup</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Fáze střídavého proudu L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Fáze střídavého proudu L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Senzor střídavého proudu %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Senzor střídavého proudu %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Senzory střídavého proudu</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Senzory střídavého proudu</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Aktivní</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Aktivní</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Přetížení</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Stav alarmu</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Stav alarmu</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarmy</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarmy</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Povolit nabíjení</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Povolit nabíjení</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Povolit vybíjení</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Povolit vybíjení</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Automatické skenování</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Automatické skenování</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Baterie</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Baterie</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>proud baterie</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>proud baterie</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Napětí baterie</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Napětí baterie</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Nabíjecí proud</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Nabíjecí proud</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Nabíjení</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Nabíjení</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Zrušení chyby</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Zrušení chyby</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Sepnuto</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Sepnuto</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Připojeno</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Připojeno</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Proud</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Proud</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Proudové transformátory</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Proudové transformátory</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Vlastní název</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Vlastní název</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Odladit</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Odladit</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Zařízení</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Zařízení</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deaktivováno</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>vybíjení</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>vybíjení</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Odpojeno</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Odpojeno</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Aktivovat</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Aktivovat</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Aktivováno</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Aktivováno</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energie</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energie</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Chyba</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Chyba</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Chyba:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Chyba:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Kód chyby</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Kód chyby</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Verze firmwaru</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Verze firmwaru</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generátor</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generátor</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Vysoká teplota baterie</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Vysoká teplota baterie</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Alarm vysoké úrovně</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Alarm vysoké úrovně</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Vysoké napětí startovací baterie</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Vysoké napětí startovací baterie</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Vysoká teplota</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Vysoká teplota</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Alarmy vysokého napětí</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Alarmy vysokého napětí</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Historie</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Historie</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Hodina(y)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Hodina(y)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Nečinný</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Nečinný</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Neaktivní</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Neaktivní</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Měnič / nabíječka</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP adresa</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP adresa</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Nízká teplota baterie</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Nízká teplota baterie</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Alarm nízké úrovně</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Alarm nízké úrovně</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Nízké napětí startovací baterie</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Nízké napětí startovací baterie</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Nízká úroveň nabití</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Nízká úroveň nabití</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Nízká teplota</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Nízká teplota</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Alarmy nízkého napětí</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Alarmy nízkého napětí</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Výrobce</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Výrobce</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Maximální teplota</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Maximální teplota</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Maximální napětí</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Maximální napětí</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Minimální teplota</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Minimální teplota</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Minimální napětí</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Minimální napětí</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Režim</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Režim</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Název modelu</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Název modelu</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Ne</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Ne</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Žádná chyba</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Žádná chyba</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Není k dispozici</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Není k dispozici</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Nepřipojeno</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Nepřipojeno</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Offline</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Offline</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>Ok</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>Ok</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Zapnuto</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Zapnuto</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Rozpojeno</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Rozpojeno</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Heslo</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Heslo</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Fáze</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Fáze</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Stiskněte pro odstranění</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Stiskněte pro odstranění</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Stisknout pro resetování</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Stisknout pro resetování</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Stisknout pro skenování</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Stisknout pro skenování</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>FV měnič</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>FV měnič</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>FV výkon</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>FV výkon</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Noční klid</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Noční klid</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relé</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relé</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Restart</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Restart</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Odstranit</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Odstranit</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>Chod</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>Chod</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Skenování %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Skenování %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Výrobní číslo</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Výrobní číslo</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Nastavení</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Nastavení</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Nastavení</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Nastavení</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Síla signálu</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Síla signálu</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Standby</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Standby</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Spuštění po dosažení podmínek pro</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Spuštění po dosažení podmínek pro</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Čas spuštění</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Čas spuštění</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Spouštěcí hodnota během doby klidu</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Spouštěcí hodnota během doby klidu</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Spustit, když je aktivní varování pro</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Spustit, když je aktivní varování pro</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Stav nabití</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Stav nabití</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Stav</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Stav</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Spuštění (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Spuštění (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Hodnota zastavení v době klidu</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Hodnota zastavení v době klidu</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Zastavit po dosažení podmínek pro</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Zastavit po dosažení podmínek pro</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Zastavený</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Zastavený</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Teplota</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Teplota</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Teplotní snímač</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Teplotní snímač</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Dnes</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Dnes</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Celkem</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Celkem</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Monitorování</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Monitorování</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Typ</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Typ</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Unikátní identifikační číslo</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Unikátní identifikační číslo</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Neznámý</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Neznámý</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>VE.Bus chyba</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>VE.Bus chyba</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Napětí</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Napětí</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Připojení k VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Připojení k VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Po vymazání varování, zastavit po</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Po vymazání varování, zastavit po</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Ano</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Ano</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Včera</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Včera</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Výnos</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Výnos</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Zero feed-in mezní výkon</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Zero feed-in mezní výkon</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Stanovené datum</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Stanovené datum</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Začněte nyní</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Začněte nyní</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Časovaný běh</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Časovaný běh</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Zastavte se</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Zastavte se</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Celková doba chodu</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Celková doba chodu</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Nastavit čas %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Nastavit čas %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Generátor bude pokračovat v provozu, pokud je splněna podmínka automatického spuštění.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Generátor bude pokračovat v provozu, pokud je splněna podmínka automatického spuštění.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Režim měniče / nabíječky</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Režim měniče / nabíječky</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Nastavit</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Nastavit</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Zrušit</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Zrušit</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Zavřít</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Zavřít</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Nastavený čas</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Nastavený čas</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Již se používá</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Již se používá</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Chyba výměny</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Chyba výměny</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Výměna dokončena</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Výměna dokončena</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Výměna instancí zařízení...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Výměna instancí zařízení...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Instance zařízení %1 je již používána zařízením '%3'. Vyměnit instance zařízení a přiřadit je k %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Instance zařízení %1 je již používána zařízením &apos;%3&apos;. Vyměnit instance zařízení a přiřadit je k %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Instance zařízení %1 je již používána jiným zařízením stejného typu. Vyměnit instance zařízení a přiřadit je k %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Instance zařízení %1 je již používána jiným zařízením stejného typu. Vyměnit instance zařízení a přiřadit je k %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Nelze vyměnit instance zařízení: operace vypršela.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Nelze vyměnit instance zařízení: operace vypršela.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Nové instance zařízení budou při restartu aktivní.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Nové instance zařízení budou při restartu aktivní.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Výměna</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Výměna</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Chyba při kontrole aktualizací firmwaru</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Chyba při kontrole aktualizací firmwaru</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Stahuji a instaluji firmware %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Stahuji a instaluji firmware %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Instaluji firmware...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Instaluji firmware...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Chyba při instalaci firmwaru</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Chyba při instalaci firmwaru</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Není k dispozici novější verze</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Není k dispozici novější verze</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Žádný firmaware nenalezen</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Žádný firmaware nenalezen</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Palivo</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Palivo</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Čistá voda</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Čistá voda</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Odpadní voda</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Odpadní voda</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Nádrž na vodu</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Nádrž na vodu</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Olej</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Olej</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>SPLAŠKY</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>SPLAŠKY</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzín</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzín</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Nafta</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Nafta</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Hydraulický olej</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Hydraulický olej</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Surová voda</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Surová voda</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Nastavení uzamčené úrovně přístupu</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Nastavení uzamčené úrovně přístupu</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Chybné heslo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Chybné heslo</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Krátce</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Krátce</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Přehled</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Přehled</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Úrovně</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Úrovně</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Oznámení</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Oznámení</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>nyní</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>nyní</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>Před %1m</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>Před %1m</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>před %1h %2m</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>před %1h %2m</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Každý den</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Každý den</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Pracovní dny</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Pracovní dny</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Víkendy</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Víkendy</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Pondělí</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Pondělí</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Úterý</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Úterý</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Středa</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Středa</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Čtvrtek</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Čtvrtek</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Pátek</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Pátek</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Sobota</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Sobota</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Neděle</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Neděle</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 nebo %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 nebo %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Rozvrh %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Rozvrh %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Den</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Den</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Není nastaveno</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Není nastaveno</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Limit stavu nabití</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Limit stavu nabití</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Vlastní spotřeba překračuje stanovený limit</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Vlastní spotřeba překračuje stanovený limit</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">FV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>FV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>FV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>Fotovoltaické panely a baterie</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>Fotovoltaické panely a baterie</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Kontrola...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Kontrola...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Stav alarmu</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Stav alarmu</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Vymazat historii</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Vymazat historii</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Odstraňování</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Odstraňování</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Vynucené zapnutí</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Vynucené zapnutí</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Vynucené vypnutí</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Vynucené vypnutí</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Stav relé</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Stav relé</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Obnovení historie na samotném monitoru</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Obnovení historie na samotném monitoru</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Stisknout pro vysunutí</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Stisknout pro vysunutí</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Probíhá vysunutí, čekejte prosím</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Probíhá vysunutí, čekejte prosím</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Nebyla nalezena žádná paměť</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Nebyla nalezena žádná paměť</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 teplotní čidlo</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 teplotní čidlo</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>Snímač teploty %1 (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>Snímač teploty %1 (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Snímač teploty (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Snímač teploty (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Nic neprovádět</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Nic neprovádět</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Varování: Teploty aktivace a deaktivace jsou nastaveny na stejnou hodnotu. To vede k ignorování podmínky.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Varování: Teploty aktivace a deaktivace jsou nastaveny na stejnou hodnotu. To vede k ignorování podmínky.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Stav %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Stav %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Funkce deaktivována</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Funkce deaktivována</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Žádné (zakázat)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Žádné (zakázat)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relé 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relé 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relé 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relé 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Varování: Výše vybrané relé není nastaveno na teplotu, tato podmínka bude ignorována.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Varování: Výše vybrané relé není nastaveno na teplotu, tato podmínka bude ignorována.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Hodnota pro aktivaci</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Hodnota pro aktivaci</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Jednotka objemu</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Jednotka objemu</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Metry krychlové</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Metry krychlové</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Litry</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Litry</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Galony (USA)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Galony (USA)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Galony (Imperial)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Galony (Imperial)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Minimální napětí</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Minimální napětí</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Maximální napětí</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Maximální napětí</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Maximální napětí</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Maximální proud</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Maximální proud</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Doba nabíjení</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Doba nabíjení</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Rychlé nabíjení (bulk)</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Udržování</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Rychlé nabíjení (bulk)</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Rychlé nabíjení (bulk)</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Udržování</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Udržování</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>hr</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>hr</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>Vyskytly se chyby %1</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>Vyskytly se chyby %1</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Zátěž</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Zátěž</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2. poslední</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2. poslední</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3. poslední</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3. poslední</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4. poslední</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4. poslední</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Maximální výkon</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Maximální výkon</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Nelze se připojit</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Nelze se připojit</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Odpojeno, pokus o opětovné připojení</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Odpojeno, pokus o opětovné připojení</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Připojení</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Připojení</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Připojení</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Připojeno, čeká na zprávy zprostředkovatele</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Připojeno, čeká na zprávy zprostředkovatele</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Připojeno, příjem zpráv od zprostředkovatele</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Připojeno, příjem zpráv od zprostředkovatele</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Připojené, načítání uživatelského rozhraní</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Připojené, načítání uživatelského rozhraní</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Nesprávná verze protokolu</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Nesprávná verze protokolu</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>ID klienta odmítnuto</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>ID klienta odmítnuto</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Zprostředkovatelská služba není k dispozici</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Zprostředkovatelská služba není k dispozici</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Špatné uživatelské jméno nebo heslo</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Špatné uživatelské jméno nebo heslo</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Klient není oprávněn</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Klient není oprávněn</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Chyba dopravního spojení</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Chyba dopravního spojení</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Chyba při porušení protokolu</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Chyba při porušení protokolu</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Chyba protokolu MQTT úrovně 5</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Chyba protokolu MQTT úrovně 5</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Vypnutí alarmu</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Vypnutí alarmu</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Celkový výkon</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Celkový výkon</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>Min.</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>Min.</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0 m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0&#xa0;m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Porucha</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Porucha</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Získávám IP adresu</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Získávám IP adresu</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Připojeno</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Odpojit</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Odpojit</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Odpojeno</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC zátěž</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC zátěž</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>DC zátěže</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>DC zátěže</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Vítr</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Vítr</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Pobřežní přípojka</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Pobřežní přípojka</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Omezení proudu v síti</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Omezení proudu v síti</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Omezení proudu generátoru</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Omezení proudu generátoru</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Břehový proudový limit</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Břehový proudový limit</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Zastavení</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Zastavení</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Zastavení</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 zbývá</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 zbývá</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>nádrž %1 (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>nádrž %1 (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>Nabíječka AC</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>Nabíječka AC</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Generátor</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Generátor</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>Stejnosměrná nabíječka</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>Stejnosměrná nabíječka</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Generátor stejnosměrného proudu</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Generátor stejnosměrného proudu</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC SYSTÉM</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC SYSTÉM</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Palivový článek</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Palivový článek</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Hřídelový generátor</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Hřídelový generátor</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Generátor vody</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Generátor vody</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Větrná nabíječka</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Větrná nabíječka</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Nízko</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Nízko</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Vysoko</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Vysoko</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Udržovat baterie v nabitém stavu</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Udržovat baterie v nabitém stavu</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimalizováno s ohledem na životnost baterie</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimalizováno s ohledem na životnost baterie</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimalizováno bez výdrže baterie</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimalizováno bez výdrže baterie</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Externí ovládání</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Nabito</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Nabito</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Čekání na slunce</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Čekání na slunce</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Čekání na RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Čekání na RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Čekání na start</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Čekání na start</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Chyba testu uzemnění</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Chyba testu uzemnění</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Chyba testu vstupu CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Chyba testu vstupu CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Zjištěn zbytkový proud</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Zjištěn zbytkový proud</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Zjištěno podpětí</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Zjištěno podpětí</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Zjištěno přepětí</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Zjištěno přepětí</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Zjištěno přehřátí</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Zjištěno přehřátí</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Limit nabíjení</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Limit nabíjení</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Zahájení nabíjení</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Zahájení nabíjení</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Naplánováno</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Naplánováno</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Naplánováno</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Rozcvička</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Rozcvička</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Ochlazení</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Ochlazení</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>KONTROLNÍ SPUŠTĚNÍ</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>KONTROLNÍ SPUŠTĚNÍ</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Manuálně spuštěný</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Manuálně spuštěný</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Stahování pro zavedení systému</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Stahování pro zavedení systému</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>V chodu (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>V chodu (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>V chodu (Ztlumené)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>V chodu (Ztlumené)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relé %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relé %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Závada</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Závada</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorpce</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorpce</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Skladování</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Skladování</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Vyrovnávání</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Vyrovnávání</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Externí ovládání</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Nízký výkon</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Nízký výkon</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Poruchový stav</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Poruchový stav</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Rychlé nabíjení</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Rychlé nabíjení</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Absorpční nabíjení</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Absorpční nabíjení</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Udržovací nabíjení</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Udržovací nabíjení</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Režim skladování</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Režim skladování</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Vyrovnávací nabíjení</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Vyrovnávací nabíjení</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Pass-thru</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Pass-thru</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Měnič</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Měnič</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Asistence</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Asistence</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Režim dodávky energie</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Režim dodávky energie</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Udržování</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Probuďte se</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Probuďte se</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Opakovaná absorpce</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Opakovaná absorpce</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Automatické vyrovnávání</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Automatické vyrovnávání</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>Systém Battery Safe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>Systém Battery Safe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Detekce zatížení</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Detekce zatížení</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Zablokovaný</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Zablokovaný</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamická ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dynamická ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dynamická ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Skupinový master</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Skupinový master</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Master případu</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Master případu</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Master skupiny a případu</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Master skupiny a případu</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Samostatný a skupinový master</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Samostatný a skupinový master</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Pouze nabíječka</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Pouze nabíječka</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Pouze měnič</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Pouze měnič</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Alarm nízkého napětí baterie</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Alarm vysokého napětí baterie</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Alarm zkratu</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Alarm zkratu</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Deaktivovat přístupový bod</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Deaktivovat přístupový bod</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Stejnosměrný vstup</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Stejnosměrný vstup</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>U lithiových baterií se nedoporučuje nabíjení pod 10 %. U ostatních typů baterií zjistěte v datasheetu minimální úroveň doporučenou výrobcem.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>U lithiových baterií se nedoporučuje nabíjení pod 10 %. U ostatních typů baterií zjistěte v datasheetu minimální úroveň doporučenou výrobcem.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Zakázat autostart?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Zakázat autostart?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Střídač / nabíječka (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Střídač / nabíječka (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Zobrazení využití procesoru</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Zobrazení využití procesoru</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Ukončení aplikace</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Ukončení aplikace</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Ukončit</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Ukončit</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Verze aplikace</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Verze aplikace</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Teplota oleje</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Teplota oleje</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Všimněte si, že změnou nastavení dolní meze vybíjení Time-to-go se změní také nastavení Low state-of-charge (Nízký stav nabití) v nabídce relé.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Všimněte si, že změnou nastavení dolní meze vybíjení Time-to-go se změní také nastavení Low state-of-charge (Nízký stav nabití) v nabídce relé.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Doba provozu</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Doba provozu</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Nabité Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Nabité Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Zahájení cyklů</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Zahájení cyklů</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Dokončené cykly</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Dokončené cykly</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Počet bonusů</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Počet bonusů</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Počet hlubokých výbojů</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Počet hlubokých výbojů</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Historie nabíjecích cyklů</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Historie nabíjecích cyklů</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Hodnota čidla, když je nádrž plná</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Hodnota čidla, když je nádrž plná</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Čas do servisu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Čas do servisu</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Funkce automatického spuštění</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Funkce automatického spuštění</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Při použití této možnosti se ujistěte, že generátor není připojen ke vstupu AC %1.</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Při použití této možnosti se ujistěte, že generátor není připojen ke vstupu AC %1.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Časovač služby byl vynulován</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Časovač služby byl vynulován</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Nepřetržité skenování může rušit provoz Wi-Fi.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Nepřetržité skenování může rušit provoz Wi-Fi.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Minimální a maximální rozsahy měřidla</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Minimální a maximální rozsahy měřidla</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Úvodní stránka</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Restartování aplikace...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Restartování aplikace...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Nepodařilo se změnit jazyk!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Nepodařilo se změnit jazyk!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 minuta</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 minut</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 minut</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Nikdy</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Počkejte prosím na změnu jazyka.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Počkejte prosím na změnu jazyka.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Stručné zobrazení jednotky</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Stručné zobrazení jednotky</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Žádné štítky</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Žádné štítky</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Zobrazit objemy nádrží</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Zobrazit objemy nádrží</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Zobrazit procenta</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Zobrazit procenta</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Poznámka: Pokud nelze zobrazit proud (například při zobrazení součtu pro kombinované zdroje střídavého a stejnosměrného proudu), zobrazí se místo toho výkon.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Poznámka: Pokud nelze zobrazit proud (například při zobrazení součtu pro kombinované zdroje střídavého a stejnosměrného proudu), zobrazí se místo toho výkon.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Limity nabíjecího proudu</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Limity nabíjecího proudu</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Oficiální vydání</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Oficiální vydání</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Beta verze</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Beta verze</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Testování (interní Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Testování (interní Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Vyvíjet (interní Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Vyvíjet (interní Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Restartuji...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Restartuji...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Povolení stavových LED diod</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Povolení stavových LED diod</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Zahřátí a ochlazení</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Zahřátí a ochlazení</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Doba zastavení generátoru</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Doba zastavení generátoru</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarm, když generátor není v režimu automatického spuštění</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarm, když generátor není v režimu automatického spuštění</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Pokud je funkce autostart vypnutá déle než 10 minut, spustí se alarm.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Pokud je funkce autostart vypnutá déle než 10 minut, spustí se alarm.</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Vlastní spotřeba z baterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Vlastní spotřeba z baterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Všechny systémové zátěže</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Všechny systémové zátěže</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Pouze kritická zatížení</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Pouze kritická zatížení</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Minimální hodnota stavu nabití (síť přítomna)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Stav životnosti baterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Stav životnosti baterie</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Přístup k signálu K na adrese http://venus.local:3000 a prostřednictvím VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Přístup k signálu K na adrese http://venus.local:3000 a prostřednictvím VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Přístup k Node-RED na adrese https://venus.local:1881 a prostřednictvím VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Přístup k Node-RED na adrese https://venus.local:1881 a prostřednictvím VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Měření na baterii</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Měření na baterii</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Stav systému</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Stav systému</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Seznam zařízení</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Seznam zařízení</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Instance zařízení VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Instance zařízení VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Alarm vysoké teploty</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Alarm vysoké teploty</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Řízeno BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Řízeno BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarmy a chyby</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarmy a chyby</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Tato funkce vyžaduje firmware verze 400 nebo vyšší. Pro aktualizaci zařízení Multi/Quattro se obraťte na svého instalatéra.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Tato funkce vyžaduje firmware verze 400 nebo vyšší. Pro aktualizaci zařízení Multi/Quattro se obraťte na svého instalatéra.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Nabíječka není připravena, vyrovnávání nelze spustit</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Nabíječka není připravena, vyrovnávání nelze spustit</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Vyrovnání nelze spustit během stavu hromadného nabíjení</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Vyrovnání nelze spustit během stavu hromadného nabíjení</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Maximální proud</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Maximální proud</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Maximální výkon</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Maximální výkon</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Minimální proud</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Minimální proud</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Žádný</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Není k dispozici</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Vypnuto</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">Ok</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Celková historie</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Celková historie</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Nastavení</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Neznámý</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Výnos dnes</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Výnos dnes</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware nainstalován, zařízení se restartuje</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware nainstalován, zařízení se restartuje</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Ovládání dotykového vstupu</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Ovládání dotykového vstupu</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Chyba testu svařovaných kontaktů (zkrat)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Chyba testu svařovaných kontaktů (zkrat)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Přepnutí na 3 fáze</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Přepnutí na 3 fáze</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Přepnutí na 1 fázi</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Přepnutí na 1 fázi</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Zastavení nabíjení</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Zastavení nabíjení</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Rezervováno</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Rezervováno</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Invertorový režim</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Invertorový režim</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC výstup L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC výstup L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Vstup</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Vstup</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Průchozí</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Průchozí</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Stránka se automaticky načte za deset sekund, aby se načetla nejnovější verze.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Stránka se automaticky načte za deset sekund, aby se načetla nejnovější verze.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Invertor (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Invertor (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Invertory/Nabíječky</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Invertory/Nabíječky</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Nebyly nalezeny žádné měřiče energie
+        <translation>Nebyly nalezeny žádné měřiče energie
 
 Všimněte si, že tato nabídka zobrazuje pouze měřiče Carlo Gavazzi připojené přes RS485. Jakékoli jiné měřiče, včetně měřičů Carlo Gavazzi připojených přes ethernet, naleznete v nabídce zařízení Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Automatické nastavení</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Automatické nastavení</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Pokud je tato funkce povolena, minima a maxima měřidel a grafů se automaticky upravují na základě minulých hodnot.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Pokud je tato funkce povolena, minima a maxima měřidel a grafů se automaticky upravují na základě minulých hodnot.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Vynulování všech hodnot rozsahu na nulu</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Vynulování všech hodnot rozsahu na nulu</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Obnovení hodnot rozsahu</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Obnovení hodnot rozsahu</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Jste si jisti, že chcete všechny hodnoty vynulovat?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Jste si jisti, že chcete všechny hodnoty vynulovat?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Maximální proud: AC v 1 připojeném</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Maximální proud: AC v 1 připojeném</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Maximální proud: AC ve 2 připojených</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Maximální proud: AC ve 2 připojených</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Maximální proud: žádné střídavé vstupy</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Maximální proud: žádné střídavé vstupy</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>Stejnosměrný výstup</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>Stejnosměrný výstup</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solární energie</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solární energie</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Otáčky motoru</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Otáčky motoru</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Teplota motoru</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Teplota motoru</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Teplota ovladače</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Teplota ovladače</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Aktivní cyklus</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Aktivní cyklus</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Cyklus %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Cyklus %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>Odpojení stejnosměrného proudu</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>Odpojení stejnosměrného proudu</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Vypnuto</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Vypnuto</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Změna funkce</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Změna funkce</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Aktualizace firmwaru</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Aktualizace firmwaru</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Obnovení softwaru</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Obnovení softwaru</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Neúplné</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Neúplné</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Uplynulý čas</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Uplynulý čas</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Nabíjení / údržba (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Nabíjení / údržba (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Baterie (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Baterie (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Nízké VÝSTUPNÍ AC napětí</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Nízké VÝSTUPNÍ AC napětí</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Vysoké VÝSTUPNÍ AC napětí</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Vysoké VÝSTUPNÍ AC napětí</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Celkový výnos</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Celkový výnos</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Systémový výnos</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Systémový výnos</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Denní historie</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Denní historie</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Není třeba konfigurovat žádné alarmy</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Není třeba konfigurovat žádné alarmy</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Maximální FV napětí</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Maximální FV napětí</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Maximální napětí baterie</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Maximální napětí baterie</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Minimální napětí baterie</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Minimální napětí baterie</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Chyba bateriové banky</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Chyba bateriové banky</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Napětí baterie není podporováno</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Napětí baterie není podporováno</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Nesprávný počet baterií</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Nesprávný počet baterií</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Nesprávná konfigurace baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Nesprávná konfigurace baterie</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Stav balancéru</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Stav balancéru</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Vyvážený</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Vyvážený</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Nerovnováha</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Nerovnováha</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Tuto možnost použijte v systémech, které neprovádějí peak shaving.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Tuto možnost použijte v systémech, které neprovádějí peak shaving.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Tuto možnost použijte pro špičkové holení.</translation>
+        <translation>Tuto možnost použijte pro špičkové holení.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Práh pro snížení špiček se nastavuje pomocí nastavení omezení střídavého vstupního proudu. Další informace naleznete v dokumentaci.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Práh pro snížení špiček se nastavuje pomocí nastavení omezení střídavého vstupního proudu. Další informace naleznete v dokumentaci.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Na této obrazovce lze měnit prahové hodnoty pro snížení špiček při importu a exportu. Další informace naleznete v dokumentaci.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Na této obrazovce lze měnit prahové hodnoty pro snížení špiček při importu a exportu. Další informace naleznete v dokumentaci.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Omezit systémový střídavý dovozní proud</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Omezit systémový střídavý dovozní proud</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Pro použití této funkce musí být měření v síti nastaveno na externí měřič a musí být nainstalován aktuální asistent ESS.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Pro použití této funkce musí být měření v síti nastaveno na externí měřič a musí být nainstalován aktuální asistent ESS.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Maximální dovozní proud systému (na fázi)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Maximální dovozní proud systému (na fázi)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Aby bylo možné tuto funkci používat, musí být měření v síti nastaveno na možnost Externí měřič.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Aby bylo možné tuto funkci používat, musí být měření v síti nastaveno na možnost Externí měřič.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Maximální exportní proud systému (na fázi)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Maximální exportní proud systému (na fázi)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Drátové připojení</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Drátové připojení</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Krátce</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Vysoké zatížení systému, zavřením bočního panelu se sníží zatížení procesoru</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Vysoké zatížení systému, zavřením bočního panelu se sníží zatížení procesoru</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Limit vstupního proudu</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Limit vstupního proudu</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Zkrat</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Zkrat</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Nákup</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Nákup</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Prodej</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Prodej</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Cílová SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Cílová SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC out %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC out %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Sledovač</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Sledovač</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Zařízení RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Zařízení RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Pozastavení animací elektronů</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Pozastavení animací elektronů</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Celková kapacita</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Celková kapacita</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Počet BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Počet BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Omezit střídavý exportní proud systému</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Omezit střídavý exportní proud systému</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Zařízení Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Zařízení Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Přidat zařízení</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Přidat zařízení</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Vyhledat zařízení</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Vyhledat zařízení</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Uložená zařízení</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Uložená zařízení</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Objevená zařízení</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Objevená zařízení</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Přidání zařízení Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Přidání zařízení Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protokol</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protokol</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Port</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Port</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Jednotka</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Jednotka</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Žádná zařízení Modbus nejsou uložena</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Žádná zařízení Modbus nejsou uložena</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Zařízení %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Zařízení %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Odstranění zařízení Modbus?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Odstranění zařízení Modbus?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Nebyla nalezena žádná zařízení Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Nebyla nalezena žádná zařízení Modbus</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Baterie %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Baterie %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>Střídavý proud</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>Střídavý proud</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Start/stop generátoru je zakázán</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Start/stop generátoru je zakázán</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Funkce dálkového spouštění je u elektrocentrály vypnutá. Genset GX nyní nebude možné spustit ani zastavit. Povolte ji na ovládacím panelu elektrocentrály.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Funkce dálkového spouštění je u elektrocentrály vypnutá. Genset GX nyní nebude možné spustit ani zastavit. Povolte ji na ovládacím panelu elektrocentrály.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Funkce automatického spuštění</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Funkce automatického spuštění</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Aktuální doba běhu</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Stav kontroly</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Stav kontroly</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Stav elektrocentrály</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Stav elektrocentrály</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Režim dálkového spouštění</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Režim dálkového spouštění</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Tlak oleje</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Tlak oleje</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Naplánované úrovně nabití</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Naplánované úrovně nabití</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Aktivní (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Aktivní (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Ruční zastavení</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Ruční zastavení</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Rozpojený obvod</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Rozpojený obvod</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (není k dispozici)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (není k dispozici)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Dotykový vstup zapnut</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Dotykový vstup zapnut</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Dotykový vstup vypnut</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Dotykový vstup vypnut</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Dotykový vstup deaktivován</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Dotykový vstup deaktivován</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Potvrzení upozornění</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Potvrzení upozornění</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Kontrolní chybový kód</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Kontrolní chybový kód</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Pomocí této nabídky můžete definovat údaje o baterii, které se zobrazí po kliknutí na ikonu Baterie na stránce Přehled. Stejný výběr je viditelný také na portálu VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Pomocí této nabídky můžete definovat údaje o baterii, které se zobrazí po kliknutí na ikonu Baterie na stránce Přehled. Stejný výběr je viditelný také na portálu VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Systémové napětí [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Systémové napětí [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Informace o připojení</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Informace o připojení</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Vyberte prosím...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Vyberte prosím...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Zabezpečeno</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Zabezpečeno</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Chráněno heslem a síťová komunikace je šifrovaná.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Chráněno heslem a síťová komunikace je šifrovaná.</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Slabé</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Slabé</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Chráněno heslem, ale síťová komunikace není šifrována.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Chráněno heslem, ale síťová komunikace není šifrována.</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Nezajištěné</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Nezajištěné</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Žádné heslo a síťová komunikace není šifrovaná.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Žádné heslo a síťová komunikace není šifrovaná.</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Heslo musí mít alespoň 8 znaků</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Zadejte heslo</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Heslo musí mít alespoň 8 znaků</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Heslo musí mít alespoň 8 znaků</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Zvolit profil "Zabezpečený"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Zvolit profil &quot;Zabezpečený&quot;?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Zvolit profil "Slabý"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Zvolit profil &quot;Slabý&quot;?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Zvolit profil "Nezajištěný"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Zvolit profil &quot;Nezajištěný&quot;?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Místní síťové služby jsou chráněny heslem
+        <translation>- Místní síťové služby jsou chráněny heslem
 - síťová komunikace je šifrovaná
 - je povoleno zabezpečené připojení s VRM
 - Nezabezpečená nastavení nelze povolit</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Místní síťové služby jsou chráněny heslem
+        <translation>- Místní síťové služby jsou chráněny heslem
 - Je povolen i nešifrovaný přístup k místním webovým stránkám (HTTP/HTTPS).</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Místní síťové služby nepotřebují heslo
+        <translation>- Místní síťové služby nepotřebují heslo
 - Je povolen i nešifrovaný přístup k místním webovým stránkám (HTTP/HTTPS).</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Kořenové heslo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Kořenové heslo</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Odhlásit se</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Odhlásit se</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Odhlásit se</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Odhlásit se</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Odhlásit se?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Odhlásit se?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Tím se odpojí všechna místní síťová připojení.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Tím se odpojí všechna místní síťová připojení.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Odhlásit se</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Odhlásit se</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Pouze pro čtení</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Pouze pro čtení</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Úplný</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Úplný</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Jste si jistý?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Jste si jistý?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Změnou tohoto nastavení na hodnotu Pouze pro čtení nebo Vypnuto dojde k zablokování.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Změnou tohoto nastavení na hodnotu Pouze pro čtení nebo Vypnuto dojde k zablokování.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Přístup k MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Přístup k MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' není číslo.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; není číslo.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Ano, odhlaste mě</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Ano, odhlaste mě</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Použijte číslo s %1 číslicemi nebo méně.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Použijte číslo s %1 číslicemi nebo méně.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' není platná IP adresa.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; není platná IP adresa.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' není platné číslo portu. Použijte číslo v rozmezí 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; není platné číslo portu. Použijte číslo v rozmezí 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 není platné číslo jednotky. Použijte číslo v rozmezí 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 není platné číslo jednotky. Použijte číslo v rozmezí 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Aktuální doba běhu</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Aktuální doba běhu</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Chybové kódy elektrocentrály</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Chybové kódy elektrocentrály</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Teplota chladiče</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Teplota chladiče</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Nabíjecí napětí</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Nabíjecí napětí je v současné době řízeno systémem BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Nabíjecí napětí je v současné době řízeno systémem BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Omezení nabíjecího proudu</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Omezení nabíjecího proudu</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>Řízeno BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>Řízeno BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Kontrola BMS se aktivuje automaticky, když je BMS přítomný. Vynulujte, pokud se konfigurace systému změnila nebo žádný BMS není k dispozici.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Kontrola BMS se aktivuje automaticky, když je BMS přítomný. Vynulujte, pokud se konfigurace systému změnila nebo žádný BMS není k dispozici.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Časovač služby je vypnutý.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Časovač služby je vypnutý.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Portál VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Portál VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (vzdálený přístup VPN)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (vzdálený přístup VPN)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Před povolením síťových služeb musí být nakonfigurován profil zabezpečení, viz Nastavení - Obecné.</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Před povolením síťových služeb musí být nakonfigurován profil zabezpečení, viz Nastavení - Obecné.</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' bylo nahrazeno '%2', protože obsahovalo neplatné znaky.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; bylo nahrazeno &apos;%2&apos;, protože obsahovalo neplatné znaky.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Inicializace...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Inicializace...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Backend začíná...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Backend začíná...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend se zastavil.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend se zastavil.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Připojení se nezdařilo.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Připojení se nezdařilo.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Toto zařízení GX je odhlášeno ze systému Tailscale.
+        <translation>Toto zařízení GX je odhlášeno ze systému Tailscale.
 
 Počkejte prosím nebo zkontrolujte své internetové připojení.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Čekáme na odpověď od společnosti Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Čekáme na odpověď od společnosti Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Připojte toto zařízení GX k účtu Tailscale otevřením tohoto odkazu:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Připojte toto zařízení GX k účtu Tailscale otevřením tohoto odkazu:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Vyčkejte prosím nebo zkontrolujte své internetové připojení.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Vyčkejte prosím nebo zkontrolujte své internetové připojení.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Neznámý stav: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Neznámý stav: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Chyba: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Chyba: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Chcete-li upravit tato nastavení, zakažte Tailscale.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Chcete-li upravit tato nastavení, zakažte Tailscale.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Povolení měřítka ocasu</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Povolení měřítka ocasu</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Název stroje</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Název stroje</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Odhlášení z účtu Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Odhlášení z účtu Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Přístup k místní síti</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Přístup k místní síti</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Přístup k místní síti ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Přístup k místní síti ethernet</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Přístup k místní síti WiFi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Přístup k místní síti WiFi</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Vlastní síť(e)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Vlastní síť(e)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Příklad: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Příklad: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Vysvětlení:
+        <translation>Vysvětlení:
 
 Tato funkce, kterou Tailscale nazývá podsíťové trasy, umožňuje vzdálený přístup k jiným zařízením v místní síti (sítích).
 
@@ -7387,2991 +8028,3058 @@ Pole Vlastní sítě přijímá seznam podsítí v notaci CIDR oddělený čárk
 Po přidání/povolení nové sítě je třeba ji jednou schválit v konzole správce Tailscale.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Vlastní argumenty "tailscale up"</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Vlastní argumenty &quot;tailscale up&quot;</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Vlastní adresa URL serveru (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Vlastní adresa URL serveru (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Tento regulátor elektrocentrály vyžaduje k ovládání pomocné relé, které však není nakonfigurováno. Nakonfigurujte relé 1 v části Nastavení → Relé na "Připojené pomocné relé elektrocentrály".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Tento regulátor elektrocentrály vyžaduje k ovládání pomocné relé, které však není nakonfigurováno. Nakonfigurujte relé 1 v části Nastavení → Relé na &quot;Připojené pomocné relé elektrocentrály&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarmy vysokého napětí startovací baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarmy vysokého napětí startovací baterie</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Přeskočit zahřívání generátoru</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Přeskočit zahřívání generátoru</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Nahoře, ale bez služeb (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Nahoře, ale bez služeb (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Heslo kořene změněno na %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Heslo kořene změněno na %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Připojené pomocné relé elektrocentrály</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Připojené pomocné relé elektrocentrály</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Poloha střídavých zátěží</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Poloha střídavých zátěží</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Vstup a výstup střídavého proudu</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Vstup a výstup střídavého proudu</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Tuto možnost použijte, pokud je na vstupu měniče/ nabíječky přítomno střídavé zatížení. Tuto možnost použijte, pokud si nejste jisti.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Tuto možnost použijte, pokud je na vstupu měniče/ nabíječky přítomno střídavé zatížení. Tuto možnost použijte, pokud si nejste jisti.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Pouze střídavý výstup</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Pouze střídavý výstup</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Tuto možnost použijte v případě, že systém používá síťový elektroměr, ale všechna střídavá zatížení jsou na výstupu měniče/nabíječky.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Tuto možnost použijte v případě, že systém používá síťový elektroměr, ale všechna střídavá zatížení jsou na výstupu měniče/nabíječky.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Měsíční</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Měsíční</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>Nabíječka pro elektromobily</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>Nabíječka pro elektromobily</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Tepelné čerpadlo</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Tepelné čerpadlo</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Základní zatížení</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Základní zatížení</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Spouštění a zastavování generátoru na základě nakonfigurovaných podmínek automatického spouštění.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Spouštění a zastavování generátoru na základě nakonfigurovaných podmínek automatického spouštění.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Nastavení stejnosměrné elektrocentrály</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Nastavení stejnosměrné elektrocentrály</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Teplota alternátoru</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Teplota alternátoru</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Teplota motoru</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Teplota motoru</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Celková doba chodu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Celková doba chodu</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Profil zabezpečení sítě</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Profil zabezpečení sítě</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Posledních %1 dní</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Posledních %1 dní</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generátor se zastaví v %1, pokud nejsou povoleny podmínky automatického spuštění, které jej udržují v chodu.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generátor se zastaví v %1, pokud nejsou povoleny podmínky automatického spuštění, které jej udržují v chodu.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generátor poběží, dokud nebude ručně zastaven, pokud nejsou povoleny podmínky automatického spuštění, které jej udržují v chodu.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generátor poběží, dokud nebude ručně zastaven, pokud nejsou povoleny podmínky automatického spuštění, které jej udržují v chodu.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Klasické uživatelské rozhraní</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Klasické uživatelské rozhraní</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Nové uživatelské rozhraní</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Nové uživatelské rozhraní</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Úspěšná změna jazyka!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Omezení výkonu</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Úspěšná změna jazyka!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>U zařízení Multi-RS a HS19 jsou nastavení ESS k dispozici na stránce produktu RS System.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>U zařízení Multi-RS a HS19 jsou nastavení ESS k dispozici na stránce produktu RS System.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Spuštění/vypnutí elektrocentrály</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Spuštění/vypnutí elektrocentrály</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Přepnutí verze firmwaru není možné, pokud není vybrán "Network Security Profile" v "Settings / General".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Přepnutí verze firmwaru není možné, pokud není vybrán &quot;Network Security Profile&quot; v &quot;Settings / General&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Doba trvání &lt;wbr&gt;(hh:mm)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Doba trvání &lt;wbr&gt;(hh:mm)</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Systémové alarmy</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Systémové alarmy</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Žádné systémové alarmy</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Žádné systémové alarmy</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Zpět</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Zpět</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Co je nového</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Co je nového</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>Přeskočit</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>Přeskočit</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Vítejte!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Vítejte!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Jsme rádi, že můžeme představit zcela přepracované rozhraní, které zlepšuje použitelnost i estetiku zařízení GX.
+        <translation>Jsme rádi, že můžeme představit zcela přepracované rozhraní, které zlepšuje použitelnost i estetiku zařízení GX.
 
 Díky zjednodušené navigaci a novému vzhledu je nyní vše, co máte rádi, ještě snadněji dostupné a vizuálně přitažlivější.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Tmavý - světlý režim</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Tmavý - světlý režim</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Různá prostředí vyžadují různá nastavení zobrazení. Tmavý a světlý režim zajišťují nejlepší zážitek ze sledování bez ohledu na to, kde se nacházíte.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Různá prostředí vyžadují různá nastavení zobrazení. Tmavý a světlý režim zajišťují nejlepší zážitek ze sledování bez ohledu na to, kde se nacházíte.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Všechny klíčové informace, které potřebujete, jsou prezentovány v přehledném a jednoduchém uspořádání. Ústředním prvkem je přizpůsobitelný widget s kroužky, který vám umožní rychlý přístup k informacím o systému na první pohled.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Všechny klíčové informace, které potřebujete, jsou prezentovány v přehledném a jednoduchém uspořádání. Ústředním prvkem je přizpůsobitelný widget s kroužky, který vám umožní rychlý přístup k informacím o systému na první pohled.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Získejte lepší kontrolu nad systémem díky aktualizovanému panelu Přehled, který obsahuje systémové údaje v reálném čase - vše na jednom místě pro snadné sledování.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Získejte lepší kontrolu nad systémem díky aktualizovanému panelu Přehled, který obsahuje systémové údaje v reálném čase - vše na jednom místě pro snadné sledování.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Ovládací prvky</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Ovládací prvky</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Všechny každodenní ovládací prvky jsou nyní sloučeny v novém podokně Ovládací prvky. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Všechny každodenní ovládací prvky jsou nyní sloučeny v novém podokně Ovládací prvky. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watty a ampéry</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watty a ampéry</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Nyní můžete přepínat mezi watty a ampéry. Vyberte si jednotku, která nejlépe vyhovuje vašim preferencím.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Nyní můžete přepínat mezi watty a ampéry. Vyberte si jednotku, která nejlépe vyhovuje vašim preferencím.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Přečíst více</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Přečíst více</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Více informací o obnoveném uživatelském rozhraní najdete na níže uvedeném odkazu.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Více informací o obnoveném uživatelském rozhraní najdete na níže uvedeném odkazu.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Naskenujte QR kód a zjistěte více informací o obnoveném uživatelském rozhraní.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Naskenujte QR kód a zjistěte více informací o obnoveném uživatelském rozhraní.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Hotovo</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Hotovo</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Další</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Další</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Chyba: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Chyba: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Aktivní chyba</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Aktivní chyba</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Celková doba chodu generátoru (hodiny)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Celková doba chodu generátoru (hodiny)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Úvodní stránka</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Úvodní stránka</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Uživatelské rozhraní</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Uživatelské rozhraní</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Uživatelské rozhraní (vzdálená konzola)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Uživatelské rozhraní (vzdálená konzola)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 aktualizováno</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 aktualizováno</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>Uživatelské rozhraní se přepne na %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>Uživatelské rozhraní se přepne na %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 je nastaveno na %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Tento fotovoltaický střídač podporuje omezení výkonu. Pokud toto nastavení narušuje normální provoz, zakažte jej.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 je nastaveno na %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Stisknutím tlačítka "OK" restartujete počítač</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Stisknutím tlačítka &quot;OK&quot; restartujete počítač</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Obnovení továrního nastavení zařízení Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Obnovení továrního nastavení zařízení Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Jste si jisti, že chcete obnovit výchozí tovární nastavení zařízení Node-RED? Tím se vymažou všechny vaše toky.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Jste si jisti, že chcete obnovit výchozí tovární nastavení zařízení Node-RED? Tím se vymažou všechny vaše toky.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Stav připojení</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Stav připojení</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Stav připojení (kanál HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Stav připojení (kanál HTTPS)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Stav připojení (kanál HTTP)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Stav připojení (kanál HTTP)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Stav připojení (kanál MQTT v reálném čase)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Stav připojení (kanál MQTT v reálném čase)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Stav připojení (kanál MQTT RPC)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Stav připojení (kanál MQTT RPC)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Automatické spuštění - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Automatické spuštění - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Hodnota pro deaktivaci</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Hodnota pro deaktivaci</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Neprovádí se</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Neprovádí se</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Ztráta komunikace</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Ztráta komunikace</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>Stav SOC</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>Stav SOC</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>Podmínka zatížení střídavým proudem</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>Podmínka zatížení střídavým proudem</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Aktuální stav baterie</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Aktuální stav baterie</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Stav napětí baterie</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Stav napětí baterie</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Stav přetížení měniče</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Stav přetížení měniče</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Nabíjení/vybíjení zakázáno</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Nabíjení/vybíjení zakázáno</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Nabíjení zakázáno</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Nabíjení zakázáno</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Vyřazení z provozu</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Vyřazení z provozu</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Krátce</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Stručný popis (otevřený boční panel)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Stručný popis (otevřený boční panel)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Přehled</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Úrovně (nádrže)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Úrovně (nádrže)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Úrovně (prostředí)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Úrovně (prostředí)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Seznam baterií</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Seznam baterií</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>Zařízení GX bylo aktualizováno</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>Zařízení GX bylo aktualizováno</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Po %n minutách</numerusform>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Po %n minutách</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Po spuštění aplikace přejděte na tuto stránku.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Po spuštění aplikace přejděte na tuto stránku.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Časový limit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Časový limit</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Vrátit se na úvodní stránku, když je aplikace neaktivní.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Vrátit se na úvodní stránku, když je aplikace neaktivní.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Po jedné minutě nečinnosti vyberte aktuální stránku jako úvodní stránku, pokud je v tomto seznamu.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Po jedné minutě nečinnosti vyberte aktuální stránku jako úvodní stránku, pokud je v tomto seznamu.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Tento proudový limit je pevně nastaven v konfiguraci systému. Nelze jej nastavit.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Tento proudový limit je pevně nastaven v konfiguraci systému. Nelze jej nastavit.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Režim je pevně nastaven v konfiguraci systému. Nelze jej nastavit.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Režim je pevně nastaven v konfiguraci systému. Nelze jej nastavit.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Funkce start/stop generátoru není povolena, přejděte do nastavení relé a nastavte funkci na "Genset start/stop".</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Standardní čas v Maroku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Standardní čas v západní střední Africe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Standardní čas v Jižní Africe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Standardní čas v Namibii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Standardní čas v Egyptě</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standardní čas ve východní Africe</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Standardní čas v Argentině</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Standardní čas na východě Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Standardní čas v Grónsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Standardní čas v Montevideu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Standardní čas na Newfoundlandu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Standardní čas ve východní části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantický standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Standardní čas v centrální Brazílii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Standardní čas v Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standardní čas v západní části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Standardní čas ve Venezuele</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Východní standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Standardní čas východního pobřeží Spojených států</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Standardní čas centrální části Kanady</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Standardní čas ve Střední Americe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Centrální standardní čas (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Centrální standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Horský standardní čas (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Horský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Horský standardní čas ve Spojených státech</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacifický standardní čas (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacifický standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Standardní čas na Aljašce</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Havaj-Aleutské ostrovy</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standardní čas na Novém Zélandu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standardní čas v centrálním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standardní čas v západním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standardní čas v Západní Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standardní čas v Jihovýchodní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standardní čas v centrální Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standardní čas v západní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standardní čas ve východní Africe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standardní čas v západní části Jižní Ameriky</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standardní čas západní Evropy</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Standardní čas na Kamčatce</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Standardní čas v Magadanu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Standardní čas ve Vladivostoku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Standardní čas v Jakutsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Standardní čas v Tokiu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Standardní čas v Koreji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Standardní čas v Singapuru</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Standardní čas v Ulánbátaru</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Standardní čas v Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Standardní čas v Severní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Standardní čas v Číně</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standardní čas v Jihovýchodní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Standardní čas v Severní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Standardní čas v Myanmaru</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Standardní čas v severní centrální Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standardní čas v centrální Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Standardní čas v Bangladéši</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Standardní čas v Nepálu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Standardní čas na Srí Lance</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Standardní čas v Indii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standardní čas v západní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Standardní čas v Pákistánu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Standardní čas v Jekatěrinburgu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Standardní čas v Gruzii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Standardní čas na Kavkaze</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Standardní čas v Ázerbájdžánu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Standardní čas v Afghánistánu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Standardní čas v Íránu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arabský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Standardní čas v Sýrii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Standardní čas na středním východě</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Standardní čas v Jordánsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Standardní čas v Izraeli</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Standardní čas v Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Standardní čas na Azorách</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Standardní čas na Kapverdách</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Standardní čas v Tasmánii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Standardní čas ve východní Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Standardní východoaustralský čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Standardní čas v centrální Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Standardní čas v centrální Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standardní čas v Západní Austrálii</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Standardní čas ve středním Atlantiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Standardní čas datové hranice</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GTM standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Standardní čas střední Evropy</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Středoevrospký standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Standardní čas v Rumunsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standardní čas západní Evropy</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Standardní čas ve vých. Evropě</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Standardní čas FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Standardní čas GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Standardní čas v Bělorusku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Standardní čas v Rusku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Standardní čas v Turecku</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Standardní čas na Mauríciu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Standardní čas na Vánočním ostrově</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Standardní čas na Tonze</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Standardní čas na Fidži</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standardní čas na Novém Zélandu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standardní čas v centrálním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standardní čas v západním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Standardní čas na Samoi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Standardní čas na Havaji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Standardní čas na Velikonočním ostrově</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Funkce start/stop generátoru není povolena, přejděte do nastavení relé a nastavte funkci na &quot;Genset start/stop&quot;.</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Neznámý</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Solární výnos</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Stejnosměrný vstup</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC zátěž</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">DC zátěže</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Přehled</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Stav</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">FV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Celkový výnos</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Systémový výnos</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Pouze alarm</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarmy a upozornění</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Upozornění</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Žádná chyba</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Žádná chyba</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Neznámá chyba: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Neznámá chyba: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Žádná chyba</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Žádná chyba</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Chyba spuštění baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Chyba spuštění baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Nejsou připojeny baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Nejsou připojeny baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Neznámá baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Neznámá baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Odlišné typy baterií</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Odlišné typy baterií</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Počet neprávných baterií</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Počet neprávných baterií</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt nenalazen</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt nenalazen</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Chyba měření baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Chyba měření baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Chyba interního výpočtu</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Chyba interního výpočtu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Počet nesprávných baterií v sérii</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Počet nesprávných baterií v sérii</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Chyba hardwaru</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Chyba hardwaru</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Chyba hlídače</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Chyba hlídače</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Přepětí</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Přepětí</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Podpětí</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Podpětí</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Příliš vysoká teplota</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Příliš vysoká teplota</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Příliš nízká teplota</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Příliš nízká teplota</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Nedostatečné nabíjení v pohotovostním režimu</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Nedostatečné nabíjení v pohotovostním režimu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Chyba ADC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Chyba ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Chyba komunikace baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Chyba komunikace baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Chyba počátku nabíjení</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Chyba počátku nabíjení</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Chyba bezpečnostního stykače</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Chyba bezpečnostního stykače</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Chyba aktualizace baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Chyba aktualizace baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Chyba komunikačního kabelu BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Chyba komunikačního kabelu BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Selhání referenčního napětí</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Selhání referenčního napětí</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Nesprávné napětí systému</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Nesprávné napětí systému</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Vypršel čas pro počáteční nabíjení</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Vypršel čas pro počáteční nabíjení</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Selhání ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Selhání ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Ztráta kalibračních dat</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Ztráta kalibračních dat</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Neplatné nastavení</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Neplatné nastavení</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Interlock</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Interlock</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Nouzové vypnutí</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Nouzové vypnutí</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Časový limit komunikace</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Časový limit komunikace</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Bezpečnostní zámek</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Bezpečnostní zámek</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Přehřátí terminálu</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Přehřátí terminálu</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Žádná chyba</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Vysoká teplota baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Vysoké napětí baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Tčidlo baterie chybně zapojeno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Chybějící Tčidlo baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Včidlo baterie chybně zapojeno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Chybějící Včidlo baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Vysoké ztráty vodičů baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Nízké napětí baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Velké zvlnění napětí baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Nízká úroveň stavu nabití</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Problém se středním napětím baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Příliš nízká teplota baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Vysoká teplota nabíječky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Nadměrný proud nabíječky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Záporný proud nabíječky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Překročen čas pro bulk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problém s proudovým čidlem nabíječky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Interní T čidlo špatně zapojeno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Chybějící interní T čidlo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Ventilátor nabíječky nebyl nalezen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Nadproud ventilátoru nabíječky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Přehřátí svorky nabíječky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Zkrat nabíječky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Problém fáze rychlého nabíjení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Ochrana proti přebití</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Vysoké vstupní napětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Nadměrný vstupní proud</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Nadměrný vstupní výkon</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Problém se vstupní polaritou</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Chybějící vstupní napětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Vypnutí vstupu (žádné opětovné zapnutí)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Vypnutí vstupu (opětovné zapnutí)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Interní chyba vstupu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Selhání izolace fotovoltaického panelu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Detekována chyba uzemnění</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Přetížení měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Příliš vysoká teplota měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Špičkový proud měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Interní úroveň DC měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Nesprávná úroveň AC výstupu měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Chyba fáze rychlého nabíjení měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Měnič je připojen k AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Chyba testu relé ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Chyba testu relé ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Zařízení zmizelo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Nekompatibilní zařízení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Ztráta BMS komunikace</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Chybná konfigurace sítě</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Otáčení fáze</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Více vstupů střídavého proudu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Přetížení fáze</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Chyba zápisu do paměti</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Příliš vysoká teplota CPU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Ztráta komunikace</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Ztráta kalibračních dat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Nekompatibilní firmware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Nekompatibilní hardware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Neplatné nastavení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Selhání referenčního napětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Selhání testování</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Historie je neplatná</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Neplatné čítače kWh</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Chyba DC napětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Chyba snímače GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Chyba napájení 3V3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Chyba napájení 5V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Chyba napájení 12V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Chyba napájení 15V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Vypnutí vstupu PV</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Chcete-li změnit nastavení, nastavte přepínač do odemčené polohy.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Použít zdroj dat D-Bus: připojte se k zadané adrese D-Bus.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>adresa</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Použít zdroj dat D-Bus: připojte se k výchozí adrese D-Bus</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Použít zdroj dat MQTT: připojte se k zadané adrese zprostředkovatele MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>adresa</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>ID portálu zařízení zdroje dat MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>ID portálu</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Úlomek webhostingu MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>střep</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Uživatelské jméno zdroje dat MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Uživatel</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Heslo zdroje dat MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>složit</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Token zdroje dat MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>žeton</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Povolit čítač FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Přeskočit úvodní obrazovku</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Pro testování použijte simulovaný zdroj dat.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Zařízení vypnuto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Smíchané staré/nové MK2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Očekávaná chyba zařízení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Nedetekováno jiné zařízení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Přepětí na AC-výstup</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Chyba programu DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS bez asistenta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Test zemního relé selhal</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Chyba synchronizace systémového času</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Chyba testování síťového relé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Neshoda konfigurace s druhou jednotkou mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Chyba přenosu zařízení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Čeká se na konfiguraci nebo chybí hardwarový klíč</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Chybí master fází</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Objevilo se přepětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Podřízená jednotka nemá AC vstup!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Zařízení nemůže být podřízené</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Byla iniciována ochrana systému</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Nekompatibilita firmwaru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Interní chyba</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Neúspěšný test relé brání připojení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>VE.Bus chyba</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Neznámá chyba:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Interní chyba</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Žádná chyba</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Vysoká teplota baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Vysoké napětí baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Nízké napětí baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Napětí baterie překročilo nakonfigurované maximum</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Vysoká teplota alternátoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Vysoké otáčky alternátoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Vysoká teplota FET polního pohonu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Chybí požadovaný snímač</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Nízké napětí alternátoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Posunutí vysokého napětí alternátoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Napětí alternátoru překročilo nakonfigurované maximum</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Vysoké napětí alternátoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Odpojená baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Odpojení baterie při vysokém napětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Akumulátor mimo rozsah</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Příliš mnoho zařízení BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Brzy dojde k odpojení baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Příliš mnoho zařízení ke sledování</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Odpojení baterie při nízkém napětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Odpojení baterie při vysokém proudu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Odpojení baterie při vysoké teplotě</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Odpojení baterie při nízké teplotě</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Ztráta BMS komunikace</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC vypnuto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>Měnič DC/DC není připraven</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>Vysoké primární napětí DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>Nízké primární napětí DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>Vysoké sekundární napětí DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>Nízké sekundární napětí DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>Vysoká teplota DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>Chybná konfigurace DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Vadný snímač teploty baterie</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Neznámá chyba:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Neznámá chyba:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Žádná chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Vysoká teplota baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Vysoké napětí baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Tčidlo baterie chybně zapojeno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Chybějící Tčidlo baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Včidlo baterie chybně zapojeno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Chybějící Včidlo baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Vysoké ztráty vodičů baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Nízké napětí baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Velké zvlnění napětí baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Nízká úroveň stavu nabití</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Problém se středním napětím baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Příliš nízká teplota baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Vysoká teplota nabíječky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Nadměrný proud nabíječky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Záporný proud nabíječky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Překročen čas pro bulk</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Problém s proudovým čidlem nabíječky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Interní T čidlo špatně zapojeno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Chybějící interní T čidlo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Ventilátor nabíječky nebyl nalezen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Nadproud ventilátoru nabíječky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Přehřátí svorky nabíječky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Zkrat nabíječky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Problém fáze rychlého nabíjení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Ochrana proti přebití</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Vysoké vstupní napětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Nadměrný vstupní proud</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Nadměrný vstupní výkon</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Problém se vstupní polaritou</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Chybějící vstupní napětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Vypnutí vstupu (žádné opětovné zapnutí)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Vypnutí vstupu (opětovné zapnutí)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Interní chyba vstupu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Selhání izolace fotovoltaického panelu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Detekována chyba uzemnění</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Přetížení měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Příliš vysoká teplota měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Špičkový proud měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Interní úroveň DC měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Nesprávná úroveň AC výstupu měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Chyba fáze rychlého nabíjení měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Měnič je připojen k AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Chyba testu relé ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Chyba testu relé ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Zařízení zmizelo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Nekompatibilní zařízení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Ztráta BMS komunikace</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Chybná konfigurace sítě</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Otáčení fáze</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Více vstupů střídavého proudu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Přetížení fáze</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Chyba zápisu do paměti</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Příliš vysoká teplota CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Ztráta komunikace</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Ztráta kalibračních dat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Nekompatibilní firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Nekompatibilní hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Neplatné nastavení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Selhání referenčního napětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Selhání testování</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Historie je neplatná</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Neplatné čítače kWh</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Chyba DC napětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Chyba snímače GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>Chyba napájení 3V3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>Chyba napájení 5V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>Chyba napájení 12V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>Chyba napájení 15V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Vypnutí vstupu PV</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Neznámá chyba:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Neznámá chyba:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Neznámá chyba:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Neznámá chyba:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Žádná chyba</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>AC napětí L1 příliš nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>AC napětí příliš nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>AC napětí L1 příliš vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>AC napětí příliš vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>AC frekvence L1 příliš nízká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>AC frekvence příliš nízká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>AC frekvence L1 příliš vysoká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>AC frekvence příliš nízká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC proud L1 příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>AC proud příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>AC výkon L1 příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>AC výkon příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Nouzové vypnutí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Servo proud příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Příliš nízký tlak oleje</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Příliš vysoký tlak oleje</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Příliš nízká teplota motoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Příliš vysoká teplota motoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Příliš nízká teplota navíjení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Příliš vysoká teplota navíjení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Příliš nízká teplota výfukových plynů</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Příliš vysoká teplota výfukových plynů</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Nízká elektronická teplota</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Vysoká elektronická teplota</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Příliš nízké napětí startéru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Příliš veliký proud startovací baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Příliš nízké žhavicí napětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Příliš vysoký proud záře</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Příliš vysoké napětí systému Cold-Start-Aid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Příliš vysoký proud Cold-Start-Aid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Příliš nízké napětí magnetu pro udržování paliva</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Příliš vysoký proud magnetu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Příliš nízké napětí na cívce zastavovacího elektromagnetu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Proud stojícího elektromagnetu cívky je příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Příliš nízké napětí na tahové cívce elektromagnetické brzdy </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Proud stojícího elektromagnetu tažné cívky je příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Příliš nízké napětí ventilátoru/vodního čerpadla</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Příliš vysoký proud ventilátoru/vodního čerpadla</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Nízké napětí proudového senzoru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Proudový snímač proudu vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Příliš nízké výstupní napětí Boostu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Příliš vysoký proud posíleného výstupu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Příliš nízké napájecí napětí sběrnice</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Příliš vysoký napájecí proud sběrnice</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Napětí startovací baterie příliš nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Napětí startovací baterie příliš vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Příliš pomalé otáčení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Příliš rychlé otáčení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Neočekávané zastavení/problém s přívodem paliva</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Příliš nízké napětí napájecího stykače</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Proud výkonového stykače příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>AC napětí L2 příliš nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>AC napětí L2 příliš vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>AC frekvence L2 příliš nízká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>AC frekvence L2 příliš vysoká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>AC proud L2 příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>AC výkon L2 příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>AC napětí L3 příliš nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>AC napětí L3 příliš vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>AC frekvence L3 příliš nízká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>AC frekvence L3 příliš vysoká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC proud L3 příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>AC výkon L3 příliš vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Příliš nízké výstupní napětí měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Příliš vysoký výstupní proud měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Příliš nízké napětí univerzálního výstupu (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Příliš vysoký proud univerzálního výstupu (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Příliš nízké napětí univerzálního výstupu (5 A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Příliš vysoký proud univerzálního výstupu (5 A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT DC napětí 1 nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>AGT stejnosměrné napětí 1 vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT stejnosměrný proud 1 nízký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT stejnosměrný proud 1 vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Napětí AGT DC 2 nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Napětí AGT DC 2 vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT stejnosměrný proud 2 nízký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT stejnosměrný proud 2 vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Nízký chladič AGT B6</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 chladič vysoký</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 rail (-) low</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 kolejnice (-) vysoká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 rail (+) nízká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 rail (+) vysoká</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Příliš nízká teplota paliva</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Vysoká teplota paliva</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Příliš malé množství paliva</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Ztráta řídící jednotky</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Ztráta panelu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Nutnost servisu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Ztráta třífázového modulu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Ztráta AGT modulu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Synchronizační selhání</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Ztráta externí ECU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Přívod vzduchového filtru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Diagnostická zpráva (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Ztráta synchronizačního modulu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Selhání vyvážení zátěže</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Deaktivován synchronizační mód</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Červené brzdové světlo (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Výstražné světlo oranžové barvy (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Kontrolka poruchy (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Ochranná lampa (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Špatné rotační pole</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Chyba palivového čidla</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Spuštění bez měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Autobus č. 1 mrtvý</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Žádost o zahájení zamítnuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Odmítnutí dálkového spuštění</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Vynucené vypnutí zátěžového relé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Synchronizační modul je offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Ztracený systém BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Převodník DC Link Voltage Low/Reverse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Převodník DC Link Current Low</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Převodník DC Předběžné napětí nízké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Převodník DC Přednabíjecí napětí Vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Chyba ovladače převodníku IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Chybová smyčka řízení výkonu měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Měnič Detekce frekvence střídavého proudu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Selhání řídicí hodnoty převodníku</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Změna továrního nastavení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Změna parametru v režimu správce</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Ruční zásah (ext. systém)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Nezdařený start</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Hlídací pes</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Vysoká teplota měniče L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Vysoká teplota měniče L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Vysoká teplota měniče L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Vysoká teplota měniče DC link</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Přetížení měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Ztráta komunikace měniče</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>DC přetížení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>DC přepětí</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Bez spojení</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Žádná chyba</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Neznámá chyba: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Neznámá chyba:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Tlak oleje</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Přehřátí hlavy válců</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Řízení nabíjení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Rychlost vyšší, než se očekávalo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Nadměrná rychlost</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Teplota oleje vyšší, než se očekávalo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Teplota oleje rozpojený obvod / zkrat na napájení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Teplotní zkrat na zem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analogová nastavená hodnota vysoká / krátká na napájení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analogová nastavená hodnota nízká / zkrat na zem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Časový limit příjmu zprávy TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Časový limit příjmu zprávy CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Vysoké napětí baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Nízké napětí baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Zkreslený signál rychlosti</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Interní napájení snímače 5 V vysoké</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Nízké vnitřní napájení snímače 5 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Vysoký barometrický tlak</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Nízký barometrický tlak</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Zkrat výstupního palivového čerpadla na napájení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Zkrat výstupního palivového čerpadla na zem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Zkrat výstupní žhavicí svíčky na napájení</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Zkrat výstupní žhavicí svíčky na zem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Rozpojený obvod vstřikovače/zkrat na spodní straně na zem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Vnitřní zkrat cívky vstřikovače</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Zkrat na spodní straně vstřikovače</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Uplynulé hodiny služby</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Selhání procesoru</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Neznámá chyba:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Baterie</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Baterie</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Lednička</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Lednička</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Obecné</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Obecné</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Pokoj</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Pokoj</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Venkovní</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Venkovní</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Ohřívač vody</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Ohřívač vody</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Mrazák</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Mrazák</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Neznámá chyba:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Žádná chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>AC napětí L1 příliš nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>AC napětí příliš nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>AC napětí L1 příliš vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>AC napětí příliš vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>AC frekvence L1 příliš nízká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>AC frekvence příliš nízká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>AC frekvence L1 příliš vysoká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>AC frekvence příliš nízká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC proud L1 příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>AC proud příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>AC výkon L1 příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>AC výkon příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Nouzové vypnutí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Servo proud příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Příliš nízký tlak oleje</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Příliš vysoký tlak oleje</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Příliš nízká teplota motoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Příliš vysoká teplota motoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Příliš nízká teplota navíjení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Příliš vysoká teplota navíjení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Příliš nízká teplota výfukových plynů</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Příliš vysoká teplota výfukových plynů</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Nízká elektronická teplota</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Vysoká elektronická teplota</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Příliš nízké napětí startéru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Příliš veliký proud startovací baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Příliš nízké žhavicí napětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Příliš vysoký proud záře</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Příliš vysoké napětí systému Cold-Start-Aid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Příliš vysoký proud Cold-Start-Aid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Příliš nízké napětí magnetu pro udržování paliva</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Příliš vysoký proud magnetu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Příliš nízké napětí na cívce zastavovacího elektromagnetu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Proud stojícího elektromagnetu cívky je příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Příliš nízké napětí na tahové cívce elektromagnetické brzdy </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Proud stojícího elektromagnetu tažné cívky je příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Příliš nízké napětí ventilátoru/vodního čerpadla</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Příliš vysoký proud ventilátoru/vodního čerpadla</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Nízké napětí proudového senzoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Proudový snímač proudu vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Příliš nízké výstupní napětí Boostu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Příliš vysoký proud posíleného výstupu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Příliš nízké napájecí napětí sběrnice</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Příliš vysoký napájecí proud sběrnice</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Napětí startovací baterie příliš nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Napětí startovací baterie příliš vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Příliš pomalé otáčení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Příliš rychlé otáčení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Neočekávané zastavení/problém s přívodem paliva</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Příliš nízké napětí napájecího stykače</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Proud výkonového stykače příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>AC napětí L2 příliš nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>AC napětí L2 příliš vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>AC frekvence L2 příliš nízká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>AC frekvence L2 příliš vysoká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>AC proud L2 příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>AC výkon L2 příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>AC napětí L3 příliš nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>AC napětí L3 příliš vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>AC frekvence L3 příliš nízká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>AC frekvence L3 příliš vysoká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC proud L3 příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>AC výkon L3 příliš vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Příliš nízké výstupní napětí měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Příliš vysoký výstupní proud měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Příliš nízké napětí univerzálního výstupu (1A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Příliš vysoký proud univerzálního výstupu (1A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Příliš nízké napětí univerzálního výstupu (5 A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Příliš vysoký proud univerzálního výstupu (5 A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT DC napětí 1 nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>AGT stejnosměrné napětí 1 vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT stejnosměrný proud 1 nízký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT stejnosměrný proud 1 vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Napětí AGT DC 2 nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Napětí AGT DC 2 vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT stejnosměrný proud 2 nízký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT stejnosměrný proud 2 vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>Nízký chladič AGT B6</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 chladič vysoký</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 rail (-) low</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 kolejnice (-) vysoká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 rail (+) nízká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 rail (+) vysoká</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Příliš nízká teplota paliva</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Vysoká teplota paliva</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Příliš malé množství paliva</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Ztráta řídící jednotky</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Ztráta panelu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Nutnost servisu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Ztráta třífázového modulu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Ztráta AGT modulu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Synchronizační selhání</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Ztráta externí ECU</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Přívod vzduchového filtru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Diagnostická zpráva (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Ztráta synchronizačního modulu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Selhání vyvážení zátěže</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Deaktivován synchronizační mód</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Červené brzdové světlo (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Výstražné světlo oranžové barvy (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Kontrolka poruchy (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Ochranná lampa (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Špatné rotační pole</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Chyba palivového čidla</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Spuštění bez měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Autobus č. 1 mrtvý</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Žádost o zahájení zamítnuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Odmítnutí dálkového spuštění</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Vynucené vypnutí zátěžového relé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Synchronizační modul je offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>Ztracený systém BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Převodník DC Link Voltage Low/Reverse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Převodník DC Link Current Low</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Převodník DC Předběžné napětí nízké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Převodník DC Přednabíjecí napětí Vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Chyba ovladače převodníku IGBT/MOSFET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Chybová smyčka řízení výkonu měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Měnič Detekce frekvence střídavého proudu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Selhání řídicí hodnoty převodníku</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Změna továrního nastavení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Změna parametru v režimu správce</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Ruční zásah (ext. systém)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Nezdařený start</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Hlídací pes</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Vysoká teplota měniče L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Vysoká teplota měniče L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Vysoká teplota měniče L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Vysoká teplota měniče DC link</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Přetížení měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Ztráta komunikace měniče</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>DC přetížení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>DC přepětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Bez spojení</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Žádná chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Neznámá chyba: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Neznámá chyba:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Tlak oleje</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Přehřátí hlavy válců</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Řízení nabíjení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Rychlost vyšší, než se očekávalo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Nadměrná rychlost</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Teplota oleje vyšší, než se očekávalo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Teplota oleje rozpojený obvod / zkrat na napájení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Teplotní zkrat na zem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Analogová nastavená hodnota vysoká / krátká na napájení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Analogová nastavená hodnota nízká / zkrat na zem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Časový limit příjmu zprávy TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Časový limit příjmu zprávy CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Vysoké napětí baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Nízké napětí baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Zkreslený signál rychlosti</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Interní napájení snímače 5 V vysoké</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Nízké vnitřní napájení snímače 5 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Vysoký barometrický tlak</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Nízký barometrický tlak</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Zkrat výstupního palivového čerpadla na napájení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Zkrat výstupního palivového čerpadla na zem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Zkrat výstupní žhavicí svíčky na napájení</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Zkrat výstupní žhavicí svíčky na zem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Rozpojený obvod vstřikovače/zkrat na spodní straně na zem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Vnitřní zkrat cívky vstřikovače</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Zkrat na spodní straně vstřikovače</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Uplynulé hodiny služby</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Selhání procesoru</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Chcete-li změnit nastavení, nastavte přepínač do odemčené polohy.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Použít zdroj dat D-Bus: připojte se k zadané adrese D-Bus.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Použít zdroj dat D-Bus: připojte se k výchozí adrese D-Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Použít zdroj dat MQTT: připojte se k zadané adrese zprostředkovatele MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>ID portálu zařízení zdroje dat MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>ID portálu</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Úlomek webhostingu MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>střep</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Uživatelské jméno zdroje dat MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Uživatel</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Heslo zdroje dat MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>složit</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Token zdroje dat MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>žeton</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Povolit čítač FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Přeskočit úvodní obrazovku</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Pro testování použijte simulovaný zdroj dat.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Standardní čas v Maroku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Standardní čas v západní střední Africe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Standardní čas v Jižní Africe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Standardní čas v Namibii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Standardní čas v Egyptě</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Standardní čas ve východní Africe</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Standardní čas v Argentině</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Standardní čas na východě Jižní Ameriky</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Standardní čas v Grónsku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Standardní čas v Montevideu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Standardní čas na Newfoundlandu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Standardní čas ve východní části Jižní Ameriky</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Atlantický standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Standardní čas v centrální Brazílii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Standardní čas v Paraguay</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Standardní čas v západní části Jižní Ameriky</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Standardní čas ve Venezuele</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Východní standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Standardní čas východního pobřeží Spojených států</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Standardní čas centrální části Kanady</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Standardní čas ve Střední Americe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Centrální standardní čas (Mexiko)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Centrální standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Horský standardní čas (Mexiko)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Horský standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Horský standardní čas ve Spojených státech</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Pacifický standardní čas (Mexiko)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Pacifický standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Standardní čas na Aljašce</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Havaj-Aleutské ostrovy</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Standardní čas na Novém Zélandu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Standardní čas v centrálním Pacifiku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Standardní čas v západním Pacifiku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Standardní čas v Západní Austrálii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Standardní čas v Jihovýchodní Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Standardní čas v centrální Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Standardní čas v západní Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Standardní čas ve východní Africe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Standardní čas v západní části Jižní Ameriky</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Standardní čas západní Evropy</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Standardní čas na Kamčatce</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Standardní čas v Magadanu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Standardní čas ve Vladivostoku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Standardní čas v Jakutsku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Standardní čas v Tokiu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Standardní čas v Koreji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Standardní čas v Singapuru</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Standardní čas v Ulánbátaru</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Standardní čas v Taipei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Standardní čas v Severní Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Standardní čas v Číně</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Standardní čas v Jihovýchodní Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Standardní čas v Severní Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Standardní čas v Myanmaru</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Standardní čas v severní centrální Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Standardní čas v centrální Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Standardní čas v Bangladéši</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Standardní čas v Nepálu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Standardní čas na Srí Lance</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Standardní čas v Indii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Standardní čas v západní Asii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Standardní čas v Pákistánu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Standardní čas v Jekatěrinburgu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Standardní čas v Gruzii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Standardní čas na Kavkaze</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Standardní čas v Ázerbájdžánu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Arabský standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Standardní čas v Afghánistánu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Standardní čas v Íránu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Arabský standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Arabský standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Standardní čas v Sýrii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Standardní čas na středním východě</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Standardní čas v Jordánsku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Standardní čas v Izraeli</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Standardní čas v Greenwich</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Standardní čas na Azorách</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Standardní čas na Kapverdách</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Standardní čas v Tasmánii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Standardní čas ve východní Austrálii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Standardní východoaustralský čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Standardní čas v centrální Austrálii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Standardní čas v centrální Austrálii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Standardní čas v Západní Austrálii</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Standardní čas ve středním Atlantiku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Standardní čas datové hranice</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>GTM standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Standardní čas střední Evropy</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Středoevrospký standardní čas</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Standardní čas v Rumunsku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Standardní čas západní Evropy</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Standardní čas ve vých. Evropě</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Standardní čas FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Standardní čas GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Standardní čas v Bělorusku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Standardní čas v Rusku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Standardní čas v Turecku</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Standardní čas na Mauríciu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Standardní čas na Vánočním ostrově</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Standardní čas na Tonze</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Standardní čas na Fidži</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Standardní čas na Novém Zélandu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Standardní čas v centrálním Pacifiku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Standardní čas v západním Pacifiku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Standardní čas na Samoi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Standardní čas na Havaji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Standardní čas na Velikonočním ostrově</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Interní chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Neznámá chyba:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Interní chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Žádná chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Vysoká teplota baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Vysoké napětí baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Nízké napětí baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Napětí baterie překročilo nakonfigurované maximum</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Vysoká teplota alternátoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Vysoké otáčky alternátoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Vysoká teplota FET polního pohonu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Chybí požadovaný snímač</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Nízké napětí alternátoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Posunutí vysokého napětí alternátoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Napětí alternátoru překročilo nakonfigurované maximum</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Vysoké napětí alternátoru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Odpojená baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Odpojení baterie při vysokém napětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Akumulátor mimo rozsah</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Příliš mnoho zařízení BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Brzy dojde k odpojení baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Příliš mnoho zařízení ke sledování</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Odpojení baterie při nízkém napětí</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Odpojení baterie při vysokém proudu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Odpojení baterie při vysoké teplotě</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Odpojení baterie při nízké teplotě</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Ztráta BMS komunikace</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC vypnuto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>Měnič DC/DC není připraven</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>Vysoké primární napětí DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>Nízké primární napětí DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>Vysoké sekundární napětí DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>Nízké sekundární napětí DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>Vysoká teplota DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>Chybná konfigurace DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Vadný snímač teploty baterie</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_da.ts
+++ b/i18n/venus-gui-v2_da.ts
@@ -1,7383 +1,8025 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="da">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Deaktiveret</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Deaktiveret</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Inverter overload</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Inverter overload</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Strømforsyning</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Strømforsyning</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Fra</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Fra</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Auto</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Batteri</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Forbundet</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Afbrudt.</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generator</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Høj batteri volt</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Høj batteri volt</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Inverter/oplader</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Inverter/oplader</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Lav batteri volt</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Lav batteri volt</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manual</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manual</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Ingen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Ingen</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Stilling</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Stilling</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Hastighed</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Hastighed</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Tilstand</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Tilstand</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installerer %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installerer %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Ukendt fejl</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Ukendt fejl</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Minimum SOC:</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Minimum SOC:</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Ukendt</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Indtast adgangskode</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Indtast adgangskode</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Tryk for at tjekke</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Tryk for at tjekke</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Forsyning</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Forsyning</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Sol produktion</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Sol produktion</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Ekstern styring</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Ekstern styring</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Tanke</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Tanke</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Omgivelser</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Omgivelser</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Ingen aktuelle advarsler</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Ingen aktuelle advarsler</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Generelt</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Generelt</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Dato &amp; Tid</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Dato &amp; Tid</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>System opsætning</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>System opsætning</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Display &amp; sprog</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Display &amp; sprog</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM Online Portal</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM Online Portal</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Energi måler</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Energi måler</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>PV invertere</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>PV invertere</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM Modem</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM Modem</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Generator Start/stop</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Generator Start/stop</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Tank pumpe</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Tank pumpe</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Services</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Services</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Venus OS Large features</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Venus OS Large features</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Grænse for batterilevetid: %1</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Grænse for batterilevetid: %1</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Autostart vil være deaktiveret, og generatoren vil ikke starte automatisk baseret på de konfigurerede betingelser.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Autostart vil være deaktiveret, og generatoren vil ikke starte automatisk baseret på de konfigurerede betingelser.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Manuelt stop</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Manuelt stop</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Manuel start</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Manuel start</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Stilling</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Autostart</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Autostart</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Kontakter</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Kontakter</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Adgangsniveau</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Adgangsniveau</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Bruger</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Bruger</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Bruger &amp; installatør</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Bruger &amp; installatør</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superbruger</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superbruger</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Service</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Service</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Sørg for også at nulstille VE.Bus-systemet efter deaktivering af DVCC.</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Sørg for også at nulstille VE.Bus-systemet efter deaktivering af DVCC.</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Begræns opladnings strøm</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Begræns opladnings strøm</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Maksimum lade strøm</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Maksimum lade strøm</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Brug %1 værdi til start/stop</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Brug %1 værdi til start/stop</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Start når %1 er højere end</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Start når %1 er højere end</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Start når %1 er lavere end</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Start når %1 er lavere end</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Stop, når %1 er højere end</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Stop, når %1 er højere end</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Stop, når %1 er lavere end</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Stop, når %1 er lavere end</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Fjern IP-adresse?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Fjern IP-adresse?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Forbindelse</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Forbindelse</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Produkt</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Produkt</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Navn</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Navn</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>Produkt-ID</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>Produkt-ID</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Hardware version</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Hardware version</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Enheds navn</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Enheds navn</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Fjernkontakt styring deaktiveret</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Fjernkontakt styring deaktiveret</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Generator i fejl tilstand</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Generator i fejl tilstand</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Generator ikke fundet ved AC input</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Generator ikke fundet ved AC input</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Akkumuleret køre tid siden sidste test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Akkumuleret køre tid siden sidste test</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Tid til næste test kørsel</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Tid til næste test kørsel</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Kører nu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Kører nu</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Manuel start</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Manuel start</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Start generator</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Start generator</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Daglig køre tid</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Daglig køre tid</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Værdien skal være højere end stop værdien</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Værdien skal være højere end stop værdien</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Værdien skal være lavere end start værdien</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Værdien skal være lavere end start værdien</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>Vekselstrømsudgang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>Vekselstrømsudgang</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">Vekselstrømsudgang</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Brug AC forbruget til start/stop</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Brug AC forbruget til start/stop</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Målinger</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Målinger</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Total forbrug</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Total forbrug</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Inverter total AC out</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Inverter total AC out</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Inverter AC out højeste fase</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Inverter AC out højeste fase</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Start når power er højere end</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Start når power er højere end</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Stop når power er laverede end</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Stop når power er laverede end</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Batterimonitor</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Batterimonitor</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Monitor utilgængelig, vælg en anden</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Monitor utilgængelig, vælg en anden</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Batterimonitor</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Monitor utilgængelig, vælg en anden</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Ved kommunikations tab</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Ved kommunikations tab</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Stop generator</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Stop generator</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Lad generator forsætte</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Lad generator forsætte</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Stop generatoren, når AC-indgangen er tilgængelig</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Stop generatoren, når AC-indgangen er tilgængelig</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>Batteri SoC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>Batteri SoC</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Inverter høj temperatur</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Inverter høj temperatur</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Inverter høj temperatur</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Start på høj temperatur advarsel</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Start på høj temperatur advarsel</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Start på overbelastning advarsel</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Start på overbelastning advarsel</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Periodisk kørsel</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Periodisk kørsel</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Køre interval</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Køre interval</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 dag(e)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 dag(e)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Spring over hvis den har kørt for</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Spring over hvis den har kørt for</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Start altid</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Start altid</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Køre interval start dato</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Køre interval start dato</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Køre tid (tt:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Køre tid (tt:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Kør indtil batterierne er opladet</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Kør indtil batterierne er opladet</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (Fix)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (Fix)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS forbundet, men ingen GPS fix</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS forbundet, men ingen GPS fix</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Ingen GPS forbundet</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Ingen GPS forbundet</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Latitude</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Latitude</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Longitude</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Longitude</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/t</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/t</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Kurs</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Kurs</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Højde</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Højde</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Antal satelitter</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Antal satelitter</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Net setpoint</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Net setpoint</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>AC-in setpoint</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>AC-in setpoint</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Strøm: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Strøm: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Spænding: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Spænding: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Grænser (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Grænser (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Opladning: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Opladning: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Afladning: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Afladning: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Grænser (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Grænser (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Synlig</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Synlig</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Usynlig</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Usynlig</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Hjælpe målinger)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Hjælpe målinger)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Output %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Output %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Aktiv batteri monitor</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Aktiv batteri monitor</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Navn</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Indtast navn</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Indtast navn</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Indtast navn</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Kontinuerlig scanning</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Kontinuerlig scanning</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Bluetooth adaptere</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Bluetooth adaptere</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Pinkode</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Pinkode</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Det er måske nødvendig at fjerne eksisterende parings informationer før opkobling.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Det er måske nødvendig at fjerne eksisterende parings informationer før opkobling.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Fase type</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Fase type</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Enkelt fase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Enkelt fase</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Multi fase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Multi fase</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>PV inverter på fase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>PV inverter på fase 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>PV inverter på fase 2 Position</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>PV inverter på fase 2 Position</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>CAN-bus profil</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>CAN-bus profil</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deaktiveret</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Op, men ingen tjenester (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Op, men ingen tjenester (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Enhed fundet</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Enhed fundet</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000-out</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000-out</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Unik identifikations nummer vælger</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Unik identifikations nummer vælger</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Vent venligst, opdaterer og tjekker det unikke nummer tager noget tid</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Vent venligst, opdaterer og tjekker det unikke nummer tager noget tid</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Ovenstående vælger indstiller, hvilken blok af unikke identitetsnumre der skal bruges til NAME Unique Identity Numbers i PGN 60928 NAME-feltet. Ændres kun, når der bruges flere GX-enheder i et VE.Can-netværk.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Ovenstående vælger indstiller, hvilken blok af unikke identitetsnumre der skal bruges til NAME Unique Identity Numbers i PGN 60928 NAME-feltet. Ændres kun, når der bruges flere GX-enheder i et VE.Can-netværk.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Ovenstående vælger indstiller, hvilken blok af unikke identitetsnumre der skal bruges til serienummeret i feltet DGN 60928 ADDRESS_CLAIM. Ændres kun, når der bruges flere GX-enheder i et RV-C-netværk.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Ovenstående vælger indstiller, hvilken blok af unikke identitetsnumre der skal bruges til serienummeret i feltet DGN 60928 ADDRESS_CLAIM. Ændres kun, når der bruges flere GX-enheder i et RV-C-netværk.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Check unikke ID numre</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Check unikke ID numre</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Tryk for at tjekke</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Der er en anden enhed forbundet med dette unikke nummer, vælg venligst et nyt nummer.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Der er en anden enhed forbundet med dette unikke nummer, vælg venligst et nyt nummer.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>Ok: Ingen andre enheder er forbundet med dette nummer.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>Ok: Ingen andre enheder er forbundet med dette nummer.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Netværks status</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Netværks status</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Adaptiv skærmstyrke</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Adaptiv skærmstyrke</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Lysstyrke</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Lysstyrke</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Display sluk tid</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Display sluk tid</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 sek</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 sek</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 sek</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 sek</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Aldrig</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Aldrig</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Visningstilstand</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Visningstilstand</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Mørk</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Mørk</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Lys</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Lys</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Korte visningsniveauer</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Korte visningsniveauer</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Sprog</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Sprog</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Ændring af sprog</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Ændring af sprog</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Visning af elektrisk strøm</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Visning af elektrisk strøm</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Effekt (watt)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Effekt (watt)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Strøm (ampere)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Strøm (ampere)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Enheder</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Enheder</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Niveau %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Niveau %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;FORSIGTIG:&lt;/b&gt; Læs manualen, før du justerer.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;FORSIGTIG:&lt;/b&gt; Læs manualen, før du justerer.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Begræns styrede batteri lade volt</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Begræns styrede batteri lade volt</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Maksimum lade volt</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Maksimum lade volt</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Shared voltage sense</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Shared voltage sense</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Shared temperature sense</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Shared temperature sense</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Sensor utilgængelig, vælg en anden</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Sensor utilgængelig, vælg en anden</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Sensor utilgængelig, vælg en anden</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Brugt sensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Brugt sensor</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Shared current sense</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Shared current sense</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>SCS Status</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>SCS Status</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Deaktiveret (Ekstern styret)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Deaktiveret (Ekstern styret)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Deaktiveret (ingen ladere)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Deaktiveret (ingen ladere)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Deaktiveret (ingen batteri monitor)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Deaktiveret (ingen batteri monitor)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Automatisk valg</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Automatisk valg</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Ingen BMS styring</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Ingen BMS styring</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Styrer BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Styrer BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Utilgængelig, vælg anden</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Utilgængelig, vælg anden</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Automatisk valgt</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Automatisk valgt</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Ingen</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Bygge dato/tid</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Bygge dato/tid</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Online opdateringer</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Online opdateringer</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Installer firmware fra SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Installer firmware fra SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Gemt backup firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Gemt backup firmware</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Tjek for opdateringer på SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Tjek for opdateringer på SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Firmware fundet</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Firmware fundet</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installation af %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installation af %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Tryk for at opdatere til %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Tryk for at opdatere til %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Tryk for at opdatere til %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Firmware bygge dato/tid</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Firmware bygge dato/tid</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Automatisk opdatering</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Automatisk opdatering</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Tjek kun</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Tjek kun</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Tjek og kun download</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Tjek og kun download</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Tjek og opdater</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Tjek og opdater</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Opdater feed</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Opdater feed</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Image type</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Image type</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normal</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normal</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Large</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Large</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Tjek for opdatering</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Tjek for opdatering</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Opdatering tilgængelig</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Opdatering tilgængelig</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Installerer %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Installerer %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Installerer %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Opdater bygge dato/tid</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Opdater bygge dato/tid</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Inverter</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Inverter</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Find PV invertere</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Find PV invertere</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Fundet IP adresser</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Fundet IP adresser</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Tilføj IP adresse manuelt</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Tilføj IP adresse manuelt</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>TCP Port</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>TCP Port</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Flerfaset</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Flerfaset</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Split-fase (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Split-fase (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Vis</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Vis</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1...</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1...</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1...</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2...</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2...</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Rescan efter IP-adresser?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Rescan efter IP-adresser?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Scan igen</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Scan igen</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH på LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH på LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Fjernsupport</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Fjernsupport</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Fjern support tunnel</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Fjern support tunnel</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>Fjern support IP og port</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>Fjern support IP og port</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Log ud nu</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Genstart nu</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Genstart nu</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Enheden er blevet genstartet.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Hørbar alarm</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Hørbar alarm</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Demo mode</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Demo mode</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS Demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS Demo</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Båd/Camper demo1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Båd/Camper demo1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Båd/camper demo 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Båd/camper demo 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Starter demo mode, nogle indstillinger samt bruger interfacet vil ikke responderer i et øjeblik.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Starter demo mode, nogle indstillinger samt bruger interfacet vil ikke responderer i et øjeblik.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Betingelser</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Betingelser</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Minimum køre tid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Minimum køre tid</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Opvarmningstid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Opvarmningstid</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Nedkølingstid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Nedkølingstid</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Find generator på AC input</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Find generator på AC input</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Ingen af AC indgangene er sat til generator. Gå til system opsætnings siden og sæt den korrekte AC input til generator for at aktivere denne funktion.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Ingen af AC indgangene er sat til generator. Gå til system opsætnings siden og sæt den korrekte AC input til generator for at aktivere denne funktion.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>En alarm vil blive udløst når der ikke kommer noget strøm fra generatoren til inverterens AC input. Vær sikker på at den korrekte AC input er sat til generatoren i opsætningen.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>En alarm vil blive udløst når der ikke kommer noget strøm fra generatoren til inverterens AC input. Vær sikker på at den korrekte AC input er sat til generatoren i opsætningen.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Stille periode start tid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Stille periode start tid</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Stille periode slut tid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Stille periode slut tid</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Køretid og service</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Køretid og service</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Reset daglig køretid tællere</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Reset daglig køretid tællere</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Den daglige køretid er nulstillet</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Den daglige køretid er nulstillet</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Det er ikke muligt at ændre tællerne når generatoren kører</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Det er ikke muligt at ændre tællerne når generatoren kører</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Generatorens serviceinterval (timer)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Generatorens serviceinterval (timer)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Servicetidsinterval indstillet til %1h. Brug knappen 'Nulstil servicetimer' til at nulstille servicetimeren.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Servicetidsinterval indstillet til %1h. Brug knappen &apos;Nulstil servicetimer&apos; til at nulstille servicetimeren.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Nulstil servicetimer</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Nulstil servicetimer</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>GPS indstillinger</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>GPS indstillinger</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Format</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Format</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Hastigheds enhed</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Hastigheds enhed</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilometer i timen</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilometer i timen</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Meter pr. sekund</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Meter pr. sekund</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Miles per hour</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Miles per hour</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Knob</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Knob</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Intet GSM modem tilsluttet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Intet GSM modem tilsluttet</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Udbyder</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Udbyder</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Det kan være nødvendigt at konfigurer APN indstillingerne under denne side, tjek din udbyder for detaljer.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Det kan være nødvendigt at konfigurer APN indstillingerne under denne side, tjek din udbyder for detaljer.
 Hvis det ikke virker, tjek Sim-kortet på en telefon for at være sikker på det virker og det virker med data.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Tillad roaming</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Tillad roaming</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>SIM status</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>SIM status</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM ikke indsat</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM ikke indsat</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN påkrævet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN påkrævet</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK krævet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK krævet</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>SIM Fejl</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>SIM Fejl</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM optaget</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM optaget</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Forkert SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Forkert SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Forkert PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Forkert PIN</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Klar</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Klar</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Ukendt fejl</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Standard</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Standard</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Brug standard APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Brug standard APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>APN navn</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>APN navn</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Brug godkendelse</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Brug godkendelse</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Brugernavn</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Brugernavn</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Eget-forbrug</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Eget-forbrug</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Ingen ESS assistent fundet</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Ingen ESS assistent fundet</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Net måling</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Net måling</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Ekstern måler</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Ekstern måler</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Inverter/oplader</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Inverter/oplader</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Inverter AC output i brug</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Inverter AC output i brug</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Multifase regulation</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Multifase regulation</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Total af alle phaser</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Total af alle phaser</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Individuel fase</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Individuel fase</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Hver fase reguleres individuelt for at opnå netindstillingspunktet (systemets effektivitet reduceres).
+        <translation>Hver fase reguleres individuelt for at opnå netindstillingspunktet (systemets effektivitet reduceres).
 
 FORSIGTIG: Må kun bruges, hvis det kræves af forsyningsleverandøren.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Summen af alle faser reguleres intelligent for at opnå nettets setpunkt (systemets effektivitet optimeres).
+        <translation>Summen af alle faser reguleres intelligent for at opnå nettets setpunkt (systemets effektivitet optimeres).
 
 Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inaktiv</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamisk ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Minimum SoC (med mindre nettet fejler)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Minimum SoC (med mindre nettet fejler)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Aktiv SoC grænse</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Aktiv SoC grænse</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Oprethold</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Opladning</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Peak shaving</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Peak shaving</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Kun over minimum SoC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Kun over minimum SoC</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Altid</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Altid</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Afladning deaktiveret</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Afladning deaktiveret</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Langsom ladning</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Langsom ladning</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Oprethold</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Oprethold</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Opladning</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Opladning</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Begræns opladnings power</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Begræns opladnings power</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Maksimum opladnings power</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Maksimum opladnings power</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Begræns inverter power</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Begræns inverter power</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Maksimum inverter power</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Maksimum inverter power</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Net setpoint</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Net setpoint</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Net feed-in</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Net feed-in</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>AC-koblet PV - Feed in overskud</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>AC-koblet PV - Feed in overskud</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>DC-Koblet PV - Feed in overskud</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>DC-Koblet PV - Feed in overskud</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Begræns systems feed-in</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Begræns systems feed-in</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Maksimum feed-in</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Maksimum feed-in</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Feed-in begrænsning aktiv</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Feed-in begrænsning aktiv</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Analoge input</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Analoge input</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Digitale input</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Digitale input</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Digital indgang %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Digital indgang %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Impuls måler</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Impuls måler</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Dør alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Dør alarm</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Sump pumpe</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Sump pumpe</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Sump alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Sump alarm</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Tyveri alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Tyveri alarm</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Røg alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Røg alarm</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Brand alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Brand alarm</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>CO2 alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>CO2 alarm</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Bluetooth sensorer</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Bluetooth sensorer</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Bemærk, at disse funktioner ikke er officielt understøttet af Victron. Venligst henvend dig til community.victronenergy.com for spørgsmål.
+        <translation>Bemærk, at disse funktioner ikke er officielt understøttet af Victron. Venligst henvend dig til community.victronenergy.com for spørgsmål.
 
 Dokumentation på https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Aktiveret (safe mode)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Aktiveret (safe mode)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Udsat med %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Udsat med %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>VRM Portal ID</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>VRM Portal ID</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Logføringsinterval</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Logføringsinterval</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 time</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 time</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 Timer</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 Timer</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 Timer</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 Timer</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 timer</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 timer</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 dag</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 dag</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Brug sikker forbindelse (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Brug sikker forbindelse (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Sidste kontakt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Sidste kontakt</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Uventet svartekst</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Uventet svartekst</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Uventet HTTP-svar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Uventet HTTP-svar</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Timeout for forbindelse</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Timeout for forbindelse</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Forbindelsesfejl</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Forbindelsesfejl</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 DNS-fejl</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 DNS-fejl</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Routing error</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Routing error</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM ikke tilgængelig</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM ikke tilgængelig</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Ukendt fejl</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Ukendt fejl</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Fejlmeddelelse:
+        <translation>Fejlmeddelelse:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Genstart enhed hvis der ingen kontakt er</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Genstart enhed hvis der ingen kontakt er</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Ingen kontakt rest Delay (tt:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Ingen kontakt rest Delay (tt:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Hukommelses lokation</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Hukommelses lokation</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Ingen buffer aktiv</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Ingen buffer aktiv</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Intern hukommelse</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Intern hukommelse</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Overfører</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Overfører</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Ekstern hukommelse</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Ekstern hukommelse</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Ukendt fejl</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Ingen fejl</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Ingen fejl</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Ingen plads tilbage i hukommelsen</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Ingen plads tilbage i hukommelsen</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>IO fejl</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>IO fejl</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Fejl, mount</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Fejl, mount</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Indeholder firmware fil. Bruges ikke</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Indeholder firmware fil. Bruges ikke</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD kort / USB nøgle ikke skrivbar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD kort / USB nøgle ikke skrivbar</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Fri disk plads</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Fri disk plads</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>byte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>byte</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bytes</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bytes</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Gemte filer</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Gemte filer</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 optegnelser</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 optegnelser</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Ældste fil alder</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Ældste fil alder</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Aktiver Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Aktiver Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Ingen fejl fundet</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Ingen fejl fundet</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Tid på sidste fejl</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Tid på sidste fejl</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Tilgængelige tjenester</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Tilgængelige tjenester</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>Enheds-ID: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>Enheds-ID: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Funktion (Relæ 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Funktion (Relæ 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Funktion</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Funktion</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Alarm relæ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Alarm relæ</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Tank pumpe</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Alarm relæ polaritet</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Alarm relæ polaritet</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normal åben</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normal åben</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normal lukket</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normal lukket</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relæ 1 til</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relæ 1 til</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relæ til</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relæ til</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Funktion (Relæ 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Funktion (Relæ 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relæ 2 til</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relæ 2 til</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Temperatur styrings regler</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Temperatur styrings regler</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Relæ aktivering med temperatur</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Relæ aktivering med temperatur</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Intet relæ er konfigureret til at blive aktiveret af temperaturen. Gå til siden med relæindstillinger i hovedindstillingsmenuen, og indstil relæfunktionen til "Temperatur".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Intet relæ er konfigureret til at blive aktiveret af temperaturen. Gå til siden med relæindstillinger i hovedindstillingsmenuen, og indstil relæfunktionen til &quot;Temperatur&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Denne tilstand tillader dig at skifte imellem den nuværende eller tidligere firmware version. Intet internet eller SD kort påkrævet.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Denne tilstand tillader dig at skifte imellem den nuværende eller tidligere firmware version. Intet internet eller SD kort påkrævet.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Tryk for Reboot</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Tryk for Reboot</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Genstarter til %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Genstarter til %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Det er ikke muligt at skifte firmwareversion, når automatisk opdatering er indstillet til "Kontroller og opdater". Indstil automatisk opdatering til "Deaktiveret" eller "Kun tjek" for at aktivere denne mulighed.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Det er ikke muligt at skifte firmwareversion, når automatisk opdatering er indstillet til &quot;Kontroller og opdater&quot;. Indstil automatisk opdatering til &quot;Deaktiveret&quot; eller &quot;Kun tjek&quot; for at aktivere denne mulighed.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Backup firmware ikke tilgængelig</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Backup firmware ikke tilgængelig</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Konsol på VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-bus over TCP/IP (fejlsøgning)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-bus over TCP/IP (fejlsøgning)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Solenergi</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Solenergi</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Køretøj</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Køretøj</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Båd</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Båd</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>System navn</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>System navn</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatisk</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatisk</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Forsyning</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatisk</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Brugerdefineret</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Brugerdefineret</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Brugerdefineret navn</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Brugerdefineret navn</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>AC input 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>AC input 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>AC input 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>AC input 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Overvåg for netstrøm fejl</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Overvåg for netstrøm fejl</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Overvåg for landstrøm afbrydelse</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Overvåg for landstrøm afbrydelse</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Automatisk valgt</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Automatisk valgt</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Har DC system</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Har DC system</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Synchroniser VE.Bus SoC med batteri</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Synchroniser VE.Bus SoC med batteri</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Brug sol lade strøm for optimere VE.Bus SoC</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Brug sol lade strøm for optimere VE.Bus SoC</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Sol lader volt styring</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Sol lader volt styring</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Sol lader strøm styring</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Sol lader strøm styring</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS styring</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS styring</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS styring</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Tankpumpens start/stop-funktion er ikke aktiveret. Gå til relæindstillinger, og indstil funktionen til "Tankpumpe".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Tankpumpens start/stop-funktion er ikke aktiveret. Gå til relæindstillinger, og indstil funktionen til &quot;Tankpumpe&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Pumpe tilstand</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Pumpe tilstand</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Tank sensor</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Tank sensor</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Start niveau</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Start niveau</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Stop niveau</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Stop niveau</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Forbindelse tabt</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Forbindelse tabt</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Utilsluttet</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Utilsluttet</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Skjult]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Skjult]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Forbind til netværk?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Forbind til netværk?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Anmod om adgang</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Anmod om adgang</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Glem netværk?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Glem netværk?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Glem</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Glem</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Er du sikker på at du vil glemme dette netværk?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Er du sikker på at du vil glemme dette netværk?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC adresse</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC adresse</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>Ip Konfiguration</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>Ip Konfiguration</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Fra</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Fast</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Fast</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Netmaske</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Netmaske</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Gateway</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Gateway</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS server</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS server</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Link-lokal IP adresse</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Link-lokal IP adresse</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Forsigtig, for ESS systemer såvel som systemer med styrede batterier, CAN-bus enhedens ID skal forblive som 0. Se GX for mere information.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Forsigtig, for ESS systemer såvel som systemer med styrede batterier, CAN-bus enhedens ID skal forblive som 0. Se GX for mere information.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Enhedsinstans</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Enhedsinstans</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Netværks adresse</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Netværks adresse</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>VE.CAN-enheder</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>VE.CAN-enheder</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Enhed# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Enhed# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Ingen access points</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Ingen access points</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Ingen Wi-fi adaptor tilsluttet</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Ingen Wi-fi adaptor tilsluttet</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Opret access point</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Opret access point</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Wi-fi netværk</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Wi-fi netværk</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Er du sikker på at du vil deaktivere Access pointen?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Er du sikker på at du vil deaktivere Access pointen?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Dato/tid UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Dato/tid UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Dato/tid lokal</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Dato/tid lokal</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Tidszone</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Tidszone</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afrika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afrika</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>America</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>America</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antarktis</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antarktis</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Arktisk</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Arktisk</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asien</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantisk</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantisk</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australien</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indien</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pacific</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pacific</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Ikke tilsluttet %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Ikke tilsluttet %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Genstart nu?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Genstart nu?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>VRM-instansændringer vil ikke blive anvendt, før enheden genstartes.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>VRM-instansændringer vil ikke blive anvendt, før enheden genstartes.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Enheden genstarter...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Enheden genstarter...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Enheden er blevet genstartet.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Enheden er blevet genstartet.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Lav batteri volt alarm</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Lav batteri volt alarm</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Høj batteri volt alarm</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Høj batteri volt alarm</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Sidste fejl</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Sidste fejl</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Anden sidste fejl</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Anden sidste fejl</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Tredje sidste fejl</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Tredje sidste fejl</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Fjerde sidste fejl</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Fjerde sidste fejl</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Netværket</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Netværket</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Tilstandsvælger</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Tilstandsvælger</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Standalone</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Standalone</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Standalone</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Oplad</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Oplad</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Ekstern styring</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Charge &amp; HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Charge &amp; HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Oplad &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Oplad &amp; BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Ext. styring &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Ext. styring &amp; BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Oplad, Hub-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Oplad, Hub-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Master indstilling</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Master indstilling</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Slave</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Slave</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Slave</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Gruppe Master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Gruppe Master</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Lade master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Lade master</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Gruppe &amp; lade master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Gruppe &amp; lade master</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Lade volt</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Lade volt</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Nulstil</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Nulstil</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>BMS-kontrol aktiveres automatisk, når BMS er til stede. Nulstil, hvis systemkonfigurationen ændres, eller hvis der ikke er nogen BMS til stede.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>BMS-kontrol aktiveres automatisk, når BMS er til stede. Nulstil, hvis systemkonfigurationen ændres, eller hvis der ikke er nogen BMS til stede.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Total PV power</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Indlæs</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Indlæs</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 fundet</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 fundet</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Historie</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Historie</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Historie</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Netværks tilstand</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Netværks tilstand</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Tabelvisning</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Tabelvisning</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Diagram</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Diagram</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Advarsel</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Advarsel</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarm</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Størrelse</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Størrelse</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Kortslutning</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Kortslutning</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Omvendt polaritet</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Omvendt polaritet</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Ladestationer til elbiler</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Ladestationer til elbiler</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Session</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Session</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Tid</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Tid</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Lade tilstand</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Lade tilstand</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Start og stop selv processen. Brug dette til hurtige opladninger og tæt overvågning.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Start og stop selv processen. Brug dette til hurtige opladninger og tæt overvågning.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Starter og stopper baseret på batteriets opladningsniveau. Optimal til opladning natten over og i længere tid for at undgå overopladning.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Starter og stopper baseret på batteriets opladningsniveau. Optimal til opladning natten over og i længere tid for at undgå overopladning.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Lavere elpriser i spidsbelastningsperioder, eller hvis du vil sikre, at din elbil er fuldt opladet og klar til at køre på et bestemt tidspunkt.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Lavere elpriser i spidsbelastningsperioder, eller hvis du vil sikre, at din elbil er fuldt opladet og klar til at køre på et bestemt tidspunkt.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Aktiver opladning</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Aktiver opladning</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Lås ladedisplay</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Lås ladedisplay</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Kildeadresse</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Kildeadresse</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Opsætning</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Opsætning</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Linje-instans #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Linje-instans #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Linie enhed</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Linie enhed</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Lade enhed</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Lade enhed</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Inverter enhed</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Inverter enhed</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC-kilde #%1 instans</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC-kilde #%1 instans</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>DC kilde enhed</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>DC kilde enhed</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC-kilde #%1 prioritet</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC-kilde #%1 prioritet</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>DC kilde prioritet</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>DC kilde prioritet</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Tank enhed</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Tank enhed</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>RV-C-enheder</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>RV-C-enheder</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Aktivér visualisering af billedhastighed</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Aktivér visualisering af billedhastighed</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Ikke understøttet</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Ikke understøttet</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Fjern afbrudte enheder</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Fjern afbrudte enheder</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Ukendt enhed fundet</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Ukendt enhed fundet</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Relæ funktion</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Relæ funktion</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Oplader eller generator start/stop</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Oplader eller generator start/stop</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Manuel styring</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Sikring sprunget</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Manuel styring</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Manuel styring</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Altid åben (brug ikke relæet)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Altid åben (brug ikke relæet)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Bemærk, at hvis du ændrer indstillingen for lav opladningstilstand, ændres også indstillingen for afladningsgulv for tid til at gå i batterimenuen.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Bemærk, at hvis du ændrer indstillingen for lav opladningstilstand, ændres også indstillingen for afladningsgulv for tid til at gå i batterimenuen.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Sikring sprunget</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Sikring sprunget</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Status LEDs</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Status LEDs</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Ingen</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Hoved kontakt</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Hoved kontakt</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Varmer</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Varmer</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Intern blæser</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Intern blæser</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Advarsels flag</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Advarsels flag</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Alarm Flag</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Alarm Flag</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Kontakt</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Kontakt</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Initialisere</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Initialisere</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Nedlukning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Nedlukning</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Opdaterer</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Opdaterer</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Kører om</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Kører om</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Præ opladning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Præ opladning</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Kontaktor test</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Kontaktor test</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>State of Health</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>State of Health</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Batteritemperatur</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Batteritemperatur</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Luft temperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Luft temperatur</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Starter volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Starter volt</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Bus Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Bus Volt</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Top sektion volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Top sektion volt</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Kommunikationsfejl</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">State of Health</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Bus Volt</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Bund sektion volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Bund sektion volt</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Mid-point afvigelse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Mid-point afvigelse</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Forbrugt amperetimer</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Forbrugt amperetimer</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Tid-tilbage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Tid-tilbage</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Detaljer</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Detaljer</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarmer på modulniveau</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarmer på modulniveau</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnosticering</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnosticering</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Sikringer</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Sikringer</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>System</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>System</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parametre</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parametre</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Genfind batteri</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Genfind batteri</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Tryk for at genfinde</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Tryk for at genfinde</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Tryk for at genfinde</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Genfind batteriet kan tage op til 60 sekunder. I mellemtiden kan navnet være forkert.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Genfind batteriet kan tage op til 60 sekunder. I mellemtiden kan navnet være forkert.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Høj lade strøm</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Høj lade strøm</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Høj afladningsstrøm</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Høj afladningsstrøm</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Lav SoC</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Lav SoC</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Høj batteri volt</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Lav SoC</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Lav starter volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Lav starter volt</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Høj starter volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Høj starter volt</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Batteri temperatur sensor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Batteri temperatur sensor</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Mid-point volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Mid-point volt</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Sikring sprunget</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Høj intern temperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Høj intern temperatur</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Lav lade temperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Lav lade temperatur</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Høj lade temperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Høj lade temperatur</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Intern fejl</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Intern fejl</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Sikring er sprunget</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Sikring er sprunget</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Celle ubalance</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Celle ubalance</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Lav celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Lav celle volt</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Laveste celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Laveste celle volt</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Højeste celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Højeste celle volt</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Minimum celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Minimum celle volt</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Maksimum celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Maksimum celle volt</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Batteri moduler</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Batteri moduler</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Antal moduler, der blokerer opladning/afladning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Antal moduler, der blokerer opladning/afladning</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Installeret / tilgængelig kapacitet</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Installeret / tilgængelig kapacitet</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Dybeste afladning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Dybeste afladning</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Sidste afladning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Sidste afladning</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Gennemsnitlig afladning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Gennemsnitlig afladning</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Total antal cyklusser</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Total antal cyklusser</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Antal fulde opladninger</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Antal fulde opladninger</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Kumuleret Ah brugt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Kumuleret Ah brugt</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Minimum celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Minimum celle volt</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Maksimum celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Maksimum celle volt</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Tid siden sidste fulde opladning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Tid siden sidste fulde opladning</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Synkroniserings tæller</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Synkroniserings tæller</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarmer for lav startbatterispænding</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarmer for lav startbatterispænding</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Minimum startbatterispænding</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Minimum startbatterispænding</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Maksimal startbatterispænding</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Maksimal startbatterispænding</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Afladt energi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Afladt energi</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Opladet energi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Opladet energi</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Charge Voltage Limit (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Charge Voltage Limit (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Charge Current Limit (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Charge Current Limit (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Discharge Current Limit (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Discharge Current Limit (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Lav volt frakobling (altid ignoreret)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Lav volt frakobling (altid ignoreret)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Batteri bank</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Batteri bank</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relæ (på batteri monitor)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relæ (på batteri monitor)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Gendan fabriks indstillinger</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Gendan fabriks indstillinger</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Tryk for at gendanne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Tryk for at gendanne</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Gendan fabriksindstillingerne?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Gendan fabriksindstillingerne?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth aktiv</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth aktiv</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Nominal volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Nominal volt</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Kapacitet</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Kapacitet</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapacitet</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Opladet volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Opladet volt</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Tail current</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Tail current</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Opladet detektionstid</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Opladet detektionstid</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Peukert eksponent</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Peukert eksponent</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Lade effektivitets faktor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Lade effektivitets faktor</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Strøm grænse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Strøm grænse</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Til-tilbage gennemsnitlig periode</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Til-tilbage gennemsnitlig periode</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Tid-Tilbage afladnings grænse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Tid-Tilbage afladnings grænse</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Strøm Offset</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Strøm Offset</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Synkroniser State-of-Charge til 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Synkroniser State-of-Charge til 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Tryk for synk.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Tryk for synk.</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Kalibrer nul strøm</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Kalibrer nul strøm</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Tryk for at sætte til 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Tryk for at sætte til 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Distributør %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Distributør %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Ingen strøm på busbar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Ingen strøm på busbar</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Forbindelse tabt</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n sikring(er) sprunget</numerusform>
-        <numerusform>%n sikring(er) sprunget</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n sikring(er) sprunget</numerusform>
+            <numerusform>%n sikring(er) sprunget</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Ingen information tilgængelig, se forrige side for distributørstatus.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Ingen information tilgængelig, se forrige side for distributørstatus.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Sikring %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Sikring %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Ikke brugt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Ikke brugt</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Sprunget</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Sprunget</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Nedluknings fejl</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Nedluknings fejl</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Sidste fejl</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">Anden sidste fejl</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">Tredje sidste fejl</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">Fjerde sidste fejl</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>System kontakt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>System kontakt</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Eksternt relæ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Eksternt relæ</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Programmerbart relæ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Programmerbart relæ</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Batterier</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Batterier</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapacitet</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Batterier</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Parallel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Parallel</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Serie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Serie</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Min/Max celle volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Min/Max celle volt</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Min/max celle temperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Min/max celle temperatur</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Balancering</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Balancering</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Balancering</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Ukendt</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Output</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Output</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Field drive</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Field drive</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Motor hastighed</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Motor hastighed</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Aux volt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Aux volt</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>ingen alarmer</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>ingen alarmer</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Lav volt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Lav volt</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Høj volt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Høj volt</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Lav aux volt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Lav aux volt</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Høj aux volt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Høj aux volt</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Lav aux volt alarmer</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Lav aux volt alarmer</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Høj aux volt alarmer</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Høj aux volt alarmer</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Minimum aux volt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Minimum aux volt</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Maximum aux volt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Maximum aux volt</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Produceret energi</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Produceret energi</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Forbrugt energi</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Forbrugt energi</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Aktiver alarm</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Aktiver alarm</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Aktiv niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Aktiv niveau</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Gendan niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Gendan niveau</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Forsinkelse</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Forsinkelse</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Niveau</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Resterende</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Resterende</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Sensor battery</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Sensor battery</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Sensor battery</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Sensor type</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Sensor type</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Standard</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Standard</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Europæiske (0 til 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Europæiske (0 til 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>US (240 til 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>US (240 til 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Brugerdefineret</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Brugerdefineret</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Brugerdefineret</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Sensor værdi når fuld</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Sensor værdi når fuld</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Væske type</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Væske type</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Butan forhold</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Butan forhold</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Bruger form</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Bruger form</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Gennemsnitlig tid</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Gennemsnitlig tid</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Sensor værdi</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Sensor værdi</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Ingen brugerdefineret form defineret. Du kan definere en med op til ti punkter. Bemærk, at 0% og 100% er underforstået.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Ingen brugerdefineret form defineret. Du kan definere en med op til ti punkter. Bemærk, at 0% og 100% er underforstået.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punkt %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Tilføj punkt</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Tilføj punkt</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Sensor niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Sensor niveau</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Størrelse</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Duplikerede sensorniveauværdier er ikke tilladt.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Duplikerede sensorniveauværdier er ikke tilladt.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Volumenværdierne skal være stigende.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Volumenværdierne skal være stigende.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Ulåst (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Ulåst (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Ulåst (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Ulåst (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Ulåst (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Ulåst (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Ulåst</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Ulåst</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Fase konfiguration</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Fase konfiguration</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Kontakt position</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Kontakt position</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Enkelt fase</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2-Faset</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2-Faset</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3-Faset</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3-Faset</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Enhed fundet</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Hastighed</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Indlæs</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Kølevæske temperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Kølevæske temperatur</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Udstødnings temperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Udstødnings temperatur</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Spole temperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Spole temperatur</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Starter batteri volt</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Starter batteri volt</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Antal starter</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Antal starter</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS styring</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Frontvælger låst (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Frontvælger låst (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Ingen fejl (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Ingen fejl (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC Total</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC Total</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energi L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energi L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Fase sekvens</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Fase sekvens</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Datamanagerversion</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Datamanagerversion</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Ingen</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Blinkende LED indikere denne CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Blinkende LED indikere denne CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Smappee bus enheder</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Smappee bus enheder</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>Sol lader</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>Sol lader</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Denne indstilling er deaktiveret, når der er tilsluttet en Digital Multi Control.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Denne indstilling er deaktiveret, når der er tilsluttet en Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Denne indstilling er deaktiveret, når en VE.Bus BMS er tilsluttet.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Denne indstilling er deaktiveret, når en VE.Bus BMS er tilsluttet.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC ind %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC ind %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Omvendt</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Omvendt</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Aktiver alarm</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Omvendt</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Omvend alarm logik</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Omvend alarm logik</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Irradiance</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Irradiance</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Celle temperetur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Celle temperetur</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Ekstern temperatur (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Ekstern temperatur (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Ekstern temperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Ekstern temperatur</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Ekstern temperatur (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Ekstern temperatur (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Vind hastighed</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Vind hastighed</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Auto opdag</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Auto opdag</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Vind hastigheds sensor</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Vind hastigheds sensor</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Ekstern temperatur sensor</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Ekstern temperatur sensor</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Sum</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Sum</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Gange</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Gange</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Nulstil tæller</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Nulstil tæller</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Kortslutning</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Omvendt polaritet</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Lav sensor batteri</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Lav sensor batteri</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Fugtighed</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Fugtighed</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Tryk</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Tryk</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Lav</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Offset</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Skala</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Skala</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Sensor volt</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Sensor volt</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Total PV power</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Total PV power</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Produktside</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Produktside</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>AC-sensor %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>AC-sensor %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>En ny MK3-version er tilgængelig.
+        <translation>En ny MK3-version er tilgængelig.
 BEMÆRK: Opdateringen kan stoppe systemet midlertidigt.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Opdatering af MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Opdatering af MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Tryk for at opdatere</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Tryk for at opdatere</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Ved opdatering af MK3, vil værdierne dukke op igen, efter at opdateringen er fuldført</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Ved opdatering af MK3, vil værdierne dukke op igen, efter at opdateringen er fuldført</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Opladning af batteriet til 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Opladning af batteriet til 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Opladning af batteriet til 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Avanceret</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>I gang</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>I gang</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Tryk for at stoppe</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Tryk for at stoppe</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Tryk for at starte</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Tryk for at starte</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Oplad batteriet til 100%.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Oplad batteriet til 100%.</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Systemet vender tilbage til normal drift og prioriterer vedvarende energi.
+        <translation>Systemet vender tilbage til normal drift og prioriterer vedvarende energi.
 Ønsker du at fortsætte?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Landstrøm vil blive brugt, når den er tilgængelig, og indstillingen "Solar &amp; wind priority" vil blive ignoreret.
+        <translation>Landstrøm vil blive brugt, når den er tilgængelig, og indstillingen &quot;Solar &amp; wind priority&quot; vil blive ignoreret.
 Ønsker du at fortsætte?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Landstrøm vil blive brugt til at fuldføre en fuld batteriopladning én gang.
+        <translation>Landstrøm vil blive brugt til at fuldføre en fuld batteriopladning én gang.
 Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift og prioriterer sol- og vindenergi.
 Ønsker du at fortsætte?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Jævnspænding</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Jævnspænding</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>DC Strøm</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>DC Strøm</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Avanceret</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Avanceret</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Alarm opsætning</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Alarm opsætning</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>En VE.Bus BMS slukker automatisk systemet hvis nødvendigt for at beskytte batteriet. Styring af systemet fra en Color Control er derfor ikke muligt,</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>En VE.Bus BMS slukker automatisk systemet hvis nødvendigt for at beskytte batteriet. Styring af systemet fra en Color Control er derfor ikke muligt,</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>EN BMS assistent er installeret til VE.Bus BMS, men der er ikke fundet en VE.Bus BMS!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>EN BMS assistent er installeret til VE.Bus BMS, men der er ikke fundet en VE.Bus BMS!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Advarsel: Aktivering af udligning i et ESS-anlæg med solcelleladere kan forårsage opladning af batteriet ved højspænding med for høj strøm.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Advarsel: Aktivering af udligning i et ESS-anlæg med solcelleladere kan forårsage opladning af batteriet ved højspænding med for høj strøm.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Systemet vil automatisk skifte over til Float når equalisering er færdig.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Systemet vil automatisk skifte over til Float når equalisering er færdig.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Afbryd equalisering</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Afbryd equalisering</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Equalisering</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Equalisering</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Afbryder...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Afbryder...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Starter...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Starter...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Starter...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Tryk for at afbryde</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Tryk for at afbryde</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Afbryd og genstart absorbering</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Afbryd og genstart absorbering</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Afbryd og gå til Float</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Afbryd og gå til Float</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Afbryd</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Afbryd</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Afbryd ikke</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Afbryd ikke</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Genopdag VE.Bus-system</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Genopdag VE.Bus-system</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Genfinder...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Genfinder...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Genstart VE.Bus-system</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Genstart VE.Bus-system</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Genstarter...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Genstarter...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Tryk for genstart</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Tryk for genstart</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>AC input 1 ignoreret</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>AC input 1 ignoreret</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>AC input 2 ignoreret</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>AC input 2 ignoreret</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>ESS Relæ test</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>ESS Relæ test</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Registreringen er udført</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Afventer...</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Registreringen er udført</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Registreringen er udført</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Afventer...</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Afventer...</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>VE.Bus diagnose</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>VE.Bus diagnose</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Netværkskvalitetstæller Fase L%1, enhed %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Netværkskvalitetstæller Fase L%1, enhed %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.bus fejl 8/11 rapport</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.bus fejl 8/11 rapport</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Kun alarm</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Kun alarm</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarmer &amp; advarsler</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarmer &amp; advarsler</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>BMS Fejl</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>BMS Fejl</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Serienumre</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Serienumre</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Sidste VE.Bus Error 11-rapport #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Sidste VE.Bus Error 11-rapport #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>BF-sikkerhedstest i gang</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>BF-sikkerhedstest i gang</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>BF sikkerhedstest OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>BF sikkerhedstest OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>AC0 /AC1 uoverensstemmelse</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>AC0 /AC1 uoverensstemmelse</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Kommunikationsfejl</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Kommunikationsfejl</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>GND Relæfejl</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>GND Relæfejl</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>UMains mismatch</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>UMains mismatch</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Periode Tidsforskydning</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Periode Tidsforskydning</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Uoverensstemmelse mellem BF-relæets drev</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Uoverensstemmelse mellem BF-relæets drev</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Fejl: PE2 åben</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Fejl: PE2 åben</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Fejl: PE2 lukket</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Fejl: PE2 lukket</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Fejl i trin: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Fejl i trin: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Fase L%1, enhed %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Fase L%1, enhed %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>VE.Bus fejl 11 rapportering kræver mindst VE.Bus firmware version 454.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>VE.Bus fejl 11 rapportering kræver mindst VE.Bus firmware version 454.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus Quirks</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus Quirks</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energi</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energi</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Strømforsyning</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Strømforsyning</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Spænding</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Spænding</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Strøm</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Strøm</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Lokation</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Lokation</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Fase</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Aktiv AC input</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Aktiv AC input</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Høj DC Ripple</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Høj DC Ripple</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Høj DC volt</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Høj DC volt</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Høj DC strøm</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Høj DC strøm</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Temperatur sensor fejl</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Temperatur sensor fejl</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Volt sense fejl</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Volt sense fejl</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Overbelastning</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Overbelastning</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>DC Ripple</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>DC Ripple</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Volt Sensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Volt Sensor</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Fase rotation</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Fase rotation</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Fase rotation</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>VE.Bus version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>VE.Bus version</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2 enhed</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2 enhed</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>MK2 version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>MK2 version</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Multi Control version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Multi Control version</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>VE.Bus BMS version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>VE.Bus BMS version</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Med mindre nettet fejler</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Med mindre nettet fejler</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>AC Ind</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>AC Ind</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC IND</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC IND</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>AC input 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>AC input 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>AC input 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>AC input 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Rolle</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Rolle</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC Load</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC Load</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>AC UD</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>AC UD</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>Vekselstrømsudgang</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>Vekselstrømsudgang</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Fase L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Fase L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>AC-sensor %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>AC-sensor %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>AC-sensorer</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>AC-sensorer</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Aktiv</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Aktiv</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Overbelastning</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Alarm tilstand</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Alarm tilstand</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarmer</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarmer</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Tillad at oplade</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Tillad at oplade</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Tillad at aflade</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Tillad at aflade</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Automatisk søgning</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Automatisk søgning</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Batteri</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Batteri strøm</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Batteri strøm</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Batteri volt</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Batteri volt</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Opladning</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Opladning</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Oplader</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Oplader</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Fjern fejl</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Fjern fejl</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Lukket</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Lukket</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Forbundet</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Forbundet</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Strøm</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Strøm</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Strøm transformer</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Strøm transformer</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Eget navn</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Eget navn</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Debug</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Debug</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Enhed</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Enhed</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deaktiveret</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Aflader</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Aflader</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Afbrudt.</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Afbrudt.</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Aktiver</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Aktiver</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Aktiveret</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Aktiveret</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energi</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energi</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Fejl</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Fejl</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Fejl:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Fejl:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Fejl kode</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Fejl kode</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Firmwareversion</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Firmwareversion</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generator</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Høj batteri temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Høj batteri temperatur</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Høj niveau alarm</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Høj niveau alarm</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Høj starter batteri volt</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Høj starter batteri volt</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Høj temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Høj temperatur</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Høj volt alarmer</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Høj volt alarmer</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Historie</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Historie</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 time(r)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 time(r)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Inaktiv</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Inaktiv</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inaktiv</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inaktiv</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Inverter/oplader</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP adresse</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP adresse</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Lav batteri temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Lav batteri temperatur</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Lav niveau alarm</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Lav niveau alarm</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Lav starter batteri volt</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Lav starter batteri volt</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Lav State of Charge</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Lav State of Charge</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Lav temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Lav temperatur</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Lav volt alarmer</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Lav volt alarmer</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Fabrikant</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Fabrikant</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Maksimum temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Maksimum temperatur</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Maksimum volt</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Maksimum volt</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Minimum temperator</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Minimum temperator</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Minimum volt</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Minimum volt</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Mode</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Mode</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Model navn</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Model navn</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Nej</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Nej</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Ingen fejl</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Ingen fejl</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Ikke tilgængelig</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Ikke tilgængelig</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Ikke forbundet</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Ikke forbundet</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Offline</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Offline</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>OK</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>OK</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>On</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>On</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Åben</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Åben</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Adgangskode</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Adgangskode</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Fase</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Tryk for at fjerne</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Tryk for at fjerne</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Tryk for at nulstille</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Tryk for at nulstille</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Tryk for søge</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Tryk for søge</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>PV Inverter</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>PV Inverter</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>PV-strøm</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>PV-strøm</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Stille periode</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Stille periode</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relæ</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relæ</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Genstart</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Genstart</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Fjerne</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Fjerne</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>Kører</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>Kører</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Scanning %1</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Scanning %1</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Serienummer</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Serienummer</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Indstillinger</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Indstillinger</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Opsætning</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Opsætning</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Signal styrke</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Signal styrke</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Standby</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Standby</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Start når betingelsen er opnået for</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Start når betingelsen er opnået for</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Start tid</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Start tid</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Start værdi under stille periode</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Start værdi under stille periode</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Start når advarsel er aktiv</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Start når advarsel er aktiv</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>State of Charge</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>State of Charge</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Tilstand</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Tilstand</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Opstart (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Opstart (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Stop værdi under stille periode</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Stop værdi under stille periode</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Stop efter betingelsen er opnået for</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Stop efter betingelsen er opnået for</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Stoppet</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Stoppet</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Temperatur sensor</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Temperatur sensor</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>I dag</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>I dag</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>I alt</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>I alt</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Overvåg</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Overvåg</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Type</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Type</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Unikt identitetsnummer</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Unikt identitetsnummer</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Ukendt</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Ukendt</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>VE.Bus fejl</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>VE.Bus fejl</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Spænding</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Spænding</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Forekomst af enhed</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Forekomst af enhed</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Når advarsel er ryddet stop efter</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Når advarsel er ryddet stop efter</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Ja</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Ja</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>I går</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>I går</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Produktion</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Produktion</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Ingen Feed-in power grænse</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Ingen Feed-in power grænse</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Angiv dato</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Angiv dato</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Start nu</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Start nu</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Tidstyret kørsel</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Tidstyret kørsel</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Stop nu</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Stop nu</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Total køretid</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Total køretid</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Indstil tid %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Indstil tid %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Generatoren vil fortsætte med at køre, hvis en autostart-betingelse er opfyldt.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Generatoren vil fortsætte med at køre, hvis en autostart-betingelse er opfyldt.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Inverter/oplader-tilstand</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Inverter/oplader-tilstand</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Gem</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Gem</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Annuller</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Luk</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Luk</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Sæt tid</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Sæt tid</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Allerede i brug</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Allerede i brug</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Swap-fejl</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Swap-fejl</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Ombytning afsluttet</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Ombytning afsluttet</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Udskiftning af enhedsinstanser...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Udskiftning af enhedsinstanser...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Enhedsinstansen %1 er allerede brugt af '%3'. Byt om på enhedsinstanser og tildel den til %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Enhedsinstansen %1 er allerede brugt af &apos;%3&apos;. Byt om på enhedsinstanser og tildel den til %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Enhedsinstansen %1 bruges allerede af en anden enhed af samme type. Byt om på enhedsinstanser og tildel den til %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Enhedsinstansen %1 bruges allerede af en anden enhed af samme type. Byt om på enhedsinstanser og tildel den til %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Kan ikke udskifte enhedsinstanser: operation timet ud.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Kan ikke udskifte enhedsinstanser: operation timet ud.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Nye enhedsinstanser vil være aktive ved genstart.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Nye enhedsinstanser vil være aktive ved genstart.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Bytte</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Bytte</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Fejl under søgning efter firmwareopdateringer</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Fejl under søgning efter firmwareopdateringer</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Downloader og installerer firmware %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Downloader og installerer firmware %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Installerer firmware...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Installerer firmware...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Fejl under installation af firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Fejl under installation af firmware</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Ingen nyere version tilgængelig</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Ingen nyere version tilgængelig</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Ingen firmware fundet</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Ingen firmware fundet</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Brændstof (L)</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Brændstof (L)</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Ferskvand</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Ferskvand</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Affalds vand</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Affalds vand</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Drikkevand</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Drikkevand</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Olie</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Olie</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Sort vand</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Sort vand</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzin</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzin</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diesel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diesel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Hydraulik olie</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Hydraulik olie</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Rå vand</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Rå vand</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Indstilling af låst adgangsniveau</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Indstilling af låst adgangsniveau</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Forkert adgangskode</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Forkert adgangskode</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Kort</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Kort</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Oversigt</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Oversigt</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Niveauer</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Niveauer</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Meddelelser</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Meddelelser</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Nu</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Nu</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>For 1 måned siden</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>For 1 måned siden</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1h %2m ago</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1h %2m ago</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Hver dag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Hver dag</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Ugedage</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Ugedage</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Wekkender</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Wekkender</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Mandag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Mandag</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Tirsdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Tirsdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Onsdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Onsdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Torsdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Torsdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Fredag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Fredag</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Lørdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Lørdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Søndag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Søndag</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 eller %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 eller %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Skema %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Skema %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Dag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Dag</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Ikke sat</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Ikke sat</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>SoC grænse</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>SoC grænse</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Eget-forbrug over grænse</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Eget-forbrug over grænse</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>PV &amp; Batteri</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>PV &amp; Batteri</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Tjekker...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Tjekker...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Alarm tilstand</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Alarm tilstand</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Ryd historie</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Ryd historie</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Fjerner</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Fjerner</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Tvangs tændt</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Tvangs tændt</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Tvangs slukket</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Tvangs slukket</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Relæ tilstand</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Relæ tilstand</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Nulstil historikken på selve skærmen</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Nulstil historikken på selve skærmen</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Tryk for eject</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Tryk for eject</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Ejecting, vent venligst</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Ejecting, vent venligst</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Ingen hukommelse</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Ingen hukommelse</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD/USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD/USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 temperatur sensor</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 temperatur sensor</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 temperatursensor (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 temperatursensor (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Temperatursensor (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Temperatursensor (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Ingen handlinger</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Ingen handlinger</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Advarsel: Aktiverings- og deaktiveringstemperaturerne er indstillet til den samme værdi. Dette vil medføre, at tilstanden ignoreres.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Advarsel: Aktiverings- og deaktiveringstemperaturerne er indstillet til den samme værdi. Dette vil medføre, at tilstanden ignoreres.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Tilstand %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Tilstand %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Funktion deaktiv</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Funktion deaktiv</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Ingen (Deaktiveret)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Ingen (Deaktiveret)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relæ 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relæ 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relæ 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relæ 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Advarsel: Det ovenstående relæ er ikke konfigureret til temperatur, betingelser bliver ignoreret.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Advarsel: Det ovenstående relæ er ikke konfigureret til temperatur, betingelser bliver ignoreret.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Aktiverings regel</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Aktiverings regel</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Volumenenhed</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Volumenenhed</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Kubikmeter</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Kubikmeter</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Liter (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Liter (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Gallons (US)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Gallons (US)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Gallons (Imperial)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Gallons (Imperial)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Min volt</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Min volt</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Max volt</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Max volt</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Max volt</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Maks. strøm</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Maks. strøm</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Opladningstid</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Opladningstid</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Float</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Float</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Float</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>hr</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>hr</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 fejl(e) opstod</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 fejl(e) opstod</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Indlæs</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Indlæs</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2. sidste</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2. sidste</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3. sidste</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3. sidste</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4. sidste</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4. sidste</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Maks. effekt</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Maks. effekt</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Kan ikke forbinde</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Kan ikke forbinde</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Afbrudt, forsøger at genoprette forbindelsen</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Afbrudt, forsøger at genoprette forbindelsen</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Forbinder...</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Forbinder...</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Forbinder...</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Forbundet, afventer mæglerbeskeder</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Forbundet, afventer mæglerbeskeder</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Forbundet, modtager mæglerbeskeder</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Forbundet, modtager mæglerbeskeder</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Tilsluttet, indlæst brugergrænseflade</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Tilsluttet, indlæst brugergrænseflade</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Ugyldig protokolversion</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Ugyldig protokolversion</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Klient-ID afvist</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Klient-ID afvist</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Mæglerservice ikke tilgængelig</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Mæglerservice ikke tilgængelig</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Dårligt brugernavn eller password</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Dårligt brugernavn eller password</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Klienten er ikke autoriseret</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Klienten er ikke autoriseret</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Fejl i transportforbindelsen</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Fejl i transportforbindelsen</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Fejl ved overtrædelse af protokol</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Fejl ved overtrædelse af protokol</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>MQTT-protokol niveau 5 fejl</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>MQTT-protokol niveau 5 fejl</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Sluk for alarmen</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Sluk for alarmen</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Total styrke</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Total styrke</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2t</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2t</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1t %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1t %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Fejl</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Fejl</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Henter IP adresse</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Henter IP adresse</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Forbundet</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Afbrudt</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Afbrudt</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Afbrudt.</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC forbrug</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC forbrug</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>DC forbrug</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>DC forbrug</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Vind</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Vind</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Kyst</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Kyst</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Grænse for netstrøm</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Grænse for netstrøm</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Generatorens strømbegrænsning</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Generatorens strømbegrænsning</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Grænse for landstrøm</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Grænse for landstrøm</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Stopper</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Stopper</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Stopper</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 tilbage</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 tilbage</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 tank (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 tank (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>AC Lader</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>AC Lader</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Generator</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>DC-oplader</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>DC-oplader</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>DC-generator</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>DC-generator</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC SYSTEM</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC SYSTEM</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Brændselscelle</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Brændselscelle</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Aksel Generator</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Aksel Generator</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Vandturbine</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Vandturbine</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Vindmølle</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Vindmølle</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Lav</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Lav</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Høj</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Høj</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Hold batterierne opladet</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Hold batterierne opladet</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimeret med batterilevetid</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimeret med batterilevetid</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimeret uden BatteryLife</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimeret uden BatteryLife</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Ekstern styring</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Opladet</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Opladet</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Venter på solen</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Venter på solen</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Venter på RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Venter på RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Venter på start</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Venter på start</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Fejl i jordtest</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Fejl i jordtest</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>CP input test fejl</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>CP input test fejl</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Fejlstrøm opdaget</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Fejlstrøm opdaget</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Undervolt opdget</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Undervolt opdget</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Overvolt opdaget</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Overvolt opdaget</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Overophedning opdaget</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Overophedning opdaget</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Lade grænse</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Lade grænse</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Start opladning</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Start opladning</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Planlagt</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Planlagt</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Planlagt</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Opvarmning</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Opvarmning</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Nedkøling</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Nedkøling</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Test kørsel</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Test kørsel</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Manuelt startet</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Manuelt startet</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Boot loading</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Boot loading</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>Kører (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>Kører (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>Kører (Begrænset)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>Kører (Begrænset)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relæ %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relæ %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Fejl</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Fejl</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorbering</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorbering</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Opbevaring</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Opbevaring</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Udjævn</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Udjævn</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Ekstern styring</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>AES tilstand</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>AES tilstand</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Fejltilstand</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Fejltilstand</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Hurtig opladning</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Hurtig opladning</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Opladning af absorption</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Opladning af absorption</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Opladning af flyder</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Opladning af flyder</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Storage mode</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Storage mode</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Udligningsopladning</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Udligningsopladning</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Pass-thru</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Pass-thru</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Inverting</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Inverting</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Hjælpende</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Hjælpende</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Strømforsyningstilstand</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Strømforsyningstilstand</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Oprethold</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Vågn op</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Vågn op</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Gentagne Absorbering</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Gentagne Absorbering</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Automatisk udligning</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Automatisk udligning</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>Spar batteri</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>Spar batteri</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Registrering af belastning</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Registrering af belastning</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Blokeret</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Blokeret</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamisk ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dynamisk ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dynamisk ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Gruppe Master</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Gruppe Master</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Enheds Master</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Enheds Master</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Gruppe &amp; ensheds master</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Gruppe &amp; ensheds master</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Standalone &amp; gruppe master</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Standalone &amp; gruppe master</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Kun opladning</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Kun opladning</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Kun inverter</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Kun inverter</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Lav batteri volt alarm</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Høj batteri volt alarm</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Kortslutnings alarm</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Kortslutnings alarm</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Deaktiver Access point</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Deaktiver Access point</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>DC-indgang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>DC-indgang</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>For litiumbatterier anbefales en opladning på under 10 % ikke. For andre batterityper skal du tjekke databladet for det minimumsniveau, der anbefales af producenten.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>For litiumbatterier anbefales en opladning på under 10 % ikke. For andre batterityper skal du tjekke databladet for det minimumsniveau, der anbefales af producenten.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Deaktiverer du autostart?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Deaktiverer du autostart?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Inverter/oplader (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Inverter/oplader (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Vis CPU-brug</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Vis CPU-brug</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Afslut applikation</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Afslut applikation</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Stop</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Stop</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Applikationsversion</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Applikationsversion</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Olietemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Olietemperatur</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Bemærk, at en ændring af indstillingen Time-to-go discharge floor også ændrer indstillingen Low state-of-charge i relæmenuen.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Bemærk, at en ændring af indstillingen Time-to-go discharge floor også ændrer indstillingen Low state-of-charge i relæmenuen.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Drifts tid</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Drifts tid</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Ladede Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Ladede Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Startede cyklusser</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Startede cyklusser</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Fuldendte cyklusser</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Fuldendte cyklusser</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Antal power-ups</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Antal power-ups</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Antal dybe afledninger</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Antal dybe afledninger</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Historik for opladningscyklus</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Historik for opladningscyklus</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Sensor værdi når lav</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Sensor værdi når lav</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Tid til service</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Tid til service</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Autostart-funktionalitet</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Autostart-funktionalitet</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Sørg for, at generatoren ikke er tilsluttet AC-indgangen %1, når du bruger denne indstilling.</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Sørg for, at generatoren ikke er tilsluttet AC-indgangen %1, når du bruger denne indstilling.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Servicetimeren er blevet nulstillet</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Servicetimeren er blevet nulstillet</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Kontinuerlig scanning kan forstyrre Wi-Fi-funktionen.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Kontinuerlig scanning kan forstyrre Wi-Fi-funktionen.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Minimum og maksimum måleområde</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Minimum og maksimum måleområde</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Startside</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Genstarter applikationen...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Genstarter applikationen...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Det lykkedes ikke at skifte sprog!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Det lykkedes ikke at skifte sprog!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Aldrig</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Vent venligst, mens sproget ændres.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Vent venligst, mens sproget ændres.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Kort visning enhed</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Kort visning enhed</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Ingen etiketter</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Ingen etiketter</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Vis tankvolumener</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Vis tankvolumener</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Vis procenter</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Vis procenter</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Bemærk: Hvis strøm ikke kan vises (f.eks. når der vises en total for kombinerede AC- og DC-kilder), vises effekt i stedet.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Bemærk: Hvis strøm ikke kan vises (f.eks. når der vises en total for kombinerede AC- og DC-kilder), vises effekt i stedet.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Grænser for opladningsstrøm</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Grænser for opladningsstrøm</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Officiel udgivelse</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Officiel udgivelse</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Beta version</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Beta version</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Test (Victron intern)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Test (Victron intern)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Udvikle (Victron internt)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Udvikle (Victron internt)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Genstarter...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Genstarter...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Aktivér status-LED'er</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Aktivér status-LED&apos;er</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Opvarmning og nedkøling</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Opvarmning og nedkøling</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Generatorens stoptid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Generatorens stoptid</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarm, når generatoren ikke er i autostart-tilstand</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarm, når generatoren ikke er i autostart-tilstand</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>En alarm udløses, når autostart-funktionen er deaktiveret i mere end 10 minutter.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>En alarm udløses, når autostart-funktionen er deaktiveret i mere end 10 minutter.</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Selvforbrug fra batteri</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Selvforbrug fra batteri</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Alle systembelastninger</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Alle systembelastninger</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Kun kritiske belastninger</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Kun kritiske belastninger</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Minimum SoC (med mindre nettet fejler)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Status for batteriets levetid</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Status for batteriets levetid</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Få adgang til Signal K på http://venus.local:3000 og via VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Få adgang til Signal K på http://venus.local:3000 og via VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Få adgang til Node-RED på https://venus.local:1881 og via VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Få adgang til Node-RED på https://venus.local:1881 og via VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Batteri målinger</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Batteri målinger</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Systemstatus</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Systemstatus</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Enhedsoversigt</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Enhedsoversigt</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>VRM-enhedsinstanser</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>VRM-enhedsinstanser</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Høj temperatur alarm</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Høj temperatur alarm</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>BMS kontrolleret</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>BMS kontrolleret</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarmer og fejl</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarmer og fejl</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Denne funktion kræver firmwareversion 400 eller højere. Kontakt din installatør for at opdatere din Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Denne funktion kræver firmwareversion 400 eller højere. Kontakt din installatør for at opdatere din Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Opladeren er ikke klar, udligning kan ikke startes</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Opladeren er ikke klar, udligning kan ikke startes</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Udligning kan ikke udløses under masseopladningstilstand</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Udligning kan ikke udløses under masseopladningstilstand</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Maksimum strøm</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Maksimum strøm</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Maksimal effekt</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Maksimal effekt</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Minimum strømstyrke</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Minimum strømstyrke</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Ingen</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Ikke tilgængelig</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Fra</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Overordnet historie</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Overordnet historie</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Indstillinger</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Ukendt</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Produktion idag</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Produktion idag</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware installeret, enheden genstarter</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware installeret, enheden genstarter</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Touch input control</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Touch input control</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Testfejl for svejsede kontakter (kortsluttet)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Testfejl for svejsede kontakter (kortsluttet)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Skift til 3-fase</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Skift til 3-fase</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Skift til 1 fase</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Skift til 1 fase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Stop opladning</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Stop opladning</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Reserveret</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Reserveret</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Inverter-tilstand</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Inverter-tilstand</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Out L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Out L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Input</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Input</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Gennemgang</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Gennemgang</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Siden genindlæses automatisk om ti sekunder for at indlæse den nyeste version.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Siden genindlæses automatisk om ti sekunder for at indlæse den nyeste version.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Inverter (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Inverter (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Vekselretter/opladere</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Vekselretter/opladere</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Ingen energimålere fundet
+        <translation>Ingen energimålere fundet
 
 Bemærk, at denne menu kun viser Carlo Gavazzi-målere, der er tilsluttet via RS485. For alle andre målere, herunder Carlo Gavazzi-målere, der er tilsluttet via ethernet, skal du i stedet se menuen Modbus TCP/UDP-enheder.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Auto-ranging</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Auto-ranging</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Når den er aktiveret, justeres minima og maksima for målere og grafer automatisk ud fra tidligere værdier.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Når den er aktiveret, justeres minima og maksima for målere og grafer automatisk ud fra tidligere værdier.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Nulstil alle områdets værdier til nul</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Nulstil alle områdets værdier til nul</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Nulstil områdeværdier</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Nulstil områdeværdier</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Er du sikker på, at du vil nulstille alle værdier?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Er du sikker på, at du vil nulstille alle værdier?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Maksimal strømstyrke: AC i 1 tilsluttet</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Maksimal strømstyrke: AC i 1 tilsluttet</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Maksimal strømstyrke: AC i 2 tilsluttede</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Maksimal strømstyrke: AC i 2 tilsluttede</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Maksimal strøm: ingen AC-indgange</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Maksimal strøm: ingen AC-indgange</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>DC-udgang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>DC-udgang</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solenergi</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solenergi</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Motor RPM</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Motor RPM</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Motor temperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Motor temperatur</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Controller temperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Controller temperatur</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Aktiv cyklus</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Aktiv cyklus</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Cyklus %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Cyklus %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>DC frakobling</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>DC frakobling</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Slukket</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Slukket</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Ændring af funktion</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Ændring af funktion</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Firmware-opdatering</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Firmware-opdatering</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Nulstilling af software</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Nulstilling af software</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Ufuldstændig</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Ufuldstændig</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Forløbet tid</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Forløbet tid</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Opladning/vedligeholdelse (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Opladning/vedligeholdelse (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Batteri (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;slut&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Batteri (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;slut&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Lav AC OUT volt</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Lav AC OUT volt</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Høj AC OUT volt</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Høj AC OUT volt</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Total produktion</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Total produktion</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Systemets produktion</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Systemets produktion</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Daglig historie</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Daglig historie</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Ingen alarmer at konfigurere</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Ingen alarmer at konfigurere</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Maksimum PV volt</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Maksimum PV volt</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Maksimum batteri vol</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Maksimum batteri vol</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Minimum batteri volt</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Minimum batteri volt</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Fejl i batteribanken</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Fejl i batteribanken</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Batterispænding understøttes ikke</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Batterispænding understøttes ikke</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Forkert antal batterier</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Forkert antal batterier</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Ugyldig batterikonfiguration</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Ugyldig batterikonfiguration</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Balancer status</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Balancer status</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Balanceret</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Balanceret</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Ubalance</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Ubalance</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Brug denne mulighed i systemer, der ikke udfører peak shaving.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Brug denne mulighed i systemer, der ikke udfører peak shaving.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Brug denne indstilling til peak shaving.</translation>
+        <translation>Brug denne indstilling til peak shaving.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Tærsklen for peak shaving indstilles ved hjælp af indstillingen for AC-indgangsstrøm. Se dokumentation for yderligere oplysninger.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Tærsklen for peak shaving indstilles ved hjælp af indstillingen for AC-indgangsstrøm. Se dokumentation for yderligere oplysninger.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Spidslastgrænserne for import og eksport kan ændres på denne skærm. Se dokumentation for yderligere information.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Spidslastgrænserne for import og eksport kan ændres på denne skærm. Se dokumentation for yderligere information.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Begræns systemets AC-importstrøm</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Begræns systemets AC-importstrøm</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>For at bruge denne funktion skal netmåling være indstillet til Ekstern måler, og der skal være installeret en opdateret ESS-assistent.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>For at bruge denne funktion skal netmåling være indstillet til Ekstern måler, og der skal være installeret en opdateret ESS-assistent.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Maksimal systemimportstrøm (pr. fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Maksimal systemimportstrøm (pr. fase)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Netmåling skal være indstillet til Ekstern måler for at bruge denne funktion.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Netmåling skal være indstillet til Ekstern måler for at bruge denne funktion.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Maksimal systemeksportstrøm (pr. fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Maksimal systemeksportstrøm (pr. fase)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Wired</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Wired</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Kort</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Høj systembelastning, luk sidepanelet for at reducere CPU-belastningen</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Høj systembelastning, luk sidepanelet for at reducere CPU-belastningen</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Input nuværende grænse</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Input nuværende grænse</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Kortslutning</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Kortslutning</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Køb af</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Køb af</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Salg</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Salg</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Mål SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Mål SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC ud %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC ud %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Tracker</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Tracker</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>RS-enheder</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>RS-enheder</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Sæt elektronanimationer på pause</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Sæt elektronanimationer på pause</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Samlet kapacitet</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Samlet kapacitet</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Antal BMS'er</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Antal BMS&apos;er</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Begræns systemets AC-eksportstrøm</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Begræns systemets AC-eksportstrøm</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Modbus TCP/UDP-enheder</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Modbus TCP/UDP-enheder</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Tilføj enhed</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Tilføj enhed</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Skan for enheder</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Skan for enheder</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Gemte enheder</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Gemte enheder</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Opdagede enheder</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Opdagede enheder</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Tilføj Modbus TCP/UDP-enhed</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Tilføj Modbus TCP/UDP-enhed</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protokol</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protokol</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Port</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Port</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Enhed</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Enhed</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Ingen Modbus-enheder gemt</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Ingen Modbus-enheder gemt</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Enhed %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Enhed %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Fjerne Modbus-enhed?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Fjerne Modbus-enhed?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Ingen Modbus-enheder fundet</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Ingen Modbus-enheder fundet</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Batteri %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Batteri %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>AC Strøm</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>AC Strøm</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Generator start/stop deaktiveret</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Generator start/stop deaktiveret</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Fjernstartfunktionen er deaktiveret på aggregatet. GX vil ikke være i stand til at starte eller stoppe aggregatet nu. Aktivér den på aggregatets kontrolpanel.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Fjernstartfunktionen er deaktiveret på aggregatet. GX vil ikke være i stand til at starte eller stoppe aggregatet nu. Aktivér den på aggregatets kontrolpanel.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Auto start funktion</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Auto start funktion</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Nuværende køretid</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Kontrolstatus</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Kontrolstatus</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Genset-status</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Genset-status</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Fjernstart-tilstand</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Fjernstart-tilstand</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Olietryk</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Olietryk</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Skema lade niveauer</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Skema lade niveauer</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Aktiv (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Aktiv (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Manuelt stop</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Manuelt stop</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Åbent kredsløb</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Åbent kredsløb</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (ikke tilgængelig)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (ikke tilgængelig)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Touch input til</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Touch input til</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Touch input fra</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Touch input fra</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Touch input deaktiveret</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Touch input deaktiveret</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Bekræft advarsler</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Bekræft advarsler</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Kontrolfejlkode</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Kontrolfejlkode</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Brug denne menu til at definere de batteridata, der vises, når du klikker på batteriikonet på oversigtssiden. Det samme valg er også synligt på VRM-portalen.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Brug denne menu til at definere de batteridata, der vises, når du klikker på batteriikonet på oversigtssiden. Det samme valg er også synligt på VRM-portalen.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Systemets spænding</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Systemets spænding</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Oplysninger om forbindelse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Oplysninger om forbindelse</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Vælg venligst...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Vælg venligst...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Sikret</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Sikret</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Beskyttet med adgangskode, og netværkskommunikationen er krypteret</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Beskyttet med adgangskode, og netværkskommunikationen er krypteret</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Svag</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Svag</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Passwordbeskyttet, men netværkskommunikationen er ikke krypteret</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Passwordbeskyttet, men netværkskommunikationen er ikke krypteret</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Usikret</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Usikret</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Ingen adgangskode, og netværkskommunikationen er ikke krypteret</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Ingen adgangskode, og netværkskommunikationen er ikke krypteret</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Adgangskoden skal være mindst 8 tegn lang</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Indtast adgangskode</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Adgangskoden skal være mindst 8 tegn lang</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Adgangskoden skal være mindst 8 tegn lang</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Vælg profilen 'Sikret'?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Vælg profilen &apos;Sikret&apos;?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Vælg 'Svag' profil?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Vælg &apos;Svag&apos; profil?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Vælg profilen 'Usikret'?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Vælg profilen &apos;Usikret&apos;?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Lokale netværkstjenester er beskyttet med adgangskode
+        <translation>- Lokale netværkstjenester er beskyttet med adgangskode
 - Netværkskommunikationen er krypteret
 - En sikker forbindelse med VRM er aktiveret
 - Usikre indstillinger kan ikke aktiveres</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokale netværkstjenester er beskyttet med adgangskode
+        <translation>- Lokale netværkstjenester er beskyttet med adgangskode
 - Ukrypteret adgang til lokale hjemmesider er også aktiveret (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokale netværkstjenester behøver ikke en adgangskode
+        <translation>- Lokale netværkstjenester behøver ikke en adgangskode
 - Ukrypteret adgang til lokale hjemmesider er også aktiveret (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Adgangskode til roden</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Adgangskode til roden</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Log ud</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Log ud</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Log ud nu</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Log ud nu</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Logge ud?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Logge ud?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Dette vil afbryde alle lokale netværksforbindelser.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Dette vil afbryde alle lokale netværksforbindelser.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Log af</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Log af</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Skrivebeskyttet</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Skrivebeskyttet</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Fuld</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Fuld</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Er du sikker?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Er du sikker?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Hvis du ændrer denne indstilling til Skrivebeskyttet eller Fra, bliver du låst ude.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Hvis du ændrer denne indstilling til Skrivebeskyttet eller Fra, bliver du låst ude.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>MQTT-adgang</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>MQTT-adgang</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' er ikke et tal.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; er ikke et tal.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Bekræft</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Bekræft</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Brug et tal med %1 cifre eller mindre.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Brug et tal med %1 cifre eller mindre.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' er ikke en gyldig IP-adresse.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; er ikke en gyldig IP-adresse.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' er ikke et gyldigt portnummer. Brug et tal mellem 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; er ikke et gyldigt portnummer. Brug et tal mellem 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 er ikke et gyldigt enhedsnummer. Brug et tal mellem 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 er ikke et gyldigt enhedsnummer. Brug et tal mellem 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Nuværende køretid</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Nuværende køretid</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Genset-fejlkoder</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Genset-fejlkoder</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Kølelegemets temperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Kølelegemets temperatur</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Lade volt</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Opladningsspændingen styres i øjeblikket af BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Opladningsspændingen styres i øjeblikket af BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Ladestrøm grænse</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Ladestrøm grænse</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>BMS kontrolleret</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>BMS kontrolleret</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>BMS styring er automatisk aktiveret når en BMS er tilstede. 
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>BMS styring er automatisk aktiveret når en BMS er tilstede. 
 Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Servicetimer deaktiveret.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Servicetimer deaktiveret.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>VRM-portal</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>VRM-portal</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (VPN-fjernadgang)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (VPN-fjernadgang)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>En sikkerhedsprofil skal konfigureres, før netværkstjenesterne kan aktiveres, se Indstillinger - Generelt</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>En sikkerhedsprofil skal konfigureres, før netværkstjenesterne kan aktiveres, se Indstillinger - Generelt</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' blev erstattet med '%2', da den indeholdt ugyldige tegn.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; blev erstattet med &apos;%2&apos;, da den indeholdt ugyldige tegn.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Initialisering...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Initialisering...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Backend starter...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Backend starter...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend stoppet.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend stoppet.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Forbindelsen mislykkedes.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Forbindelsen mislykkedes.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Denne GX-enhed er logget ud af Tailscale.
+        <translation>Denne GX-enhed er logget ud af Tailscale.
 
 Vent venligst eller tjek din internetforbindelse.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Jeg venter på svar fra Tailscale.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Jeg venter på svar fra Tailscale.</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Tilslut denne GX-enhed til din Tailscale-konto ved at åbne dette link:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Tilslut denne GX-enhed til din Tailscale-konto ved at åbne dette link:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Vent venligst eller tjek din internetforbindelse.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Vent venligst eller tjek din internetforbindelse.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Ukendt tilstand: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Ukendt tilstand: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Fejl: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Fejl: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Deaktiver Tailscale for at redigere disse indstillinger.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Deaktiver Tailscale for at redigere disse indstillinger.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Aktiver haleskala</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Aktiver haleskala</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Maskinens navn</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Maskinens navn</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Log ud af Tailscale-konto</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Log ud af Tailscale-konto</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Adgang til lokalt netværk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Adgang til lokalt netværk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Adgang til lokalt ethernet-netværk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Adgang til lokalt ethernet-netværk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Få adgang til lokalt WiFi-netværk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Få adgang til lokalt WiFi-netværk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Brugerdefineret(e) netværk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Brugerdefineret(e) netværk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Eksempel: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Eksempel: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Forklaring:
+        <translation>Forklaring:
 
 Denne funktion, som Tailscale kalder subnet routes, giver fjernadgang til andre enheder i det/de lokale netværk.
 
@@ -7386,2989 +8028,3057 @@ Feltet custom networks accepterer en kommasepareret liste over undernet med CIDR
 Når du har tilføjet/aktiveret et nyt netværk, skal du godkende det i Tailscale-administratorens konsol én gang.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Brugerdefinerede "haleopskalering"-argumenter</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Brugerdefinerede &quot;haleopskalering&quot;-argumenter</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Brugerdefineret server-URL (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Brugerdefineret server-URL (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Denne generatorstyring kræver et hjælperelæ for at blive styret, men hjælperelæet er ikke konfigureret. Konfigurer venligst Relæ 1 under Indstillinger → Relæ til "Tilsluttet hjælperelæ til generator".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Denne generatorstyring kræver et hjælperelæ for at blive styret, men hjælperelæet er ikke konfigureret. Konfigurer venligst Relæ 1 under Indstillinger → Relæ til &quot;Tilsluttet hjælperelæ til generator&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarmer for høj startbatterispænding</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarmer for høj startbatterispænding</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Spring opvarmning af generator over</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Spring opvarmning af generator over</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Op, men ingen tjenester (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Op, men ingen tjenester (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Root-adgangskode ændret til %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Root-adgangskode ændret til %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Tilsluttet genset-hjælperelæ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Tilsluttet genset-hjælperelæ</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Placering af AC-belastninger</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Placering af AC-belastninger</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>AC-indgang og -udgang</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>AC-indgang og -udgang</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Brug denne indstilling, når der er AC-belastninger på inverterens/laderens indgang. Brug denne indstilling, hvis du er usikker.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Brug denne indstilling, når der er AC-belastninger på inverterens/laderens indgang. Brug denne indstilling, hvis du er usikker.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Kun AC-udgang</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Kun AC-udgang</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Brug denne indstilling, når systemet bruger en netmåler, men alle vekselstrømsbelastninger er på inverterens/laderens udgang.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Brug denne indstilling, når systemet bruger en netmåler, men alle vekselstrømsbelastninger er på inverterens/laderens udgang.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Månedligt</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Månedligt</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>EV Lader</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>EV Lader</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Varmepumpe</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Varmepumpe</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Væsentlige belastninger</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Væsentlige belastninger</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Start og stop generatoren baseret på de konfigurerede autostartbetingelser.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Start og stop generatoren baseret på de konfigurerede autostartbetingelser.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Indstillinger for jævnstrømsgenerator</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Indstillinger for jævnstrømsgenerator</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Generatorens temperatur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Generatorens temperatur</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Motorens temperatur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Motorens temperatur</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Total køretid</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Total køretid</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Profil for netværkssikkerhed</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Profil for netværkssikkerhed</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Sidste %1 dage</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Sidste %1 dage</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generatoren stopper i %1, medmindre der er aktiveret autostartbetingelser, som holder den kørende.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generatoren stopper i %1, medmindre der er aktiveret autostartbetingelser, som holder den kørende.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generatoren kører, indtil den stoppes manuelt, medmindre der er aktiveret autostartbetingelser, som holder den kørende.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generatoren kører, indtil den stoppes manuelt, medmindre der er aktiveret autostartbetingelser, som holder den kørende.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Klassisk brugergrænseflade</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Klassisk brugergrænseflade</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Ny brugergrænseflade</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Ny brugergrænseflade</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Vellykket ændring af sprog!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Begrænsning af effekt</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Vellykket ændring af sprog!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>For Multi-RS- og HS19-enheder er ESS-indstillingerne tilgængelige på RS-systemets produktside.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>For Multi-RS- og HS19-enheder er ESS-indstillingerne tilgængelige på RS-systemets produktside.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Start/stop af generator</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Start/stop af generator</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Det er ikke muligt at skifte firmwareversion uden at vælge "Netværkssikkerhedsprofil" i "Indstillinger / Generelt".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Det er ikke muligt at skifte firmwareversion uden at vælge &quot;Netværkssikkerhedsprofil&quot; i &quot;Indstillinger / Generelt&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Varighed</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Varighed</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Systemets alarmer</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Systemets alarmer</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Ingen systemalarmer</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Ingen systemalarmer</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Tilbage</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Tilbage</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Hvad er nyt</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Hvad er nyt</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>skip</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>skip</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Velkommen!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Velkommen!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Vi er glade for at kunne præsentere en helt nydesignet brugerflade, der forbedrer både brugervenligheden og æstetikken i din GX.
+        <translation>Vi er glade for at kunne præsentere en helt nydesignet brugerflade, der forbedrer både brugervenligheden og æstetikken i din GX.
 
 Med strømlinet navigation og et nyt look er alt det, du elsker, nu endnu lettere at få adgang til og mere visuelt tiltalende.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Mørk - lys tilstand</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Mørk - lys tilstand</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Forskellige miljøer kræver forskellige skærmindstillinger. Mørke og lyse tilstande sikrer den bedste oplevelse, uanset hvor du er.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Forskellige miljøer kræver forskellige skærmindstillinger. Mørke og lyse tilstande sikrer den bedste oplevelse, uanset hvor du er.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Alle de vigtige oplysninger, du har brug for, præsenteret i et rent og enkelt layout. Midtpunktet er en widget med ringe, som kan tilpasses, og som giver dig hurtig adgang til din systemindsigt på et øjeblik.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Alle de vigtige oplysninger, du har brug for, præsenteret i et rent og enkelt layout. Midtpunktet er en widget med ringe, som kan tilpasses, og som giver dig hurtig adgang til din systemindsigt på et øjeblik.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Få større kontrol med vores opdaterede oversigtspanel, der indeholder systemdata i realtid - alt sammen på ét sted for nem overvågning.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Få større kontrol med vores opdaterede oversigtspanel, der indeholder systemdata i realtid - alt sammen på ét sted for nem overvågning.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Kontrol</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Kontrol</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Alle de daglige kontroller er nu samlet i den nye kontrolrude. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Alle de daglige kontroller er nu samlet i den nye kontrolrude. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watt og ampere</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watt og ampere</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Du kan nu skifte mellem watt og ampere. Vælg den enhed, der passer bedst til dine præferencer.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Du kan nu skifte mellem watt og ampere. Vælg den enhed, der passer bedst til dine præferencer.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Lær mere</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Lær mere</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Gå ind på linket nedenfor for at finde ud af mere om den fornyede brugergrænseflade.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Gå ind på linket nedenfor for at finde ud af mere om den fornyede brugergrænseflade.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Scan QR-koden for at få mere at vide om Renewed UI.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Scan QR-koden for at få mere at vide om Renewed UI.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Færdig</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Færdig</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Næste</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Næste</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Fejl: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Fejl: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Aktiv Fejl</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Aktiv Fejl</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Total generator køre tid (timer)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Total generator køre tid (timer)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Startside</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Startside</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Brugergrænseflade</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Brugergrænseflade</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Brugergrænseflade (fjernkonsol)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Brugergrænseflade (fjernkonsol)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 opdateret</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 opdateret</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>Brugergrænsefladen skifter til %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>Brugergrænsefladen skifter til %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 er indstillet til %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Denne PV-inverter har understøttelse af effektbegrænsning. Deaktiver denne indstilling, hvis den forstyrrer den normale drift.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 er indstillet til %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Tryk på 'OK' for at genstarte</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Tryk på &apos;OK&apos; for at genstarte</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Node-RED fabriksnulstilling</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Node-RED fabriksnulstilling</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Er du sikker på, at du vil nulstille Node-RED til fabriksindstillingerne? Det vil slette alle dine flows.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Er du sikker på, at du vil nulstille Node-RED til fabriksindstillingerne? Det vil slette alle dine flows.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Forbindelsesstatus</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Forbindelsesstatus</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Forbindelsesstatus (HTTPS-kanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Forbindelsesstatus (HTTPS-kanal)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Forbindelsesstatus (HTTP-kanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Forbindelsesstatus (HTTP-kanal)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Forbindelsesstatus (MQTT Realtidskanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Forbindelsesstatus (MQTT Realtidskanal)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Forbindelsesstatus (MQTT RPC-kanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Forbindelsesstatus (MQTT RPC-kanal)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Startet automatisk - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Startet automatisk - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Deaktiverings regel</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Deaktiverings regel</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Kører ikke</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Kører ikke</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Tab af kommunikation</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Tab af kommunikation</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>SOC-tilstand</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>SOC-tilstand</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>AC-belastningstilstand</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>AC-belastningstilstand</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Batteriets aktuelle tilstand</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Batteriets aktuelle tilstand</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Batterispændingens tilstand</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Batterispændingens tilstand</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Overbelastning af inverteren</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Overbelastning af inverteren</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Opladning/afladning deaktiveret</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Opladning/afladning deaktiveret</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Opladning deaktiveret</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Opladning deaktiveret</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 udledning deaktiveret</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 udledning deaktiveret</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Kort</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Trusse (åbent sidepanel)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Trusse (åbent sidepanel)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Oversigt</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Niveauer (tanke)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Niveauer (tanke)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Niveauer (miljø)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Niveauer (miljø)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Liste over batterier</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Liste over batterier</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>GX-enheden er blevet opdateret</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>GX-enheden er blevet opdateret</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Efter %n minut(ter)</numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Efter %n minut(ter)</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Gå til denne side, når programmet starter.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Gå til denne side, når programmet starter.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Timeout</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Timeout</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Vend tilbage til startsiden, når applikationen er inaktiv.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Vend tilbage til startsiden, når applikationen er inaktiv.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Efter et minuts inaktivitet vælges den aktuelle side som startside, hvis den findes på denne liste.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Efter et minuts inaktivitet vælges den aktuelle side som startside, hvis den findes på denne liste.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Denne strømgrænse er fast i systemkonfigurationen. Den kan ikke justeres.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Denne strømgrænse er fast i systemkonfigurationen. Den kan ikke justeres.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Tilstanden er fast i systemkonfigurationen. Den kan ikke justeres.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Tilstanden er fast i systemkonfigurationen. Den kan ikke justeres.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Generatorens start/stop-funktion er ikke aktiveret, gå til relæindstillinger og sæt funktionen til "Genset start/stop"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Marokkansk standard tid</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>W. Central Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>South Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Namibia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Egypt Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Argentina Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>E. South America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Greenland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Montevideo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Newfoundland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>SA Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Central Brazilian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Paraguay Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Venezuela Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>SA Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>US Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Canada Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Central America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Central Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Mountain Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>US Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacific Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Alaskan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutian</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Kamchatka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Magadan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Vladivostok Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Yakutsk Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Tokyo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Korea Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Singapore Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ulaanbaatar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Taipei Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>North Asia East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>China Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>North Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>N. Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Bangladesh Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Nepal Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Sri Lanka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>India Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Pakistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Ekaterinburg Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Georgian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Caucasus Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Azerbaijan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Afghanistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Iran Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arab Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Syria Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Middle East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Jordan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Israel Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Azores Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Cape Verde Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Tasmania Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>E. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>AUS Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Cen. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>AUS Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Dateline Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Central Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Central European Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>E. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Belarus Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Russian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Turkey Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Mauritius Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Christmas Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Tonga Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fiji Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hawaiian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Easter Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Generatorens start/stop-funktion er ikke aktiveret, gå til relæindstillinger og sæt funktionen til &quot;Genset start/stop&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Ukendt</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Sol produktion</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">DC-indgang</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC forbrug</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">DC forbrug</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Oversigt</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Tilstand</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Total produktion</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Systemets produktion</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Kun alarm</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarmer &amp; advarsler</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Advarsel</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Ingen fejl</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Ingen fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Ukendt fejl: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Ukendt fejl: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Ingen fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Ingen fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Batteri kommunikation fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Batteri kommunikation fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Ingen batterier tilsluttet</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Ingen batterier tilsluttet</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Ukendt battery</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Ukendt battery</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Forskellige batteri typer</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Forskellige batteri typer</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Antal forkerte batterier</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Antal forkerte batterier</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt ikke fundet</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt ikke fundet</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Batteri måler fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Batteri måler fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Intern beregnings fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Intern beregnings fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Antal forkerte batterier i serie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Antal forkerte batterier i serie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Hardware fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Hardware fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Watchdog fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Watchdog fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Over volt</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Over volt</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Under volt</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Under volt</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Over temperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Over temperatur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Under temperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Under temperatur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Underopladnings standby</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Underopladnings standby</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>ADC fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>ADC fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Batteri komm. fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Batteri komm. fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Pre-charge fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Pre-charge fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Sikkerheds kontakt fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Sikkerheds kontakt fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Batteri opdaterings fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Batteri opdaterings fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>BMS kabel fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>BMS kabel fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Ference volt fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Ference volt fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Forkert system volt</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Forkert system volt</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Præ lade timeout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Præ lade timeout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>ATC/ATD fejl</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>ATC/ATD fejl</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibrerings data tabt</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibrerings data tabt</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Indstillinger ugyldige</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Indstillinger ugyldige</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Interlock</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Interlock</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Nød stop</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Nød stop</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Timeout for kommunikation</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Timeout for kommunikation</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Sikkerhedslås</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Sikkerhedslås</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Terminal over temperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Terminal over temperatur</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Ingen fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Batteri temperatur høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Batteri volt høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Batteri Tsense fejlforbundet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Batteri Tsense mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Batteri Vsense fejlforbundet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Batteri Vsense mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Batteri stor kabel tab</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Batteri lav volt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Batteri høj ripple volt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Batteri lav SoC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Batteri mid-point volt fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Batteri temperatur for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Lader temperatur høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Oplader over strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Oplader negativ strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Oplader bulk tid udløbet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Oplader strøm sensor problem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Intern Tsensor fejlforbundet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Intern Tsensor mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Lade blæser ikke fundet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Lade blæser overbelastet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Lader terminal overophedning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Lader kortsluttet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Lade sluttrin problem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Overopladnings beskyttelse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Input volt høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Input overstrøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Input over power</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Input polaritets fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Input volt mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Input nedlukning (ingen genstart)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Input nedlukning (forsøger igen)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Input intern fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>PV isolerings fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Jord fejl opdaget</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Inverter overload</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Inverter temp for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Inverter strøm peak</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Inverter intern DC niveau</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Inverter forkert ACout niveau</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Inverter powerstage fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Inverter forbundet til AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>ACIN1 Relæ test fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>ACIN2 Relæ test fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Enhed forsvundet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Inkompatibel enhed</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>BMS forbindelse tabt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Netværk ukonfigureret</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Fase rotation</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Flere AC-indgange</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Faseoverbelastning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Hukommelses skrive fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>CPU temperatur for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Tabt kommunikation</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibrerings data tabt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Inkompatibel firmware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Inkompatibel hardware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Indstillinger ugyldige</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Reference volt fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Tester fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Historie invalid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>kWh-tællere ugyldige</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>DC volt fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>GFCI sensor fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>3V3 forsynings fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>5V forsynings fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>12V forsynings fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>15V forsynings fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>PV-indgang nedlukning</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Sæt kontakten i en ulåst position for at ændre indstillingerne.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Brug D-Bus-datakilde: Opret forbindelse til den angivne D-Bus-adresse.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>adresse</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Brug D-Bus-datakilde: Opret forbindelse til standard D-Bus-adressen</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Brug MQTT-datakilde: Opret forbindelse til den angivne MQTT-mægleradresse.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>adresse</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>MQTT datakilde enheds portal-id.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>portalId</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>MQTT VRM webhost shard</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>skår</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>MQTT datakilde brugernavn</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Bruger</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>MQTT datakilde adgangskode</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>Godkendt</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>MQTT-datakildetoken</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Token kode</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Aktiver FPS-tæller</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Spring splash-skærm over</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Brug falsk datakilde til test.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Enhed slukket</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Mix ny/gammel MK2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Forventede enheds fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Ingen andre enheder fundet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Overvolt på AC-OUT</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>DDC program fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS uden assistent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Jord relæ test fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>System tids synk fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Netstrøm relæ test fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Config mismatch with 2nd mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Device transmit error</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Afventer konfiguration eller dongle mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Fase master mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Overvolt er sket</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Slave har intet AC input!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Enhed kan ikke være slave</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>System beskyttelse igangsat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Firmware inkompalitet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Intern fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Mislykket relætest forhindrer forbindelse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>VE.Bus fejl</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Ukendt fejl:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Intern fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Ingen fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Batteri temperatur høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Batteri volt høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Batteri lav volt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Batterispænding overskredet konfigureret max</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Høj generator temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Generator høj RPM</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Field drive FET høj temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Nødvendig sensor mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Lav generator strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Generator høj spænding offset</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Generatorspænding overskredet konfigureret max</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Høj spænding i alternatoren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Batteri frakoblet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Batteri høj volt afbrydelse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Batteri enhed out of range</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>For mange BMS'er</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Batteri er ved at afbryde</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>For mange enheder at spore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Batteri lav spændingsafbrydelse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Batteri høj spændingsafbrydelse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Batteri høj temperatur afbrydelse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Batteri lav temperatur afbrydelse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>BMS forbindelse tabt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC deaktiveret</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>DC/DC converter ikke klar</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC høj primærspænding</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC lav primærspænding</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC høj sekundær strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC lav sekundær strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC høj temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>DC/DC fejlkonfiguration</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Batteriets temperatursensor er defekt</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Ukendt fejl:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Ukendt fejl:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Ingen fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Batteri temperatur høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Batteri volt høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Batteri Tsense fejlforbundet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Batteri Tsense mangler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Batteri Vsense fejlforbundet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Batteri Vsense mangler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Batteri stor kabel tab</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Batteri lav volt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Batteri høj ripple volt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Batteri lav SoC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Batteri mid-point volt fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Batteri temperatur for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Lader temperatur høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Oplader over strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Oplader negativ strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Oplader bulk tid udløbet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Oplader strøm sensor problem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Intern Tsensor fejlforbundet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Intern Tsensor mangler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Lade blæser ikke fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Lade blæser overbelastet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Lader terminal overophedning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Lader kortsluttet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Lade sluttrin problem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Overopladnings beskyttelse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Input volt høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Input overstrøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Input over power</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Input polaritets fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Input volt mangler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Input nedlukning (ingen genstart)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Input nedlukning (forsøger igen)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Input intern fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>PV isolerings fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Jord fejl opdaget</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Inverter overload</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Inverter temp for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Inverter strøm peak</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Inverter intern DC niveau</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Inverter forkert ACout niveau</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Inverter powerstage fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Inverter forbundet til AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>ACIN1 Relæ test fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>ACIN2 Relæ test fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Enhed forsvundet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Inkompatibel enhed</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>BMS forbindelse tabt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Netværk ukonfigureret</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Fase rotation</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Flere AC-indgange</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Faseoverbelastning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Hukommelses skrive fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>CPU temperatur for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Tabt kommunikation</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibrerings data tabt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Inkompatibel firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Inkompatibel hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Indstillinger ugyldige</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Reference volt fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Tester fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Historie invalid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>kWh-tællere ugyldige</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>DC volt fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>GFCI sensor fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>3V3 forsynings fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>5V forsynings fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>12V forsynings fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>15V forsynings fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>PV-indgang nedlukning</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Ukendt fejl:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Ukendt fejl:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Ukendt fejl:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Ukendt fejl:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Ingen fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>AC volt L1 for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>AC volt for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>AC volt L1 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>AC volt for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>AC frekvens L1 for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>AC frekvens for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>AC frekvens L1 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>AC frekvens for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC strøm L1 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>AC strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>AC power L1 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>AC power for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Nød stop</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Servo strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Olie tryk for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Olie tryk for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Motor temperatur for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Motor temperatur for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Spole temperatur for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Spole temperatur for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Udstødnings temperatur for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Udstødnings temperatur for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Elektronisk temperatur lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Elektronisk temperatur høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Startspænding for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Starter strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Glødespænding for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Gløderør strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Cold-Start-Aid-spænding for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Cold-Start-Aid-strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Brændstofmagnetens spænding er for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Brændstof holde magnet strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Stop solenoid hold coil spænding for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Stop solenoid holde spole strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Stop solenoid pull coil spænding for lav </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Stop solenoide træk spol strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Ventilator/vandpumpespænding for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Blæser/vandpumpestrøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Strømfølerens spænding er lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Nuværende sensorstrøm høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Boost-udgangsspænding for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Boost output strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Busforsyningsspænding for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Busforsyningens strøm er for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Starter batteri volt for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Starter batteri volt for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Rotation for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Rotation for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Uventet stop/problem med brændstoftilførsel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Strømkontaktorens spænding er for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Power kontakt strøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>AC volt L2 for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>AC volt L2 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>AC frekvens L2 for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>AC frekvens L2 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>AC strøm L2 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>AC power L2 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>AC volt L3 for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>AC volt L3 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>AC frekvens L3 for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>AC frekvens L3 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC strøm L3 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>AC power L3 for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Inverterens udgangsspænding er for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Output Inverterstrøm for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Universel udgangsspænding (1A) for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Universaludgangens (1A) strøm er for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Universel udgangsspænding (5A) for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Universaludgangens (5A) strøm er for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT DC-spænding 1 lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>AGT DC-spænding 1 høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT DC-strøm 1 lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT DC-strøm 1 høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>AGT DC-spænding 2 lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>AGT DC-spænding 2 høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT DC-strøm 2 lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT DC-strøm 2 høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 køler lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6-køler høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 skinne (-) lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 skinne (-) høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 skinne (+) lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 skinne (+) høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Brændstof temperatur for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Brændstof temperatur for høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Brændstof niveau for lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Mangler styrer enhed</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Mangler panel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Service påkræves</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Mangler 3-faset modul</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Mangler AGT modul</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Synkroniserings fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Mistet ekstern ECU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Luft filter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Diagnostisk meddelelse (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Mangler Synk. modul</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Load-balancering fejlet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Synk-mode deaktiveret</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Rød stoplygte (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Gul advarselslampe (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Indikatorlampe for funktionsfejl (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Beskyttelseslampe (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Rotationsfelt fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Brændstof sensor mangler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Start uden inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Bus #1 død</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Anmodning om start afvist</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Fjernstart nægtet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Tvungen frakobling af belastningsrelæ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Synkroniseringsmodulet er offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Tabt BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Konverter DC Link Voltage Low/Reverse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Konverter DC Link Current Low</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Konverter DC forladningsspænding lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Konverter DC-forladningsspænding Høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Omformer IGBT/MOSFET-driverfejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Konverterfejl Effektkontrolsløjfe</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Detektering af AC-frekvens på konverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Fejl i konverterens kontrolværdi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Fabriksindstilling ændret</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parameter ændret i admin-tilstand</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Manuel indgriben (ekstra system)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Init fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Invertertemperatur høj L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Invertertemperatur høj L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Inverterens temperatur er høj L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Invertertemperatur høj DC-link</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Inverter overload</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Inverter kommunikations fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>DC overbelastning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>DC overvolt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Ingen forbindelse</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Ingen fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Ukendt fejl: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Ukendt fejl:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Olietryk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Overtemperatur i topstykket</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Kontrol af opladning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Højere hastighed end forventet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Overdreven hastighed</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Olietemperaturen højere end forventet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Olietemperatur åbent kredsløb/kortslutning til strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Olietemperatur kort til jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analogt setpunkt højt / kort til strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analogt setpunkt lavt / kort til jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Timeout for modtagelse af TSC1-besked</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Timeout for modtagelse af CM1-besked</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Batteri spænding høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Batteri spænding lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Forvrænget hastighedssignal</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Intern 5V sensorforsyning høj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Intern 5V sensorforsyning lav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Højt barometertryk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Lavt barometertryk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Udgangsbrændstofpumpe kort til strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Udgangsbrændstofpumpe kort til jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Udgangsgløderør kortslutter til strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Udgangsgløderør kortsluttet til jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Injektor med åbent kredsløb/lavsiden kortsluttet til jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Intern kortslutning i injektorspolen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Injektorens lave side kortslutter til strøm</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Udløbne servicetimer</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Fejl i processoren</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Ukendt fejl:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Batteri</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Køleskab</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Køleskab</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Generisk</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Generisk</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Værelse</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Værelse</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Udendørs</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Udendørs</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Vandvarmer</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Vandvarmer</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Fryser</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Fryser</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Ukendt fejl:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Ingen fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>AC volt L1 for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>AC volt for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>AC volt L1 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>AC volt for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>AC frekvens L1 for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>AC frekvens for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>AC frekvens L1 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>AC frekvens for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC strøm L1 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>AC strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>AC power L1 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>AC power for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Nød stop</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Servo strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Olie tryk for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Olie tryk for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Motor temperatur for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Motor temperatur for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Spole temperatur for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Spole temperatur for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Udstødnings temperatur for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Udstødnings temperatur for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Elektronisk temperatur lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Elektronisk temperatur høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Startspænding for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Starter strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Glødespænding for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Gløderør strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Cold-Start-Aid-spænding for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Cold-Start-Aid-strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Brændstofmagnetens spænding er for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Brændstof holde magnet strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Stop solenoid hold coil spænding for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Stop solenoid holde spole strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Stop solenoid pull coil spænding for lav </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Stop solenoide træk spol strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Ventilator/vandpumpespænding for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Blæser/vandpumpestrøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Strømfølerens spænding er lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Nuværende sensorstrøm høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Boost-udgangsspænding for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Boost output strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Busforsyningsspænding for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Busforsyningens strøm er for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Starter batteri volt for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Starter batteri volt for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Rotation for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Rotation for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Uventet stop/problem med brændstoftilførsel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Strømkontaktorens spænding er for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Power kontakt strøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>AC volt L2 for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>AC volt L2 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>AC frekvens L2 for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>AC frekvens L2 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>AC strøm L2 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>AC power L2 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>AC volt L3 for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>AC volt L3 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>AC frekvens L3 for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>AC frekvens L3 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC strøm L3 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>AC power L3 for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Inverterens udgangsspænding er for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Output Inverterstrøm for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Universel udgangsspænding (1A) for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Universaludgangens (1A) strøm er for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Universel udgangsspænding (5A) for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Universaludgangens (5A) strøm er for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT DC-spænding 1 lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>AGT DC-spænding 1 høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT DC-strøm 1 lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT DC-strøm 1 høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>AGT DC-spænding 2 lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>AGT DC-spænding 2 høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT DC-strøm 2 lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT DC-strøm 2 høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 køler lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6-køler høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 skinne (-) lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 skinne (-) høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 skinne (+) lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 skinne (+) høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Brændstof temperatur for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Brændstof temperatur for høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Brændstof niveau for lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Mangler styrer enhed</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Mangler panel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Service påkræves</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Mangler 3-faset modul</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Mangler AGT modul</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Synkroniserings fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Mistet ekstern ECU</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Luft filter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Diagnostisk meddelelse (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Mangler Synk. modul</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Load-balancering fejlet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Synk-mode deaktiveret</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Rød stoplygte (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Gul advarselslampe (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Indikatorlampe for funktionsfejl (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Beskyttelseslampe (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Rotationsfelt fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Brændstof sensor mangler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Start uden inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Bus #1 død</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Anmodning om start afvist</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Fjernstart nægtet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Tvungen frakobling af belastningsrelæ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Synkroniseringsmodulet er offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>Tabt BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Konverter DC Link Voltage Low/Reverse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Konverter DC Link Current Low</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Konverter DC forladningsspænding lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Konverter DC-forladningsspænding Høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Omformer IGBT/MOSFET-driverfejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Konverterfejl Effektkontrolsløjfe</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Detektering af AC-frekvens på konverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Fejl i konverterens kontrolværdi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Fabriksindstilling ændret</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parameter ændret i admin-tilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Manuel indgriben (ekstra system)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Init fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Invertertemperatur høj L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Invertertemperatur høj L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Inverterens temperatur er høj L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Invertertemperatur høj DC-link</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Inverter overload</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Inverter kommunikations fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>DC overbelastning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>DC overvolt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Ingen forbindelse</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Ingen fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Ukendt fejl: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Ukendt fejl:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Olietryk</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Overtemperatur i topstykket</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Kontrol af opladning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Højere hastighed end forventet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Overdreven hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Olietemperaturen højere end forventet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Olietemperatur åbent kredsløb/kortslutning til strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Olietemperatur kort til jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Analogt setpunkt højt / kort til strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Analogt setpunkt lavt / kort til jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Timeout for modtagelse af TSC1-besked</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Timeout for modtagelse af CM1-besked</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Batteri spænding høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Batteri spænding lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Forvrænget hastighedssignal</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Intern 5V sensorforsyning høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Intern 5V sensorforsyning lav</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Højt barometertryk</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Lavt barometertryk</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Udgangsbrændstofpumpe kort til strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Udgangsbrændstofpumpe kort til jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Udgangsgløderør kortslutter til strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Udgangsgløderør kortsluttet til jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Injektor med åbent kredsløb/lavsiden kortsluttet til jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Intern kortslutning i injektorspolen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Injektorens lave side kortslutter til strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Udløbne servicetimer</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Fejl i processoren</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Sæt kontakten i en ulåst position for at ændre indstillingerne.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Brug D-Bus-datakilde: Opret forbindelse til den angivne D-Bus-adresse.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Brug D-Bus-datakilde: Opret forbindelse til standard D-Bus-adressen</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Brug MQTT-datakilde: Opret forbindelse til den angivne MQTT-mægleradresse.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>MQTT datakilde enheds portal-id.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>portalId</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>MQTT VRM webhost shard</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>skår</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>MQTT datakilde brugernavn</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Bruger</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>MQTT datakilde adgangskode</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>Godkendt</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>MQTT-datakildetoken</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Token kode</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Aktiver FPS-tæller</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Spring splash-skærm over</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Brug falsk datakilde til test.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Marokkansk standard tid</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>W. Central Africa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>South Africa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Namibia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Egypt Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>E. Africa Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Argentina Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>E. South America Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Greenland Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Montevideo Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Newfoundland Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>SA Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Atlantic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Central Brazilian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Paraguay Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>SA Western Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Venezuela Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>SA Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>US Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Canada Central Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Central America Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Central Standard Time (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Central Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Mountain Standard Time (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Mountain Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>US Mountain Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Pacific Standard Time (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Alaskan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hawaii-Aleutian</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>W. Australia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>E. Africa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>SA Western Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>W. Europe Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Kamchatka Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Magadan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Vladivostok Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Yakutsk Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Tokyo Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Korea Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Singapore Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Ulaanbaatar Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Taipei Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>North Asia East Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>China Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>North Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Myanmar Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>N. Central Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Bangladesh Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Nepal Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Sri Lanka Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>India Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Pakistan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Ekaterinburg Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Georgian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Caucasus Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Azerbaijan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Arabian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Afghanistan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Iran Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Arabic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Arab Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Syria Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Middle East Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Jordan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Israel Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Greenwich Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Azores Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Cape Verde Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Tasmania Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>E. Australia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>AUS Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Cen. Australia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>AUS Central Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>W. Australia Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Mid-Atlantic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Dateline Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>GMT Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Central Europe Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Central European Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>W. Europe Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>E. Europe Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>FLE Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>GTB Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Belarus Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Russian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Turkey Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Mauritius Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Christmas Island Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Tonga Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Fiji Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Samoa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Hawaiian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Easter Island Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Intern fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Ukendt fejl:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Intern fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Ingen fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Batteri temperatur høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Batteri volt høj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Batteri lav volt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Batterispænding overskredet konfigureret max</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Høj generator temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Generator høj RPM</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Field drive FET høj temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Nødvendig sensor mangler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Lav generator strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Generator høj spænding offset</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Generatorspænding overskredet konfigureret max</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Høj spænding i alternatoren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Batteri frakoblet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Batteri høj volt afbrydelse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Batteri enhed out of range</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>For mange BMS&apos;er</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Batteri er ved at afbryde</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>For mange enheder at spore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Batteri lav spændingsafbrydelse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Batteri høj spændingsafbrydelse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Batteri høj temperatur afbrydelse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Batteri lav temperatur afbrydelse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>BMS forbindelse tabt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC deaktiveret</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>DC/DC converter ikke klar</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC høj primærspænding</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC lav primærspænding</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC høj sekundær strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC lav sekundær strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC høj temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>DC/DC fejlkonfiguration</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Batteriets temperatursensor er defekt</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_de.ts
+++ b/i18n/venus-gui-v2_de.ts
@@ -1,7383 +1,8024 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="de">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Deaktiviert</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Deaktiviert</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Überlastung Wechselrichter</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Überlastung Wechselrichter</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Leistung</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Leistung</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Aus</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Aus</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Auto</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Batterie</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbunden</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Getrennt</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generator</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Batteriespannung hoch</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Batteriespannung hoch</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Wechselrichter/Ladegerät</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Wechselrichter/Ladegerät</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Batteriespannung niedrig</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Batteriespannung niedrig</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manuell</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manuell</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Keines</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Keines</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Position</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Position</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Geschwindigkeit</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Geschwindigkeit</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Zustand</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Zustand</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installiere %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installiere %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Unbekannter Fehler</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Unbekannter Fehler</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Mindest-SoC</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Mindest-SoC</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Unbekannt</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Passwort eingeben</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Passwort eingeben</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Zur Überprüfung drücken</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Zur Überprüfung drücken</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Netz</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Netz</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Solarertrag</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Solarertrag</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Externe Steuerung</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Externe Steuerung</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Tanks</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Tanks</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Umgebung</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Umgebung</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Keine aktuellen Alarme</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Keine aktuellen Alarme</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Allgemeines</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Allgemeines</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Datum &amp; Zeit</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Datum &amp; Zeit</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>System-Setup</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>System-Setup</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Display &amp; Sprache</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Display &amp; Sprache</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM Online-Portal</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM Online-Portal</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Energie-Messgeräte</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Energie-Messgeräte</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>PV-Wechselrichter</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>PV-Wechselrichter</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>WiFi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>WiFi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM modem</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM modem</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Generator Start/Stopp</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Generator Start/Stopp</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Tankpumpe</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Tankpumpe</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Dienste</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Dienste</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Venus OS Large Funktionen</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Venus OS Large Funktionen</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Grenze der Batterielebensdauer: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Grenze der Batterielebensdauer: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Der Autostart wird deaktiviert und der Generator startet nicht automatisch auf der Grundlage der konfigurierten Bedingungen.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Der Autostart wird deaktiviert und der Generator startet nicht automatisch auf der Grundlage der konfigurierten Bedingungen.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Manuelles Anhalten</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Manuelles Anhalten</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Manueller Start</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Manueller Start</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Position</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Autostart</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Autostart</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Schalter</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Schalter</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Zugriffsebene</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Zugriffsebene</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Benutzer</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Benutzer</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Benutzer &amp; Installateur</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Benutzer &amp; Installateur</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superuser</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superuser</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Dienst</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Dienst</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Stellen Sie sicher, dass Sie nach der Deaktivierung von DVCC auch das VE.Bus-System zurücksetzen</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Stellen Sie sicher, dass Sie nach der Deaktivierung von DVCC auch das VE.Bus-System zurücksetzen</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Ladestrombegrenzung</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Ladestrombegrenzung</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Maximaler Ladestrom</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Maximaler Ladestrom</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>%1 Wert zum Start/Stopp verwenden</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>%1 Wert zum Start/Stopp verwenden</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Start, wenn %1 höher ist als</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Start, wenn %1 höher ist als</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Start, wenn %1 kleiner ist als</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Start, wenn %1 kleiner ist als</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Anhalten, wenn %1 größer ist als</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Anhalten, wenn %1 größer ist als</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Anhalten, wenn %1 kleiner ist als</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Anhalten, wenn %1 kleiner ist als</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>IP-Adresse entfernen?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>IP-Adresse entfernen?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Verbindung</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Verbindung</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Produkt</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Produkt</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Name</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>Product-ID</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>Product-ID</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Hardwareversion</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Hardwareversion</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Gerätename</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Gerätename</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Fernschaltersteuerung deaktiviert</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Fernschaltersteuerung deaktiviert</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Generator in Fehlerzustand</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Generator in Fehlerzustand</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Generator am AC-Eingang nicht erkannt</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Generator am AC-Eingang nicht erkannt</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Kumul. Laufzeit seit letztem Testlauf</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Kumul. Laufzeit seit letztem Testlauf</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Zeit bis zum nächst. Testlauf</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Zeit bis zum nächst. Testlauf</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Jetzt in Betrieb</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Jetzt in Betrieb</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Manueller Start</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Manueller Start</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Generator starten</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Generator starten</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Tägl. Laufzeit</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Tägl. Laufzeit</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Wert muss größer als Stoppwert sein</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Wert muss größer als Stoppwert sein</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Wert muss niedriger als Startwert sein</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Wert muss niedriger als Startwert sein</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>AC Ausgang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>AC Ausgang</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">AC Ausgang</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>AC Last zum Start/Stopp verwenden</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>AC Last zum Start/Stopp verwenden</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Messwert</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Messwert</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Gesamtverbrauch</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Gesamtverbrauch</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>AC Ausgang gesamt Wechselrichter</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>AC Ausgang gesamt Wechselrichter</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Höchste Phase AC Ausgang Wechselrichter</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Höchste Phase AC Ausgang Wechselrichter</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Starten, wenn Leistung höher ist als</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Starten, wenn Leistung höher ist als</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Stoppen, wenn Leistung niedriger ist als</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Stoppen, wenn Leistung niedriger ist als</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Batteriewächter</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Batteriewächter</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Wächter nicht verfügb., ander. einr.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Wächter nicht verfügb., ander. einr.</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Batteriewächter</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Wächter nicht verfügb., ander. einr.</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Bei Unterbr. d. Datenübertragung</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Bei Unterbr. d. Datenübertragung</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Generator stoppen</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Generator stoppen</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Generator weiter laufen lassen</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Generator weiter laufen lassen</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Generator stoppen, wenn AC-Eingang verfügbar</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Generator stoppen, wenn AC-Eingang verfügbar</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>SOC Batterie</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>SOC Batterie</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Hohe Temp. Wechselricht.</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Hohe Temp. Wechselricht.</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Hohe Temp. Wechselricht.</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Bei Warnung Temp.hoch starten</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Bei Warnung Temp.hoch starten</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Start bei Warnung Überlast</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Start bei Warnung Überlast</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Periodischer Betrieb</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Periodischer Betrieb</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Ausführungsintervall</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Ausführungsintervall</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 Tag(e)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 Tag(e)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Ausführung überspringen, wenn er bereits läuft für</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Ausführung überspringen, wenn er bereits läuft für</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Immer starten</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Immer starten</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Startdatum des Ausführungsintervalls</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Startdatum des Ausführungsintervalls</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Ausführungsdauer (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Ausführungsdauer (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>In Betrieb halten bis voll geladen</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>In Betrieb halten bis voll geladen</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (fix)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (fix)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS verbunden, aber kein GPS fix</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS verbunden, aber kein GPS fix</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Kein GPS verbunden</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Kein GPS verbunden</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Breitengrad</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Breitengrad</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Längengrad</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Längengrad</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Kurs</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Kurs</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Höhe</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Höhe</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Anzahl der Satelliten</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Anzahl der Satelliten</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Sollwert Netz</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Sollwert Netz</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Sollwert AC-in</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Sollwert AC-in</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Strom: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Strom: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Spannung: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Spannung: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Grenzwerte (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Grenzwerte (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Ladung: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Ladung: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Entladung: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Entladung: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Grenzwerte (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Grenzwerte (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Sichtbar</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Sichtbar</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Versteckt</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Versteckt</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Hilfsmessung)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Hilfsmessung)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Ausgang %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Ausgang %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Aktiver Batteriewächter</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Aktiver Batteriewächter</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Name eingeben</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Name eingeben</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Name eingeben</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Kontinuierliches Scannen</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Kontinuierliches Scannen</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Bluetooth-Adapter</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Bluetooth-Adapter</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>PIN-Code</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>PIN-Code</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Es kann erforderlich sein, vorhandene Kopplungsinformationen vor der Verbindung zu entfernen.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Es kann erforderlich sein, vorhandene Kopplungsinformationen vor der Verbindung zu entfernen.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Phasentyp</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Phasentyp</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Einphasig</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Einphasig</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Mehrphasig</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Mehrphasig</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>PV Wechselr. an Phase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>PV Wechselr. an Phase 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>PV Wechselr. an Phase2 Position</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>PV Wechselr. an Phase2 Position</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>CAN-Bus-Profil</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>CAN-Bus-Profil</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deaktiviert</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 Kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 Kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-Bus BMS (250 Kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-Bus BMS (250 Kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 Kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 Kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Aufwärts, aber keine Dienste (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Aufwärts, aber keine Dienste (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Geräte</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Geräte</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000-out</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000-out</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Eindeutiger Identitätsnummernwähler</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Eindeutiger Identitätsnummernwähler</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Bitte warten Sie. Das Ändern und Überprüfen der eindeutigen Nummer dauert eine Weile</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Bitte warten Sie. Das Ändern und Überprüfen der eindeutigen Nummer dauert eine Weile</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Der obige Selektor legt fest, welcher Block von eindeutigen Identitätsnummern für die NAME Unique Identity Numbers im Feld PGN 60928 NAME verwendet werden soll. Nur ändern, wenn mehrere GX-Geräte in einem VE.Can-Netzwerk verwendet werden.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Der obige Selektor legt fest, welcher Block von eindeutigen Identitätsnummern für die NAME Unique Identity Numbers im Feld PGN 60928 NAME verwendet werden soll. Nur ändern, wenn mehrere GX-Geräte in einem VE.Can-Netzwerk verwendet werden.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Der obige Selektor legt fest, welcher Block von eindeutigen Identitätsnummern für die Seriennummer im Feld DGN 60928 ADDRESS_CLAIM verwendet werden soll. Nur ändern, wenn mehrere GX-Geräte in einem RV-C-Netzwerk verwendet werden.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Der obige Selektor legt fest, welcher Block von eindeutigen Identitätsnummern für die Seriennummer im Feld DGN 60928 ADDRESS_CLAIM verwendet werden soll. Nur ändern, wenn mehrere GX-Geräte in einem RV-C-Netzwerk verwendet werden.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Eindeutige ID-Nummern prüfen</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Eindeutige ID-Nummern prüfen</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Zur Überprüfung drücken</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Es ist ein anderes Gerät mit dieser eindeutigen Nummer verbunden, bitte wählen Sie eine neue Nummer.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Es ist ein anderes Gerät mit dieser eindeutigen Nummer verbunden, bitte wählen Sie eine neue Nummer.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: Kein anderes Gerät ist mit dieser eindeutigen Nummer verbunden.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: Kein anderes Gerät ist mit dieser eindeutigen Nummer verbunden.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Netzwerk-Status</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Netzwerk-Status</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Adaptive Helligkeit</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Adaptive Helligkeit</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Helligkeit</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Helligkeit</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Zeit bis Display aus</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Zeit bis Display aus</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 s</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 s</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Nie</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Nie</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Anzeigemodus</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Anzeigemodus</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Dunkel</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Dunkel</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Hell</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Hell</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Kurzübersicht Füllstände</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Kurzübersicht Füllstände</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Sprache</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Sprache</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Ändern der Sprache</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Ändern der Sprache</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Anzeige der elektrischen Leistung</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Anzeige der elektrischen Leistung</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Leistung (Watt)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Leistung (Watt)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Stromstärke (Ampere)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Stromstärke (Ampere)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Einheiten</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Einheiten</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Stufe %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Stufe %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;Vorsicht:&lt;/b&gt; Lesen Sie vor der Einstellung das Handbuch.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;Vorsicht:&lt;/b&gt; Lesen Sie vor der Einstellung das Handbuch.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Ladespannung der verwalteten Batterie begrenzen</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Ladespannung der verwalteten Batterie begrenzen</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Maximale Ladespannung</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Maximale Ladespannung</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Gemeinsamer Spannungssensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Gemeinsamer Spannungssensor</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Gemeinsamer Temperatursensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Gemeinsamer Temperatursensor</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Nicht verfügbarer Sensor, einen anderen einstellen</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Nicht verfügbarer Sensor, einen anderen einstellen</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Nicht verfügbarer Sensor, einen anderen einstellen</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Verwendeter Sensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Verwendeter Sensor</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Gemeinsamer Stromsensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Gemeinsamer Stromsensor</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>SCS Status</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>SCS Status</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Deaktiviert (Externe Steuerung)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Deaktiviert (Externe Steuerung)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Deaktiviert (keine Ladegeräte)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Deaktiviert (keine Ladegeräte)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Deaktiviert (kein Batteriewächter)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Deaktiviert (kein Batteriewächter)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Automatische Auswahl</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Automatische Auswahl</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Keine BMS-Steuerung</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Keine BMS-Steuerung</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Steuerndes BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Steuerndes BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Nicht verfügbar, wählen Sie ein anderes</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Nicht verfügbar, wählen Sie ein anderes</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Automatisch ausgewählt</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Automatisch ausgewählt</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Keines</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Herstellungsdatum/-Zeit</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Herstellungsdatum/-Zeit</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Online-Updates</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Online-Updates</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Firmware von SD/USB installieren</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Firmware von SD/USB installieren</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Gespeicherte Backup-Firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Gespeicherte Backup-Firmware</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Nach Updates auf SD/USB suchen</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Nach Updates auf SD/USB suchen</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Firmware gefunden</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Firmware gefunden</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installation von %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installation von %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Drücken zum Aktualisieren auf %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Drücken zum Aktualisieren auf %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Drücken zum Aktualisieren auf %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Firmware Erstellungsdatum/Zeit</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Firmware Erstellungsdatum/Zeit</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Automatische Aktualisierung</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Automatische Aktualisierung</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Nur prüfen</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Nur prüfen</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Nur prüfen und herunterladen</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Nur prüfen und herunterladen</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Prüfen und aktualisieren</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Prüfen und aktualisieren</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Update feed</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Update feed</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Image-Typ</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Image-Typ</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normal</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normal</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Large</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Large</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Nach Updates suchen</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Nach Updates suchen</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Updates verfügbar</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Updates verfügbar</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Installiere %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Installiere %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Installiere %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Update Erstellungsdatum/-zeit</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Update Erstellungsdatum/-zeit</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Wechselrichter</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Wechselrichter</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>PV-Wechselrichter suchen</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>PV-Wechselrichter suchen</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Erkannte IP-Adressen</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Erkannte IP-Adressen</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>IP-Adresse manuell hinzufügen</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>IP-Adresse manuell hinzufügen</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>TCP Port</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>TCP Port</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Mehrphasig</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Mehrphasig</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Splitphase (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Splitphase (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Anzeigen</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Anzeigen</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Ausgang MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Ausgang MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Ausgang L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Ausgang L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Nach IP-Adressen scannen?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Nach IP-Adressen scannen?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Erneut Scannen</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Erneut Scannen</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH über LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH über LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Fernunterstützung</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Fernunterstützung</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Fernunterstützung Kanal</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Fernunterstützung Kanal</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>Fernunterstützung IP und Port</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>Fernunterstützung IP und Port</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Jetzt abmelden</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Jetzt neu starten</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Jetzt neu starten</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Gerät wurde neu gestartet.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Akustischer Alarm</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Akustischer Alarm</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Demo-Modus</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Demo-Modus</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS Demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS Demo</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Boot/Wohnmobil Demo 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Boot/Wohnmobil Demo 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Boot/Wohnmobil Demo 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Boot/Wohnmobil Demo 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Das Starten des Demomodus verändert einige Einst. und das Benutzerinterface reagiert einen Moment nicht.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Das Starten des Demomodus verändert einige Einst. und das Benutzerinterface reagiert einen Moment nicht.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Bedingungen</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Bedingungen</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Mindestlaufzeit</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Mindestlaufzeit</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Aufwärmzeit</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Aufwärmzeit</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Abklingzeit</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Abklingzeit</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Generator an AC-Eingang ermitteln</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Generator an AC-Eingang ermitteln</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Keiner der AC-Eingänge ist auf einen Generator eingestellt. Gehen Sie zur Systemsetup-Seite und stellen Sie den richtigen AC-Eingang auf Generator, um diese Funktion zu aktivieren.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Keiner der AC-Eingänge ist auf einen Generator eingestellt. Gehen Sie zur Systemsetup-Seite und stellen Sie den richtigen AC-Eingang auf Generator, um diese Funktion zu aktivieren.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Wenn keine Leistung vom Generator am Wechselrichter-AC-Eingang erkannt wird, wird ein Alarm ausgelöst. Stellen Sie sicher, dass auf der System-Setup-Seite der richtige AC-Eingang auf Generator eingestellt ist.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Wenn keine Leistung vom Generator am Wechselrichter-AC-Eingang erkannt wird, wird ein Alarm ausgelöst. Stellen Sie sicher, dass auf der System-Setup-Seite der richtige AC-Eingang auf Generator eingestellt ist.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Beginn Ruhezeit</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Beginn Ruhezeit</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Ende Ruhezeiten</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Ende Ruhezeiten</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Laufzeit und Service</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Laufzeit und Service</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Tägl. Laufzeitzähler zurücksetzen</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Tägl. Laufzeitzähler zurücksetzen</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Der tägl. Laufzeitzähler wurde zurückgesetzt</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Der tägl. Laufzeitzähler wurde zurückgesetzt</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Es ist nicht möglich, die Zähler zu modifizieren, während der Generator läuft</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Es ist nicht möglich, die Zähler zu modifizieren, während der Generator läuft</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Wartungsintervall des Generators (Stunden)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Wartungsintervall des Generators (Stunden)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Servicezeitintervall auf %1h eingestellt. Verwenden Sie die Schaltfläche "Service-Timer zurücksetzen", um den Service-Timer zurückzusetzen.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Servicezeitintervall auf %1h eingestellt. Verwenden Sie die Schaltfläche &quot;Service-Timer zurücksetzen&quot;, um den Service-Timer zurückzusetzen.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Service-Timer zurücksetzen</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Service-Timer zurücksetzen</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>GPS-Einstellungen</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>GPS-Einstellungen</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Format</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Format</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41,6" N, 5° 13' 12,3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41,6&quot; N, 5° 13&apos; 12,3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52,34489, 5,22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52,34489, 5,22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20,693 N, 5° 13,205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20,693 N, 5° 13,205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Geschwindigkeitseinheit</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Geschwindigkeitseinheit</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilometer pro Stunde</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilometer pro Stunde</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Meter pro Sekunde</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Meter pro Sekunde</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Meilen pro Stunde</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Meilen pro Stunde</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Knoten</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Knoten</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Kein GSM-Modem angeschlossen</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Kein GSM-Modem angeschlossen</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Netzbetreiber</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Netzbetreiber</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Es kann notwendig sein, die APN-Einstellungen unten auf dieser Seite zu konfigurieren. Wenden Sie sich für weitere Informationen an Ihren Betreiber.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Es kann notwendig sein, die APN-Einstellungen unten auf dieser Seite zu konfigurieren. Wenden Sie sich für weitere Informationen an Ihren Betreiber.
 Sollte das nicht funktionieren, überprüfen Sie die Sim-Karte in einem Telefon und stellen Sie sicher, dass sie aufgeladen und/oder für die Nutzung von Daten registriert ist.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Roaming zulassen</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Roaming zulassen</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>SIM-Status</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>SIM-Status</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM ist nicht eingelegt</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM ist nicht eingelegt</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN erforderlich</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN erforderlich</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK erforderlich</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK erforderlich</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>SIM-Fehler</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>SIM-Fehler</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM beschäftigt</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM beschäftigt</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Falsche SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Falsche SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Falscher Pin</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Falscher Pin</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Bereit</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Bereit</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Unbekannter Fehler</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Standard</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Standard</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Verwenden Sie den Standard-APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Verwenden Sie den Standard-APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>APN-Name</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>APN-Name</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Authentifizierung verwenden</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Authentifizierung verwenden</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Benutzername</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Benutzername</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Eigenverbrauch</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Eigenverbrauch</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Kein ESS Assistent gefunden</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Kein ESS Assistent gefunden</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Netz-Messung</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Netz-Messung</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Externer Zähler</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Externer Zähler</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Wechselrichter/Ladegerät</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Wechselrichter/Ladegerät</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Wechselrichter AC-Ausgang in Betrieb</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Wechselrichter AC-Ausgang in Betrieb</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Mehrphasige Regulierung</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Mehrphasige Regulierung</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Summe aller Phasen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Summe aller Phasen</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Einzelne Phase</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Einzelne Phase</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Jede Phase wird einzeln geregelt, um den Netzsollwert zu erreichen (der Wirkungsgrad des Systems wird verringert).
+        <translation>Jede Phase wird einzeln geregelt, um den Netzsollwert zu erreichen (der Wirkungsgrad des Systems wird verringert).
 
 ACHTUNG: Nur verwenden, wenn dies vom Energieversorger verlangt wird.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Die Summe aller Phasen wird intelligent geregelt, um den Netzsollwert zu erreichen (der Wirkungsgrad der Anlage wird optimiert).
+        <translation>Die Summe aller Phasen wird intelligent geregelt, um den Netzsollwert zu erreichen (der Wirkungsgrad der Anlage wird optimiert).
 
 Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inaktiv</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamic ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>SoC Mindestwert Entladung (außer bei Netzausfall)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>SoC Mindestwert Entladung (außer bei Netzausfall)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Aktiver SOC-Grenzwert</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Aktiver SOC-Grenzwert</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Erhaltung</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Aufladen</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Lastspitzenkappung</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Lastspitzenkappung</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Nur oberhalb des Mindest-SoC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Nur oberhalb des Mindest-SoC</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Immer</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Immer</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Entladen deaktiviert</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Entladen deaktiviert</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Langsames Laden</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Langsames Laden</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Erhaltung</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Erhaltung</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Aufladen</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Aufladen</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Ladeleistung begrenzen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Ladeleistung begrenzen</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Maximale Ladeleistung</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Maximale Ladeleistung</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Wechselrichter-Leistung begrenzen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Wechselrichter-Leistung begrenzen</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Maximale Wechselrichter-Leistung</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Maximale Wechselrichter-Leistung</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Sollwert Netz</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Sollwert Netz</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Netzeinspeisung</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Netzeinspeisung</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>AC-gekoppelte PV - Überschusseinspeisung</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>AC-gekoppelte PV - Überschusseinspeisung</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>DC-gekoppelte PV - Überschusseinspeisung</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>DC-gekoppelte PV - Überschusseinspeisung</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Systemeinspeisung begrenzen</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Systemeinspeisung begrenzen</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Maximale Einspeisung</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Maximale Einspeisung</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Einspeisebegrenzung aktiv</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Einspeisebegrenzung aktiv</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Analoge Eingänge</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Analoge Eingänge</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Digitale Eingänge</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Digitale Eingänge</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Digitaler Eingang %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Digitaler Eingang %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Impulsmesser</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Impulsmesser</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Türalarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Türalarm</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Bilgepumpe</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Bilgepumpe</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Bilgenalarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Bilgenalarm</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Einbruchalarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Einbruchalarm</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Rauchalarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Rauchalarm</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Feueralarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Feueralarm</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>CO2-Alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>CO2-Alarm</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Bluetooth-Sensoren</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Bluetooth-Sensoren</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Beachten Sie, dass diese Funktionen nicht offiziell von Victron unterstützt werden. Wenden Sie sich bei Fragen bitte an community.victronenergy.com.
+        <translation>Beachten Sie, dass diese Funktionen nicht offiziell von Victron unterstützt werden. Wenden Sie sich bei Fragen bitte an community.victronenergy.com.
 
 Dokumentation unter https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Aktiviert (abgesicherter Modus)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Aktiviert (abgesicherter Modus)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Verzögert um %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Verzögert um %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>VRM Portal ID</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>VRM Portal ID</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Protokollierungsintervall</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Protokollierungsintervall</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 Stunde</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 Stunde</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 Stunden</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 Stunden</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 Stunden</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 Stunden</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 Std.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 Std.</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 Tag</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 Tag</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Sichere Verbindung verwenden (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Sichere Verbindung verwenden (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Letzter Kontakt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Letzter Kontakt</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Unerwarteter Antworttext</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Unerwarteter Antworttext</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Unerwartete HTTP-Antwort</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Unerwartete HTTP-Antwort</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Zeitüberschreitung der Verbindung</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Zeitüberschreitung der Verbindung</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Verbindungsfehler</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Verbindungsfehler</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 DNS-Fehler</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 DNS-Fehler</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Routing-Fehler</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Routing-Fehler</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM nicht verfügbar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM nicht verfügbar</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Unbekannter Fehler</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Unbekannter Fehler</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Fehlermeldung:
+        <translation>Fehlermeldung:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Gerät neu starten, wenn kein Kontakt besteht</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Gerät neu starten, wenn kein Kontakt besteht</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Rücksetzverzögerung ohne Kontakt (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Rücksetzverzögerung ohne Kontakt (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Speicherort</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Speicherort</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Kein Pufferspeicher aktiv</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Kein Pufferspeicher aktiv</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Interner Speicher</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Interner Speicher</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Es wird übertragen</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Es wird übertragen</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Externer Speicher</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Externer Speicher</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Unbekannter Fehler</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Kein Fehler</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Kein Fehler</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Nicht genügend Speicherplatz</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Nicht genügend Speicherplatz</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>IO-Fehler</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>IO-Fehler</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Mount-Fehler</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Mount-Fehler</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Enthält Firmware-Image. Nicht verwendet.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Enthält Firmware-Image. Nicht verwendet.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD-Karte / USB-Stick nicht beschreibbar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD-Karte / USB-Stick nicht beschreibbar</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Freier Speicherplatz</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Freier Speicherplatz</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>Byte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>Byte</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>Bytes</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>Bytes</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Gespeicherte Datensätze</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Gespeicherte Datensätze</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 Datensätze</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 Datensätze</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Ältester Datensatz</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Ältester Datensatz</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Modbus/TCP aktivieren</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Modbus/TCP aktivieren</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Keine Fehler gemeldet</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Keine Fehler gemeldet</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Zeitpunkt des letzten Fehlers</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Zeitpunkt des letzten Fehlers</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Verfügbare Dienste</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Verfügbare Dienste</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>Einheit ID: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>Einheit ID: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Funktion (Relais 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Funktion (Relais 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Funktion</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Funktion</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Alarmrelais</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Alarmrelais</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Tankpumpe</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuell</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polarität Alarmrelais</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polarität Alarmrelais</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Schließender Kontakt</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Schließender Kontakt</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Öffnender Kontakt</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Öffnender Kontakt</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relais 1 Ein</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relais 1 Ein</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relais an</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relais an</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Funktion (Relais 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Funktion (Relais 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relais 2 Ein</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relais 2 Ein</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Regeln für die Temperaturregelung</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Regeln für die Temperaturregelung</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Relaisaktivierung bei Temperatur</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Relaisaktivierung bei Temperatur</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Kein Relais ist so konfiguriert, dass es durch die Temperatur aktiviert wird. Gehen Sie zur Seite mit den Relaiseinstellungen im Haupteinstellungsmenü und setzen Sie die Relaisfunktion auf "Temperatur".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Kein Relais ist so konfiguriert, dass es durch die Temperatur aktiviert wird. Gehen Sie zur Seite mit den Relaiseinstellungen im Haupteinstellungsmenü und setzen Sie die Relaisfunktion auf &quot;Temperatur&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Diese Option ermöglicht es Ihnen, zwischen der aktuellen und der vorherigen Firmware-Version hin-und herzuschalten. Internet oder SD-Karte nicht erforderlich.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Diese Option ermöglicht es Ihnen, zwischen der aktuellen und der vorherigen Firmware-Version hin-und herzuschalten. Internet oder SD-Karte nicht erforderlich.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Zum Hochfahren drücken</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Zum Hochfahren drücken</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Neustart auf %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Neustart auf %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Das Wechseln der Firmwareversion ist nicht möglich, wenn die automatische Aktualisierung auf „Prüfen und aktualisieren“ eingestellt ist. Stellen Sie die automatische Aktualisierung auf „Deaktiviert“ oder „Nur prüfen“, um diese Option zu aktivieren.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Das Wechseln der Firmwareversion ist nicht möglich, wenn die automatische Aktualisierung auf „Prüfen und aktualisieren“ eingestellt ist. Stellen Sie die automatische Aktualisierung auf „Deaktiviert“ oder „Nur prüfen“, um diese Option zu aktivieren.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Firmware-Backup nicht verfügbar</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Firmware-Backup nicht verfügbar</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Konsole auf VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-Bus über TCP/IP (Fehlersuche)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-Bus über TCP/IP (Fehlersuche)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Landstrom</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Landstrom</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Fahrzeug</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Fahrzeug</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Boot</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Boot</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Systemname</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Systemname</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatisch</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatisch</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Netz</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatisch</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Benutzerdefiniert</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Benutzerdefiniert</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Benutzerdefinierter Name</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Benutzerdefinierter Name</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>AC Eingang 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>AC Eingang 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>AC Eingang 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>AC Eingang 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Überwachung auf Netzausfall</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Überwachung auf Netzausfall</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Überwachung auf Landtrennung</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Überwachung auf Landtrennung</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Automatisch ausgewählt</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Automatisch ausgewählt</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Hat DC System</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Hat DC System</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>VE.Bus SOC mit Batterie synchronisieren</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>VE.Bus SOC mit Batterie synchronisieren</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Solarladestrom verwenden, um VE.Bus SOC zu verbessern</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Solarladestrom verwenden, um VE.Bus SOC zu verbessern</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Spannungssteuerung des Solarladegeräts</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Spannungssteuerung des Solarladegeräts</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Stromregelung des Solarladegeräts</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Stromregelung des Solarladegeräts</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS-Steuerung</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS-Steuerung</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS-Steuerung</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Die Start/Stopp-Funktion der Tankpumpe ist nicht aktiviert. Gehen Sie zu den Relaiseinstellungen und stellen Sie die Funktion auf "Tankpumpe".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Die Start/Stopp-Funktion der Tankpumpe ist nicht aktiviert. Gehen Sie zu den Relaiseinstellungen und stellen Sie die Funktion auf &quot;Tankpumpe&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Status Pumpe</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Status Pumpe</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Tanksensor</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Tanksensor</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Start-Level</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Start-Level</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Stopp-Level</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Stopp-Level</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Verbindung unterbrochen</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Verbindung unterbrochen</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Ausgesteckt</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Ausgesteckt</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Versteckt]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Versteckt]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Mit Netzwerk verbinden?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Mit Netzwerk verbinden?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Verbinden</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Verbinden</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Netzwerk vergessen?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Netzwerk vergessen?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Vergessen</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Vergessen</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Möchten Sie dieses Netzwerk wirklich vergessen?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Möchten Sie dieses Netzwerk wirklich vergessen?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC-Adresse</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC-Adresse</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>IP-Konfiguration</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>IP-Konfiguration</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuell</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Aus</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Fest</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Fest</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Netzmaske</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Netzmaske</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Gateway</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Gateway</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS Server</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS Server</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Lokale IP-Adresse verknüpfen</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Lokale IP-Adresse verknüpfen</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Vorsicht, bei ESS-Systemen sowie bei Systemen mit einer verwalteten Batterie muss die CAN-Bus-Geräteinstanz auf 0 konfiguriert bleiben. Weitere Informationen finden Sie im GX-Handbuch.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Vorsicht, bei ESS-Systemen sowie bei Systemen mit einer verwalteten Batterie muss die CAN-Bus-Geräteinstanz auf 0 konfiguriert bleiben. Weitere Informationen finden Sie im GX-Handbuch.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Geräteinstanz</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Geräteinstanz</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Netzwerkadresse</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Netzwerkadresse</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>VE.CAN-Geräte</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>VE.CAN-Geräte</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Gerät# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Gerät# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Keine Access Points</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Keine Access Points</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Kein WiFi-Adapter angeschlossen</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Kein WiFi-Adapter angeschlossen</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Access Point erstellen</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Access Point erstellen</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>WiFi-Netzwerke</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>WiFi-Netzwerke</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Möchten Sie den Access Point wirklich deaktivieren?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Möchten Sie den Access Point wirklich deaktivieren?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Datum/Zeit UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Datum/Zeit UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Datum/Zeit vor Ort</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Datum/Zeit vor Ort</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Zeitzone</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Zeitzone</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afrika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afrika</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Amerika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Amerika</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antarktis</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antarktis</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Artic</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Artic</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asien</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantik</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantik</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australien</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indien</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pazifik</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pazifik</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>usw</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>usw</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Unverbunden %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Unverbunden %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Jetzt neu starten?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Jetzt neu starten?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Die Änderungen der VRM-Instanz werden erst nach einem Neustart des Geräts übernommen.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Die Änderungen der VRM-Instanz werden erst nach einem Neustart des Geräts übernommen.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Gerät startet neu...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Gerät startet neu...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Gerät wurde neu gestartet.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Gerät wurde neu gestartet.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Alarm Batteriespannung niedrig</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Alarm Batteriespannung niedrig</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Alarm Batteriespannung hoch</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Alarm Batteriespannung hoch</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Letzter Fehler</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Letzter Fehler</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Vorletzter Fehler</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Vorletzter Fehler</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Drittletzter Fehler</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Drittletzter Fehler</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Viertletzter Fehler</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Viertletzter Fehler</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Vernetzt</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Vernetzt</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Einstellung Modus</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Einstellung Modus</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Stand-Alone</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Stand-Alone</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Stand-Alone</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Last</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Last</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Externe Steuerung</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Laden &amp; HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Laden &amp; HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Laden &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Laden &amp; BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Ext. Strg. &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Ext. Strg. &amp; BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Laden, Hub-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Laden, Hub-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Einstellung Master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Einstellung Master</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Slave</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Slave</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Slave</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Group Master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Group Master</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Master Laden</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Master Laden</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Group &amp; Lade Master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Group &amp; Lade Master</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Ladespannung</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Ladespannung</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Zurücksetzen</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Zurücksetzen</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Die BMS-Steuerung wird automatisch aktiviert, wenn ein BMS vorhanden ist. Zurücksetzen, wenn die Systemkonfiguration geändert wurde oder wenn kein BMS vorhanden ist.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Die BMS-Steuerung wird automatisch aktiviert, wenn ein BMS vorhanden ist. Zurücksetzen, wenn die Systemkonfiguration geändert wurde oder wenn kein BMS vorhanden ist.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">PV Leistung gesamt</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Last</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Last</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 gefunden</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 gefunden</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Verlauf</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Verlauf</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Verlauf</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Vernetzter Betrieb</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Vernetzter Betrieb</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Tabellenansicht</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Tabellenansicht</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Tabelle</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Tabelle</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Warnung</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Warnung</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarm</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Volumen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Volumen</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Kurzgeschlossen</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Kurzgeschlossen</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Umgekehrte Polarität</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Umgekehrte Polarität</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>EV-Ladestationen</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>EV-Ladestationen</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Sitzung</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Sitzung</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Zeit</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Zeit</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Lademodus</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Lademodus</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Starten und stoppen Sie den Prozess selbst. Verwenden Sie dies für schnelle Ladungen und eine genaue Überwachung.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Starten und stoppen Sie den Prozess selbst. Verwenden Sie dies für schnelle Ladungen und eine genaue Überwachung.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Startet und stoppt je nach Ladezustand der Batterie. Optimal für nächtliche und längere Ladevorgänge, um ein Überladen zu vermeiden.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Startet und stoppt je nach Ladezustand der Batterie. Optimal für nächtliche und längere Ladevorgänge, um ein Überladen zu vermeiden.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Niedrigere Stromtarife außerhalb der Spitzenlastzeiten oder wenn Sie sicherstellen wollen, dass Ihr E-Fahrzeug zu einer bestimmten Zeit vollständig aufgeladen und betriebsbereit ist.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Niedrigere Stromtarife außerhalb der Spitzenlastzeiten oder wenn Sie sicherstellen wollen, dass Ihr E-Fahrzeug zu einer bestimmten Zeit vollständig aufgeladen und betriebsbereit ist.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Laden aktivieren</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Laden aktivieren</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Ladegerät-Display sperren</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Ladegerät-Display sperren</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Source Address</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Source Address</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Setup</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Setup</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Line Instanz #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Line Instanz #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Line Instanz</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Line Instanz</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Ladegerät Instanz</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Ladegerät Instanz</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Wechselrichter Instanz</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Wechselrichter Instanz</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC source #%1 Instanz</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC source #%1 Instanz</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>DC source Instanz</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>DC source Instanz</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC source #%1 priority</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC source #%1 priority</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>DC source priority</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>DC source priority</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Tank Instanz</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Tank Instanz</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>RV-C-Geräte</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>RV-C-Geräte</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Visualisierung der Bildrate aktivieren</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Visualisierung der Bildrate aktivieren</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Nicht unterstützt</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Nicht unterstützt</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Getrennte Geräte entfernen</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Getrennte Geräte entfernen</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Nicht unterstütztes Gerät gefunden</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Nicht unterstütztes Gerät gefunden</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Relaisfunktion</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Relaisfunktion</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Ladegerät oder Generator Start/Stopp</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Ladegerät oder Generator Start/Stopp</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Manuelle Steuerung</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Sicherung durchgebrannt</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Manuelle Steuerung</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Manuelle Steuerung</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Immer geöffnet (das Relais nicht verwenden)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Immer geöffnet (das Relais nicht verwenden)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Beachten Sie, dass eine Änderung der Einstellung für den niedrigen Ladezustand auch die Einstellung für die Entladezeit im Batteriemenü ändert.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Beachten Sie, dass eine Änderung der Einstellung für den niedrigen Ladezustand auch die Einstellung für die Entladezeit im Batteriemenü ändert.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Sicherung durchgebrannt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Sicherung durchgebrannt</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Status-LEDs</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Status-LEDs</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Keines</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Hauptschalter</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Hauptschalter</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Heizgerät</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Heizgerät</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Interner Lüfter</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Interner Lüfter</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Warn Flags</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Warn Flags</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Alarm Flags</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Alarm Flags</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Umschalten</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Umschalten</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Initialisierung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Initialisierung</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Herunterfahren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Herunterfahren</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Aktualisierung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Aktualisierung</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Wird ausgeführt werden</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Wird ausgeführt werden</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Vorabaufladung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Vorabaufladung</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Schützkontrolle</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Schützkontrolle</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Alterungszustand</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Alterungszustand</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Batterietemperatur</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Batterietemperatur</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Lufttemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Lufttemperatur</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Starterspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Starterspannung</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Busspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Busspannung</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Spannung oberer Bereich</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Spannung oberer Bereich</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Kommunikationsfehler</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Alterungszustand</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Busspannung</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Spannung unterer Bereich</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Spannung unterer Bereich</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Mittelpunktsabweichung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Mittelpunktsabweichung</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Verbrauchte Amperestunden</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Verbrauchte Amperestunden</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Restlaufzeit</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Restlaufzeit</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Details</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Details</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarme auf Modulebene</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarme auf Modulebene</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnostik</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostik</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Sicherungen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Sicherungen</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>System</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>System</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parameter</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parameter</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Batterie neu ermitteln</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Batterie neu ermitteln</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Zum erneuten Erkennen drücken</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Zum erneuten Erkennen drücken</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Zum erneuten Erkennen drücken</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Das erneute Erkennen der Batterie kann bis zu 60s dauern. Solange kann der Name der Batterie falsch angezeigt werden.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Das erneute Erkennen der Batterie kann bis zu 60s dauern. Solange kann der Name der Batterie falsch angezeigt werden.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Hoher Ladestrom</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Hoher Ladestrom</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Hoher Entladestrom</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Hoher Entladestrom</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Niedriger SOC</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Niedriger SOC</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Batteriespannung hoch</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Niedriger SOC</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Starterspannung niedrig</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Starterspannung niedrig</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Starterspannung hoch</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Starterspannung hoch</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Batterietemperatursensor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Batterietemperatursensor</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Mittelpunktspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Mittelpunktspannung</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Sicherung durchgebrannt</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Innentemperatur hoch</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Innentemperatur hoch</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Niedrige Ladetemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Niedrige Ladetemperatur</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Hohe Ladetemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Hohe Ladetemperatur</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Interner Fehler</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Interner Fehler</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Schutzschalter ausgelöst</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Schutzschalter ausgelöst</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Zellenungleichgewicht</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Zellenungleichgewicht</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Niedrige Zellenspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Niedrige Zellenspannung</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Niedrigste Zellenspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Niedrigste Zellenspannung</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Höchste Zellenspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Höchste Zellenspannung</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Minimale Zellentemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Minimale Zellentemperatur</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Maximale Zellentemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Maximale Zellentemperatur</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Batteriemodule</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Batteriemodule</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Anzahl der Module, die die Ladung/Entladung blockieren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Anzahl der Module, die die Ladung/Entladung blockieren</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Installierte / verfügbare Kapazität</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Installierte / verfügbare Kapazität</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Tiefste Entladung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Tiefste Entladung</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Letzte Entladung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Letzte Entladung</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Durchnittliche Entladung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Durchnittliche Entladung</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Ladezyklen insgesamt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Ladezyklen insgesamt</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Anzahl der vollständigen Entladungen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Anzahl der vollständigen Entladungen</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Gesamte bezogene Ah</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Gesamte bezogene Ah</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Mindestzellenspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Mindestzellenspannung</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Höchstzellenspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Höchstzellenspannung</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Zeit seit der letzten vollständigen Aufladung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Zeit seit der letzten vollständigen Aufladung</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Anzahl Synchronisierungen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Anzahl Synchronisierungen</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarm bei niedriger Spannung der Starterbatterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarm bei niedriger Spannung der Starterbatterie</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Mindestspannung der Starterbatterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Mindestspannung der Starterbatterie</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Maximale Spannung der Starterbatterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Maximale Spannung der Starterbatterie</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Entladene Energie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Entladene Energie</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Geladene Energie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Geladene Energie</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Ladespannung Grenzwert (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Ladespannung Grenzwert (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Ladestrom Grenzwert (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Ladestrom Grenzwert (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Entladestrom Grenzwert (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Entladestrom Grenzwert (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Niederspannungstrennung (immer ignoriert)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Niederspannungstrennung (immer ignoriert)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Batteriebank</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Batteriebank</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relais (im Batteriewächter)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relais (im Batteriewächter)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Fabrikeinst. wiederherst.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Fabrikeinst. wiederherst.</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Zum Wiederherst. drücken</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Zum Wiederherst. drücken</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Werkseinstellungen wiederherstellen?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Werkseinstellungen wiederherstellen?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth aktiviert</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth aktiviert</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Nennspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Nennspannung</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Kapazität</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Kapazität</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapazität</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Spannung geladen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Spannung geladen</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Schweifstrom</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Schweifstrom</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Zeit für Ladezustandserkennung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Zeit für Ladezustandserkennung</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Peukert-Exponent</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Peukert-Exponent</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Ladewirkungsgrad</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Ladewirkungsgrad</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Strom Schwellwert</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Strom Schwellwert</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Durchschnittliche Restlaufzeit</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Durchschnittliche Restlaufzeit</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Restlaufzeit bis zum untersten Entladezustand</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Restlaufzeit bis zum untersten Entladezustand</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Strom-Offset</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Strom-Offset</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Synchronisiere Ladezustand auf 100 %</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Synchronisiere Ladezustand auf 100 %</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Zum Synchr. drücken</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Zum Synchr. drücken</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Nullstromanzeige kalibrieren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Nullstromanzeige kalibrieren</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Drücken, um auf 0 zu setzen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Drücken, um auf 0 zu setzen</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Distributor %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Distributor %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Kein Strom auf Sammelschiene</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Kein Strom auf Sammelschiene</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Verbindung unterbrochen</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n Sicherung(en) durchgebrannt</numerusform>
-        <numerusform>%n Sicherung(en) durchgebrannt</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n Sicherung(en) durchgebrannt</numerusform>
+            <numerusform>%n Sicherung(en) durchgebrannt</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Keine Informationen verfügbar, siehe vorherige Seite für den Vertriebspartnerstatus.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Keine Informationen verfügbar, siehe vorherige Seite für den Vertriebspartnerstatus.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Sicherung %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Sicherung %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Nicht verwendet</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Nicht verwendet</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Durchgebrannt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Durchgebrannt</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Abschaltungen aufgrund von Fehlern</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Abschaltungen aufgrund von Fehlern</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Letzter Fehler</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">Vorletzter Fehler</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">Drittletzter Fehler</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">Viertletzter Fehler</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Systemschalter</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Systemschalter</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Externes Relais</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Externes Relais</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Programmierbarer Kontakt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Programmierbarer Kontakt</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Batterien</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Batterien</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapazität</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Batterien</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Parallel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Parallel</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>in Serie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>in Serie</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Min./Max. Zellenspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Min./Max. Zellenspannung</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Min./Max. Zellentemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Min./Max. Zellentemperatur</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Ausgleich läuft</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Ausgleich läuft</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Ausgleich läuft</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Unbekannt</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Ausgang</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Ausgang</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Feldantrieb</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Feldantrieb</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Motordrehzahl</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Motordrehzahl</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Spannung Zusatzeingang</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Spannung Zusatzeingang</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Keine Alarme</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Keine Alarme</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Spannung niedrig</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Spannung niedrig</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Spannung hoch</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Spannung hoch</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Zusatzeingang Spannung niedrig</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Zusatzeingang Spannung niedrig</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Zusatzeingang Spannung hoch</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Zusatzeingang Spannung hoch</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Alarme Zusatzeingang Spannung niedrig</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Alarme Zusatzeingang Spannung niedrig</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Hohe Zusatzeingangsspannung Alarme</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Hohe Zusatzeingangsspannung Alarme</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Min. Spannung Zusatzeingang</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Min. Spannung Zusatzeingang</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Max. Spannung Zusatzeingang</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Max. Spannung Zusatzeingang</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Produzierte Energie</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Produzierte Energie</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Verbrauchte Energie</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Verbrauchte Energie</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Alarm aktivieren</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Alarm aktivieren</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Aktiver Füllstand</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Aktiver Füllstand</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Füllstand wiederherstellen</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Füllstand wiederherstellen</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Verzögern</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Verzögern</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Level</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Level</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Noch ausstehend</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Noch ausstehend</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Sensor-Batteriespannung</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Sensor-Batteriespannung</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Sensor-Batteriespannung</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Sensorart</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Sensorart</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Standard</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Standard</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Europa (0 bis 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Europa (0 bis 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>USA (240 bis 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>USA (240 bis 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Benutzerdefiniert</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Benutzerdefiniert</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Benutzerdefiniert</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Sensorwert wenn leer</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Sensorwert wenn leer</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Flüssigkeitstyp</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Flüssigkeitstyp</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Butan-Verhältnis</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Butan-Verhältnis</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Benutzerdefinierte Form</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Benutzerdefinierte Form</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Mittelungszeit</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Mittelungszeit</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Sensorwert</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Sensorwert</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Keine eigene Form definiert. Sie können eine Form mit bis zu zehn Punkten definieren. Beachten Sie, dass 0% und 100% implizit sind.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Keine eigene Form definiert. Sie können eine Form mit bis zu zehn Punkten definieren. Beachten Sie, dass 0% und 100% implizit sind.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punkt %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Punkt hinzufügen</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Punkt hinzufügen</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Sensorniveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Sensorniveau</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Volumen</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Doppelte Sensorpegelwerte sind nicht zulässig.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Doppelte Sensorpegelwerte sind nicht zulässig.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Die Volumenwerte müssen steigen.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Die Volumenwerte müssen steigen.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Entsperrt (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Entsperrt (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Entsperrt (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Entsperrt (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Entsperrt (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Entsperrt (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Gesperrt</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Gesperrt</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Phasenkonfiguration</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Phasenkonfiguration</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Schalterstellung</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Schalterstellung</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Einphasig</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2-phasig</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2-phasig</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3-phasig</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3-phasig</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Geräte</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Geschwindigkeit</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Last</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Kühlmitteltemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Kühlmitteltemperatur</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Abgastemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Abgastemperatur</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Wicklungstemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Wicklungstemperatur</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Starterbatteriespannung</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Starterbatteriespannung</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Anzahl der Starts</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Anzahl der Starts</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS-Steuerung</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Vorderer Wählschalter gesperrt (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Vorderer Wählschalter gesperrt (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Kein Fehler (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Kein Fehler (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC Gesamt</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC Gesamt</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energie L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energie L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Phasenfolge</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Phasenfolge</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Version des Datenmanagers</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Version des Datenmanagers</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Keines</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Blinkende LED zeigt dieses CT an</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Blinkende LED zeigt dieses CT an</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Smappee-Bus-Geräte</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Smappee-Bus-Geräte</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>PV-Ladegerät</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>PV-Ladegerät</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Diese Einstellung ist deaktiviert, wenn ein Digital Multi Control angeschlossen ist.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Diese Einstellung ist deaktiviert, wenn ein Digital Multi Control angeschlossen ist.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Diese Einstellung ist deaktiviert, wenn ein VE.Bus BMS angeschlossen ist.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Diese Einstellung ist deaktiviert, wenn ein VE.Bus BMS angeschlossen ist.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC in %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC in %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Invertiert</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Invertiert</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Alarm aktivieren</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Invertiert</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Alarmlogik invertieren</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Alarmlogik invertieren</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Bestrahlungsstärke</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Bestrahlungsstärke</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Zellentemperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Zellentemperatur</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Außentemperatur (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Außentemperatur (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Außentemperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Außentemperatur</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Außentemperatur (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Außentemperatur (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Windgeschwindigkeit</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Windgeschwindigkeit</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Auto-Erkennung</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Auto-Erkennung</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Windgeschwindigkeitssensor</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Windgeschwindigkeitssensor</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Externer Temperatursensor</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Externer Temperatursensor</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Aggregat</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Aggregat</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Multiplikator</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Multiplikator</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Zähler zurücksetzen</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Zähler zurücksetzen</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Kurzgeschlossen</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Umgekehrte Polarität</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Sensorbatterie schwach</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Sensorbatterie schwach</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Luftfeuchtigkeit</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Luftfeuchtigkeit</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Luftdruck</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Luftdruck</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Niedrig</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Offset</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Skala</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Skala</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Sensorspannung</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Sensorspannung</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>PV Leistung gesamt</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>PV Leistung gesamt</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Produktseite</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Produktseite</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>AC-Sensor %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>AC-Sensor %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Eine neue MK3-Version ist verfügbar.
+        <translation>Eine neue MK3-Version ist verfügbar.
 HINWEIS: Das Update kann das System vorübergehend anhalten.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Aktualisierung des MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Aktualisierung des MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Drücken zum Aktualisieren</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Drücken zum Aktualisieren</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Aktualisieren des MK3. Werte werden nach Abschluss des Updates wieder angezeigt</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Aktualisieren des MK3. Werte werden nach Abschluss des Updates wieder angezeigt</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Batterie auf 100% aufladen</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Batterie auf 100% aufladen</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Batterie auf 100% aufladen</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Erweitert</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>Im Gange</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>Im Gange</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Drücken, um zu stoppen</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Drücken, um zu stoppen</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Zum Starten drücken</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Zum Starten drücken</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Laden der Batterie auf 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Laden der Batterie auf 100%</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Das System kehrt zum Normalbetrieb zurück und priorisiert erneuerbare Energien.
+        <translation>Das System kehrt zum Normalbetrieb zurück und priorisiert erneuerbare Energien.
 Möchtest Sie fortfahren?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Sofern verfügbar, wird Landstrom genutzt und die Option „Solar- und Windpriorität“ wird ignoriert.
+        <translation>Sofern verfügbar, wird Landstrom genutzt und die Option „Solar- und Windpriorität“ wird ignoriert.
 Möchtest Sie fortfahren?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Der Landstrom wird einmal genutzt, um die Batterie vollständig aufzuladen.
+        <translation>Der Landstrom wird einmal genutzt, um die Batterie vollständig aufzuladen.
 Nach Abschluss des Ladevorgangs kehrt das System zum Normalbetrieb zurück und priorisiert dabei Solar- und Windenergie.
 Möchtest Sie fortfahren?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>DC-Spannung</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>DC-Spannung</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>DC-Strom</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>DC-Strom</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Erweitert</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Erweitert</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Alarm-Setup</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Alarm-Setup</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>Ein VE.Bus BMS schaltet das System automatisch aus, wenn dies zum Schutz der Batterie notwendig ist. Die Steuerung des Systems über das Color Control ist daher nicht möglich.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>Ein VE.Bus BMS schaltet das System automatisch aus, wenn dies zum Schutz der Batterie notwendig ist. Die Steuerung des Systems über das Color Control ist daher nicht möglich.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Es ist ein BMS Assistent installiert, der für ein VE.BUS BMS konfiguriert ist. Das BMS wurde jedoch nicht gefunden!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Es ist ein BMS Assistent installiert, der für ein VE.BUS BMS konfiguriert ist. Das BMS wurde jedoch nicht gefunden!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Warnung: Die Aktivierung der Ausgleichung in einem ESS-System mit Solarladegeräten kann dazu führen, dass die Batterie bei hoher Spannung mit einem zu hohen Strom geladen wird.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Warnung: Die Aktivierung der Ausgleichung in einem ESS-System mit Solarladegeräten kann dazu führen, dass die Batterie bei hoher Spannung mit einem zu hohen Strom geladen wird.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Das System wird automatisch auf Float umschalten, nachdem die Ausgleichsladung abgeschlossen wurde.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Das System wird automatisch auf Float umschalten, nachdem die Ausgleichsladung abgeschlossen wurde.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Ausgleich unterbrechen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Ausgleich unterbrechen</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Ausgleichung</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Ausgleichung</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Es wird unterbrochen...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Es wird unterbrochen...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Es wird gestartet...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Es wird gestartet...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Es wird gestartet...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Zum Unterbrechen drücken</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Zum Unterbrechen drücken</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Unterbrechen und Absorption neu starten</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Unterbrechen und Absorption neu starten</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Unterbrechen und zu Float gehen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Unterbrechen und zu Float gehen</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Unterbrechen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Unterbrechen</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Nicht unterbrechen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Nicht unterbrechen</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>VE.Bus-System neu erkennen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>VE.Bus-System neu erkennen</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Es wird erneut ermittelt...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Es wird erneut ermittelt...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Neustart VE.Bus-System</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Neustart VE.Bus-System</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Neustart...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Neustart...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Drücken für Neustart</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Drücken für Neustart</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>AC-Eingang 1 ignoriert</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>AC-Eingang 1 ignoriert</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>AC-Eingang 2 ignoriert</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>AC-Eingang 2 ignoriert</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>ESS-Relais-Test</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>ESS-Relais-Test</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Abgeschlossen</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Ausstehend</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Abgeschlossen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Abgeschlossen</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Ausstehend</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Ausstehend</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>VE.Bus-Diagnose</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>VE.Bus-Diagnose</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Netzqualitätszähler Phase L%1, Gerät %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Netzqualitätszähler Phase L%1, Gerät %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.Bus Fehler 8 / 11 Bericht</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.Bus Fehler 8 / 11 Bericht</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Nur Alarm</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Nur Alarm</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarme &amp; Warnungen</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarme &amp; Warnungen</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Fehler BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Fehler BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Seriennummern</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Seriennummern</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Letzter VE.Bus Fehler 11 Bericht #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Letzter VE.Bus Fehler 11 Bericht #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>BF-Sicherheitstest im Gange</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>BF-Sicherheitstest im Gange</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>BF-Sicherheitstest OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>BF-Sicherheitstest OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>AC0 /AC1-Fehlanpassung</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>AC0 /AC1-Fehlanpassung</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Kommunikationsfehler</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Kommunikationsfehler</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>GND Relais Fehler</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>GND Relais Fehler</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>UMains Abweichung</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>UMains Abweichung</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Zeitraum Zeitabweichung</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Zeitraum Zeitabweichung</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Ansteuerung des BF-Relais nicht korrekt</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Ansteuerung des BF-Relais nicht korrekt</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Fehler: PE2 offen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Fehler: PE2 offen</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Fehler: PE2 geschlossen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Fehler: PE2 geschlossen</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Fehlerhafter Schritt: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Fehlerhafter Schritt: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Phase L%1, Gerät %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Phase L%1, Gerät %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Die Meldung von VE.Bus Fehler 11 erfordert eine minimale VE.Bus Firmwareversion 454.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Die Meldung von VE.Bus Fehler 11 erfordert eine minimale VE.Bus Firmwareversion 454.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus Quirks</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus Quirks</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energie</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energie</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Leistung</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Leistung</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Spannung</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Spannung</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Strom</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Strom</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Ort</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Ort</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Phase</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Phase</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Aktiver AC-Eingang</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Aktiver AC-Eingang</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>DC-Brummspannung hoch</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>DC-Brummspannung hoch</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>DC-Spannung hoch</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>DC-Spannung hoch</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>DC-Strom hoch</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>DC-Strom hoch</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Fehler Temperatursensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Fehler Temperatursensor</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Fehler Spannungssensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Fehler Spannungssensor</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Überlastung</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Überlastung</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>DC-Restwelligkeit</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>DC-Restwelligkeit</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Spannungssensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Spannungssensor</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Phasendrehung</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Phasendrehung</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Phasendrehung</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>VE.Bus Version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>VE.Bus Version</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2 Gerät</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2 Gerät</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>MK2 Version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>MK2 Version</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Multi Control Version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Multi Control Version</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>VE.Bus BMS Version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>VE.Bus BMS Version</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Es sei denn, das Netz fällt aus</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Es sei denn, das Netz fällt aus</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>AC-Eingang</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>AC-Eingang</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC-Eingang</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC-Eingang</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>AC-Eingang 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>AC-Eingang 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>AC-Eingang 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>AC-Eingang 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Funktion</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Funktion</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC-Last</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC-Last</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>AC-Ausgang</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>AC-Ausgang</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>AC-Ausgang</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>AC-Ausgang</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC-Phase L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC-Phase L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>AC-Sensor %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>AC-Sensor %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>AC-Sensoren</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>AC-Sensoren</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Aktiv</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Aktiv</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Überlastung</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Alarmstatus</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Alarmstatus</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarme</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarme</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Laden zulassen</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Laden zulassen</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Entladen zulassen</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Entladen zulassen</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Automatisches Scannen</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Automatisches Scannen</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Batterie</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Batterie</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Batteriestrom</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Batteriestrom</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Batteriespannung</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Batteriespannung</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Ladestrom</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Ladestrom</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Aufladen</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Aufladen</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Fehler löschen</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Fehler löschen</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Geschlossen</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Geschlossen</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Verbunden</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Verbunden</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Strom</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Strom</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Stromwandler</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Stromwandler</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Benutzerdefinierter Name</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Benutzerdefinierter Name</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Debuggen</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Debuggen</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Gerät</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Gerät</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deaktiviert</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Entladen</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Entladen</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Getrennt</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Getrennt</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Aktivieren</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Aktivieren</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Aktiviert</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Aktiviert</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energie</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energie</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Fehler</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Fehler:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Fehler:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Fehlercode</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Fehlercode</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Firmwareversion</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Firmwareversion</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generator</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Batterietemperatur hoch</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Batterietemperatur hoch</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Alarm Hoher Füllstand</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Alarm Hoher Füllstand</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Starterbatteriespannung hoch</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Starterbatteriespannung hoch</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Temperatur hoch</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Temperatur hoch</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Spannung hoch Alarme</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Spannung hoch Alarme</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Verlauf</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Verlauf</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Stunde(n)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Stunde(n)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Idle</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Idle</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inaktiv</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inaktiv</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Wechselrichter/Ladegerät</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP-Adresse</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP-Adresse</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Batterietemperatur niedrig</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Batterietemperatur niedrig</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Alarm Niedriger Füllstand</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Alarm Niedriger Füllstand</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Starterbatteriespannung niedrig</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Starterbatteriespannung niedrig</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Niedriger Ladezustand</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Niedriger Ladezustand</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Temperatur niedrig</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Temperatur niedrig</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Spannung niedrig Alarm</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Spannung niedrig Alarm</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Hersteller</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Hersteller</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Höchste Temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Höchste Temperatur</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Höchstspannung</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Höchstspannung</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Mindesttemperatur</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Mindesttemperatur</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Mindestspannung</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Mindestspannung</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Modus</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Modus</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Modellname</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Modellname</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Nein</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Nein</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Kein Fehler</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Kein Fehler</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Nicht verfügbar</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Nicht verfügbar</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Nicht verbunden</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Nicht verbunden</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Offline</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Offline</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>Ok</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>Ok</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Ein</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Ein</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Offen</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Offen</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Passwort</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Passwort</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Phase</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Phase</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Zum Löschen drücken</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Zum Löschen drücken</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Zum Zurücksetzen drücken</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Zum Zurücksetzen drücken</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Zum Scannen drücken</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Zum Scannen drücken</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>PV-Wechselrichter</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>PV-Wechselrichter</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>PV-Leistung</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>PV-Leistung</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Ruhezeit</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Ruhezeit</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relais</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relais</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Neustart</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Neustart</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Entfernen</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Entfernen</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>In Betrieb</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>In Betrieb</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Scannen %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Scannen %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Seriennummer</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Seriennummer</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Einstellungen</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Setup</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Setup</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Signalstärke</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Signalstärke</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Standby</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Standby</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Starten, nachdem Beding. erreicht für</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Starten, nachdem Beding. erreicht für</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Startzeit</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Startzeit</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Startwert in Ruhezeiten</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Startwert in Ruhezeiten</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Starten, wenn Warnung aktiv für</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Starten, wenn Warnung aktiv für</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Ladezustand</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Ladezustand</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Status</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Status</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Inbetriebnahme (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Inbetriebnahme (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Stoppwert in Ruhezeiten</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Stoppwert in Ruhezeiten</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Stopp nachdem Beding. erreicht für</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Stopp nachdem Beding. erreicht für</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Angehalten</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Angehalten</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Temperatursensor</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Temperatursensor</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Heute</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Heute</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Gesamt</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Gesamt</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Tracker</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Tracker</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Typ</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Typ</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Unique Identity Number</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Unique Identity Number</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Unbekannt</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Fehler VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Fehler VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Spannung</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Spannung</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>VRM-Instanz</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>VRM-Instanz</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Wenn Warnung gelöscht, Stopp nach</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Wenn Warnung gelöscht, Stopp nach</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Ja</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Ja</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Gestern</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Gestern</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Ertrag</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Ertrag</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Leistungsbegr. Zero feed-in</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Leistungsbegr. Zero feed-in</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Datum festlegen</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Datum festlegen</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Jetzt starten</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Jetzt starten</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Zeitgesteuerter Lauf</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Zeitgesteuerter Lauf</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Jetzt anhalten</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Jetzt anhalten</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Laufzeit gesamt</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Laufzeit gesamt</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Zeit einstellen %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Zeit einstellen %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Der Generator läuft weiter, wenn eine Autostart-Bedingung erfüllt ist.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Der Generator läuft weiter, wenn eine Autostart-Bedingung erfüllt ist.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Wechselrichter-/Ladegerät-Modus</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Wechselrichter-/Ladegerät-Modus</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Einstellen</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Einstellen</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Abbrechen</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Schließen</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Schließen</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Zeit einstellen</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Zeit einstellen</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Bereits im Einsatz</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Bereits im Einsatz</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Swap-Fehler</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Swap-Fehler</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Tausch abgeschlossen</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Tausch abgeschlossen</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Geräteinstanzen austauschen...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Geräteinstanzen austauschen...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Geräteinstanz %1 wird bereits von '%3' verwendet. Tauschen Sie die Geräteinstanzen aus und weisen Sie sie %2 zu?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Geräteinstanz %1 wird bereits von &apos;%3&apos; verwendet. Tauschen Sie die Geräteinstanzen aus und weisen Sie sie %2 zu?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Geräteinstanz %1 wird bereits von einem anderen Gerät desselben Typs verwendet. Tauschen Sie Geräteinstanzen aus und weisen Sie diese %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Geräteinstanz %1 wird bereits von einem anderen Gerät desselben Typs verwendet. Tauschen Sie Geräteinstanzen aus und weisen Sie diese %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Geräteinstanzen können nicht ausgetauscht werden: Zeitüberschreitung der Operation.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Geräteinstanzen können nicht ausgetauscht werden: Zeitüberschreitung der Operation.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Die neuen Geräteinstanzen werden beim Neustart aktiv.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Die neuen Geräteinstanzen werden beim Neustart aktiv.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Tauschen Sie</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Tauschen Sie</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Fehler bei der Prüfung auf Firmware-Updates</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Fehler bei der Prüfung auf Firmware-Updates</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Firmware %1 wird heruntergeladen und installiert...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Firmware %1 wird heruntergeladen und installiert...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Installiere Firmware...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Installiere Firmware...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Fehler bei der Installation der Firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Fehler bei der Installation der Firmware</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Keine neuere Version verfügbar</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Keine neuere Version verfügbar</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Keine Firmware gefunden</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Keine Firmware gefunden</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Treibstoff</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Treibstoff</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Frischwasser</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Frischwasser</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Abwasser</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Abwasser</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Fischkasten</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Fischkasten</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Öl</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Öl</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Schwarzwasser</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Schwarzwasser</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzin</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzin</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diesel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diesel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Hydrauliköl</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Hydrauliköl</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Rohwasser</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Rohwasser</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Einstellung gesperrt für Zugriffsstufe</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Einstellung gesperrt für Zugriffsstufe</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Falsches Passwort</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Falsches Passwort</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Kurz</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Kurz</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Übersicht</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Übersicht</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Füllstände</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Füllstände</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Benachrichtigungen</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Benachrichtigungen</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Jetzt</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Jetzt</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>vor %1m</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>vor %1m</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>vor %1h %2m</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>vor %1h %2m</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Jeden Tag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Jeden Tag</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Wochentage</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Wochentage</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Wochenenden</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Wochenenden</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Montag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Montag</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Dienstag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Dienstag</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Mittwoch</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Mittwoch</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Donnerstag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Donnerstag</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Freitag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Freitag</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Samstag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Samstag</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Sonntag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Sonntag</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 oder %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 oder %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Zeitplan %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Zeitplan %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Tag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Tag</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Nicht festgelegt</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Nicht festgelegt</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Ladezustandsbegrenzung</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Ladezustandsbegrenzung</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Eigenverbrauch über Limit</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Eigenverbrauch über Limit</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>PV &amp; Batterie</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>PV &amp; Batterie</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Überprüfe...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Überprüfe...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Alarmstatus</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Alarmstatus</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Verlauf löschen</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Verlauf löschen</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Es wird gelöscht</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Es wird gelöscht</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Erzwungen An</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Erzwungen An</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Erzwungen Aus</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Erzwungen Aus</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Relais-Status</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Relais-Status</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Zurücksetzen des Verlaufs auf dem Monitor selbst</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Zurücksetzen des Verlaufs auf dem Monitor selbst</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Zum Auswerf. drücken</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Zum Auswerf. drücken</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Wird ausgeworf. Bitte warten</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Wird ausgeworf. Bitte warten</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Kein Speicher gefunden</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Kein Speicher gefunden</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>MicroSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>MicroSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 Temperatursensor</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 Temperatursensor</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 Temperatursensor (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 Temperatursensor (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Temperatursensor (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Temperatursensor (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Keine Aktionen</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Keine Aktionen</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Warnung: Aktivierungs- und Deaktivierungstemperatur sind auf denselben Wert eingestellt. Dies führt dazu, dass die Bedingung ignoriert wird.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Warnung: Aktivierungs- und Deaktivierungstemperatur sind auf denselben Wert eingestellt. Dies führt dazu, dass die Bedingung ignoriert wird.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Bedingung %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Bedingung %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Funktion deaktiviert</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Funktion deaktiviert</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Keine (Deaktivieren)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Keine (Deaktivieren)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relais 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relais 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relais 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relais 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Warnung: Das oben ausgewählte Relais ist nicht für Temperatur konfiguriert. Diese Bedingung wird ignoriert.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Warnung: Das oben ausgewählte Relais ist nicht für Temperatur konfiguriert. Diese Bedingung wird ignoriert.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Aktivierungswert</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Aktivierungswert</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Volumeneinheit</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Volumeneinheit</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Kubikmeter</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Kubikmeter</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Liter (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Liter (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Gallonen (US)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Gallonen (US)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Gallonen (Imperial)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Gallonen (Imperial)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Min Spannung</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Min Spannung</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Max Spannung</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Max Spannung</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Max Spannung</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Max Strom</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Max Strom</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Dauer der Aufladung</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Dauer der Aufladung</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Float</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Float</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Float</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>hr</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>hr</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 Fehler aufgetreten</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 Fehler aufgetreten</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Last</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Last</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2. letzte</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2. letzte</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3. letzte</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3. letzte</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4. letzte</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4. letzte</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Maximale Leistung</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Maximale Leistung</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Verbindung kann nicht hergestellt werden</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Verbindung kann nicht hergestellt werden</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Getrennt, Versuch der Wiederherstellung der Verbindung</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Getrennt, Versuch der Wiederherstellung der Verbindung</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Es wird verbunden</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Es wird verbunden</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Es wird verbunden</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Verbunden, warte auf Broker-Nachrichten</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Verbunden, warte auf Broker-Nachrichten</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Verbunden, empfange Broker-Nachrichten</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Verbunden, empfange Broker-Nachrichten</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Verbunden, lade Benutzeroberfläche</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Verbunden, lade Benutzeroberfläche</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Ungültige Protokollversion</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Ungültige Protokollversion</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Kunden-ID abgelehnt</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Kunden-ID abgelehnt</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Maklerdienst nicht verfügbar</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Maklerdienst nicht verfügbar</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Falscher Benutzername oder Passwort</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Falscher Benutzername oder Passwort</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Kunde nicht berechtigt</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Kunde nicht berechtigt</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Transportverbindungsfehler</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Transportverbindungsfehler</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Protokollverletzungsfehler</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Protokollverletzungsfehler</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>MQTT-Protokoll Level 5 Fehler</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>MQTT-Protokoll Level 5 Fehler</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Alarm stummschalten</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Alarm stummschalten</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Gesamtleistung</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Gesamtleistung</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>Min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>Min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1T %2h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1T %2h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1h %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1h %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Ausfall</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Ausfall</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>IP Adresse wird ermittelt</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>IP Adresse wird ermittelt</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbunden</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Verbindung trennen</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Verbindung trennen</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Getrennt</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC-Lasten</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC-Lasten</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>DC-Lasten</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>DC-Lasten</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Wind</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Wind</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Land</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Land</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Netzstrombegrenzung</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Netzstrombegrenzung</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Generatorstrombegrenzung</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Generatorstrombegrenzung</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Landstrombegrenzung</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Landstrombegrenzung</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Es wird gestoppt</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Es wird gestoppt</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Es wird gestoppt</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 verbleiben</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 verbleiben</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 Tank (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 Tank (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>AC-Ladegerät</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>AC-Ladegerät</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Generator</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>DC-Ladegerät</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>DC-Ladegerät</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>DC-Generator</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>DC-Generator</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC-System</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC-System</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Brennstoffzelle</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Brennstoffzelle</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Wellengenerator</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Wellengenerator</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Hydrogenerator</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Hydrogenerator</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Windladegerät</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Windladegerät</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Niedrig</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Niedrig</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Hoch</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Hoch</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Batterien im gelad. Zustand halten</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Batterien im gelad. Zustand halten</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimiert für die Batterielebensdauer</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimiert für die Batterielebensdauer</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimiert ohne BatteryLife</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimiert ohne BatteryLife</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Externe Steuerung</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Geladen</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Geladen</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Warten auf Sonne</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Warten auf Sonne</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Warten auf RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Warten auf RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Warten auf Start</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Warten auf Start</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Fehler beim Erdungstest</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Fehler beim Erdungstest</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>CP-Eingang Testfehler</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>CP-Eingang Testfehler</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Fehlerstrom erkannt</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Fehlerstrom erkannt</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Unterspannung erkannt</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Unterspannung erkannt</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Überspannung erkannt</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Überspannung erkannt</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Überhitzung erkannt</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Überhitzung erkannt</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Ladelimit</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Ladelimit</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Ladevorgang starten</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Ladevorgang starten</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Zeitgeplant</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Zeitgeplant</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Zeitgeplant</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Warmlaufen</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Warmlaufen</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Abkühlen</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Abkühlen</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Testlauf</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Testlauf</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Manuell gestartet</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Manuell gestartet</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Es wird hochgefahren</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Es wird hochgefahren</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>Ausführung (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>Ausführung (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>Ausführung (gedrosselt)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>Ausführung (gedrosselt)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relais %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relais %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Störung</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Störung</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorption</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorption</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Lagerung</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Lagerung</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Ausgleichen</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Ausgleichen</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Externe Steuerung</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>AES-Modus</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>AES-Modus</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Störungszustand</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Störungszustand</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Bulkladung</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Bulkladung</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Absorptionsladung</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Absorptionsladung</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Erhaltungsladung</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Erhaltungsladung</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Lagerungsmodus</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Lagerungsmodus</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Ausgleichsladung</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Ausgleichsladung</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Durchleitung</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Durchleitung</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Inverting</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Inverting</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Unterstützen</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Unterstützen</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Stromversorgungsmodus</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Stromversorgungsmodus</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Erhaltung</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Aufwachen</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Aufwachen</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Wiederholte Absorption</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Wiederholte Absorption</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Automatisch ausgleichen</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Automatisch ausgleichen</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>BatterySafe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>BatterySafe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Last erkennen</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Last erkennen</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Blockiert</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Blockiert</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamic ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dynamic ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dynamic ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Group Master</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Group Master</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Master Instanz</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Master Instanz</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Group &amp; Instanz Master</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Group &amp; Instanz Master</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Einzel- und Gruppenmaster</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Einzel- und Gruppenmaster</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Nur Ladegerät</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Nur Ladegerät</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Nur Wechselrichter</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Nur Wechselrichter</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Alarm Batteriespannung niedrig</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Alarm Batteriespannung hoch</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Kurzschlussalarm</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Kurzschlussalarm</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Access Point deaktivieren</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Access Point deaktivieren</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>DC-Eingang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>DC-Eingang</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Für Lithiumbatterien wird eine Ladung unter 10 % nicht empfohlen. Bei anderen Batterietypen finden Sie im Datenblatt den vom Hersteller empfohlenen Mindestladezustand.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Für Lithiumbatterien wird eine Ladung unter 10 % nicht empfohlen. Bei anderen Batterietypen finden Sie im Datenblatt den vom Hersteller empfohlenen Mindestladezustand.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Autostart deaktivieren?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Autostart deaktivieren?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Wechselrichter/Ladegerät (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Wechselrichter/Ladegerät (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>CPU-Nutzung anzeigen</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>CPU-Nutzung anzeigen</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Beenden der Anwendung</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Beenden der Anwendung</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Beenden</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Beenden</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Anwendungsversion</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Anwendungsversion</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Öltemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Öltemperatur</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Beachten Sie, dass eine Änderung der Einstellung für die Entladezeit auch die Einstellung für den niedrigen Ladezustand im Relaismenü ändert.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Beachten Sie, dass eine Änderung der Einstellung für die Entladezeit auch die Einstellung für den niedrigen Ladezustand im Relaismenü ändert.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Betriebszeit</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Betriebszeit</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Geladene Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Geladene Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Gestartete Zyklen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Gestartete Zyklen</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Abgeschlossene Zyklen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Abgeschlossene Zyklen</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Anzahl der Einschaltvorgänge</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Anzahl der Einschaltvorgänge</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Anzahl der Tiefentladungen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Anzahl der Tiefentladungen</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Verlauf des Ladezyklus</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Verlauf des Ladezyklus</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Sensorwert wenn voll</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Sensorwert wenn voll</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Zeit bis zum Service</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Zeit bis zum Service</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Autostart-Funktionalität</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Autostart-Funktionalität</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Stellen Sie sicher, dass der Generator nicht an den AC-Eingang %1 angeschlossen ist, wenn Sie diese Option verwenden</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Stellen Sie sicher, dass der Generator nicht an den AC-Eingang %1 angeschlossen ist, wenn Sie diese Option verwenden</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Der Service-Timer wurde zurückgesetzt</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Der Service-Timer wurde zurückgesetzt</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Kontinuierliches Scannen kann den WiFi-Betrieb stören.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Kontinuierliches Scannen kann den WiFi-Betrieb stören.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Minimale und maximale Messbereiche</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Minimale und maximale Messbereiche</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Startseite</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Neustart der Anwendung...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Neustart der Anwendung...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Sprachwechsel fehlgeschlagen!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Sprachwechsel fehlgeschlagen!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Nie</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Bitte warten Sie, während die Sprache geändert wird.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Bitte warten Sie, während die Sprache geändert wird.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Kurzansicht Einheiten</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Kurzansicht Einheiten</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Keine Labels</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Keine Labels</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Tankvolumen anzeigen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Tankvolumen anzeigen</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Prozentwerte anzeigen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Prozentwerte anzeigen</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Hinweis: Wenn die Stromstärke nicht angezeigt werden kann (z. B. bei der Anzeige einer Summe für kombinierte Wechsel- und Gleichstromquellen), wird stattdessen die Leistung angezeigt.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Hinweis: Wenn die Stromstärke nicht angezeigt werden kann (z. B. bei der Anzeige einer Summe für kombinierte Wechsel- und Gleichstromquellen), wird stattdessen die Leistung angezeigt.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Ladestromgrenzwerte</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Ladestromgrenzwerte</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Offizielles Release</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Offizielles Release</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Beta-Version</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Beta-Version</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Tests (Victron-intern)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Tests (Victron-intern)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Entwickler (Victron-intern)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Entwickler (Victron-intern)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Es wird neu gestartet...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Es wird neu gestartet...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Aktivieren der Status-LEDs</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Aktivieren der Status-LEDs</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Aufwärmen &amp; Abkühlen</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Aufwärmen &amp; Abkühlen</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Generator-Stoppzeit</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Generator-Stoppzeit</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarm, wenn der Generator nicht im Autostart-Modus ist</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarm, wenn der Generator nicht im Autostart-Modus ist</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Ein Alarm wird ausgelöst, wenn die Autostart-Funktion für mehr als 10 Minuten deaktiviert bleibt.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Ein Alarm wird ausgelöst, wenn die Autostart-Funktion für mehr als 10 Minuten deaktiviert bleibt.</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Eigenverbrauch aus Batterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Eigenverbrauch aus Batterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Alle Systemlasten</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Alle Systemlasten</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Nur kritische Lasten</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Nur kritische Lasten</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">SoC Mindestwert Entladung (außer bei Netzausfall)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <extracomment>Battery life state or BatteryLife state? The latter is a term we use in ESS and has different states (Optimized with BatteryLife, Optimized without BatteryLife).</extracomment>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>BatteryLife status</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>BatteryLife status</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Zugriff auf Signal K unter http://venus.local:3000 und über VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Zugriff auf Signal K unter http://venus.local:3000 und über VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Zugriff auf Node-RED unter https://venus.local:1881 und über VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Zugriff auf Node-RED unter https://venus.local:1881 und über VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Batteriemessungen</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Batteriemessungen</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Systemstatus</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Systemstatus</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Geräteliste</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Geräteliste</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>VRM-Geräte-Instanzen</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>VRM-Geräte-Instanzen</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Alarm hohe Temperatur</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Alarm hohe Temperatur</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>BMS gesteuert</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>BMS gesteuert</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarme &amp; Fehler</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarme &amp; Fehler</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Diese Funktion erfordert Firmware-Version 400 oder höher. Wenden Sie sich an Ihren Installateur, um Ihren Multi/Quattro zu aktualisieren.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Diese Funktion erfordert Firmware-Version 400 oder höher. Wenden Sie sich an Ihren Installateur, um Ihren Multi/Quattro zu aktualisieren.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Ladegerät nicht bereit, Ausgleichsvorgang kann nicht gestartet werden</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Ladegerät nicht bereit, Ausgleichsvorgang kann nicht gestartet werden</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Der Ausgleich kann nicht während der Bulkladephase ausgelöst werden</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Der Ausgleich kann nicht während der Bulkladephase ausgelöst werden</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Maximaler Strom</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Maximaler Strom</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Maximale Leistung</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Maximale Leistung</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Minimaler Strom</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Minimaler Strom</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Keines</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Nicht verfügbar</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Aus</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">Ok</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Gesamtverlauf</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Gesamtverlauf</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Einstellungen</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Unbekannt</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Heutiger Ertrag</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Heutiger Ertrag</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware installiert, Gerät wird neu gestartet</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware installiert, Gerät wird neu gestartet</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Touch-Eingabe-Steuerung</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Touch-Eingabe-Steuerung</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Testfehler geschweißte Kontakte (Kurzschluss)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Testfehler geschweißte Kontakte (Kurzschluss)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Umschaltung auf 3 Phasen</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Umschaltung auf 3 Phasen</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Umschalten auf 1 Phase</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Umschalten auf 1 Phase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Laden stoppen</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Laden stoppen</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Reserviert</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Reserviert</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Wechselrichtermodus</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Wechselrichtermodus</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC-Ausgang L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC-Ausgang L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Eingang</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Eingang</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>PassThrough</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>PassThrough</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Die Seite wird in zehn Sekunden automatisch neu geladen, um die neueste Version zu laden.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Die Seite wird in zehn Sekunden automatisch neu geladen, um die neueste Version zu laden.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Wechselrichter (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Wechselrichter (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Wechselrichter/Ladegeräte</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Wechselrichter/Ladegeräte</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Keine Energiezähler gefunden
+        <translation>Keine Energiezähler gefunden
 
 Beachten Sie, dass dieses Menü nur Carlo Gavazzi Zähler anzeigt, die über RS485 angeschlossen sind. Für alle anderen Zähler, einschließlich der über Ethernet angeschlossenen Carlo Gavazzi Zähler, siehe stattdessen das Menü Modbus TCP/UDP Geräte.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Auto-Bereichsdynamik</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Auto-Bereichsdynamik</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Wenn diese Funktion aktiviert ist, werden die Minima und Maxima von Messgeräten und Diagrammen automatisch auf der Grundlage früherer Werte angepasst.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Wenn diese Funktion aktiviert ist, werden die Minima und Maxima von Messgeräten und Diagrammen automatisch auf der Grundlage früherer Werte angepasst.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Alle Bereichswerte auf Null zurücksetzen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Alle Bereichswerte auf Null zurücksetzen</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Bereichswerte zurücksetzen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Bereichswerte zurücksetzen</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Sind Sie sicher, dass Sie alle Werte auf Null zurücksetzen wollen?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Sind Sie sicher, dass Sie alle Werte auf Null zurücksetzen wollen?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Maximaler Strom: AC in 1 angeschlossen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Maximaler Strom: AC in 1 angeschlossen</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Maximaler Strom: AC in 2 angeschlossen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Maximaler Strom: AC in 2 angeschlossen</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Maximaler Strom: keine AC-Eingänge</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Maximaler Strom: keine AC-Eingänge</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>DC-Ausgang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>DC-Ausgang</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solar</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solar</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Motordrehzahl</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Motordrehzahl</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Motortemperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Motortemperatur</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Steuergerättemperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Steuergerättemperatur</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Aktiver Zyklus</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Aktiver Zyklus</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Zyklus %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Zyklus %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>DC-Trennung</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>DC-Trennung</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Abgeschaltet</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Abgeschaltet</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Funktionsänderung</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Funktionsänderung</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Firmware-Update</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Firmware-Update</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Software-Reset</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Software-Reset</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Unvollständig</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Unvollständig</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Verstrichene Zeit</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Verstrichene Zeit</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Ladung / Erhaltung (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Ladung / Erhaltung (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Batterie (V&lt;sub&gt;Start&lt;/sub&gt;/V&lt;sub&gt;Ende&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Batterie (V&lt;sub&gt;Start&lt;/sub&gt;/V&lt;sub&gt;Ende&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Niedrige AC-Ausgangsspannung</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Niedrige AC-Ausgangsspannung</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Hohe AC-Ausgangsspannung</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Hohe AC-Ausgangsspannung</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Gesamtertrag</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Gesamtertrag</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Systemertrag</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Systemertrag</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Täglicher Verlauf</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Täglicher Verlauf</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Keine zu konfigurierenden Alarme</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Keine zu konfigurierenden Alarme</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Maximale PV-Spannung</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Maximale PV-Spannung</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Maximale Batteriespannung</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Maximale Batteriespannung</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Minimale Batteriespannung</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Minimale Batteriespannung</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Batteriebankfehler</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Batteriebankfehler</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Batteriespannung nicht unterstützt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Batteriespannung nicht unterstützt</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Falsche Anzahl von Batterien</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Falsche Anzahl von Batterien</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Ungültige Batteriekonfiguration</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Ungültige Batteriekonfiguration</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Balancer-Status</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Balancer-Status</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Ausgeglichen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Ausgeglichen</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Unausgeglichen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Unausgeglichen</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Verwenden Sie diese Option in Systemen, die keine Lastspitzenkappung durchführen.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Verwenden Sie diese Option in Systemen, die keine Lastspitzenkappung durchführen.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Verwenden Sie diese Option für die Lastspitzenkappung.</translation>
+        <translation>Verwenden Sie diese Option für die Lastspitzenkappung.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Der Schwellenwert für die Lastspitzenkappung wird mithilfe der AC-Eingangsstrombegrenzungseinstellung festgelegt. Weitere Informationen finden Sie in der Dokumentation.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Der Schwellenwert für die Lastspitzenkappung wird mithilfe der AC-Eingangsstrombegrenzungseinstellung festgelegt. Weitere Informationen finden Sie in der Dokumentation.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Die Schwellenwerte für die Lastspitzenkappung beim Import und Export können auf diesem Bildschirm geändert werden. Siehe Dokumentation für weitere Informationen.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Die Schwellenwerte für die Lastspitzenkappung beim Import und Export können auf diesem Bildschirm geändert werden. Siehe Dokumentation für weitere Informationen.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Begrenzung des AC-Importstroms des Systems</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Begrenzung des AC-Importstroms des Systems</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Um diese Funktion nutzen zu können, muss die Netzzählung auf Externer Zähler eingestellt und ein aktueller ESS-Assistent installiert sein.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Um diese Funktion nutzen zu können, muss die Netzzählung auf Externer Zähler eingestellt und ein aktueller ESS-Assistent installiert sein.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Maximaler Systemimportstrom (pro Phase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Maximaler Systemimportstrom (pro Phase)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Die Netzzählung muss auf Externer Zähler eingestellt sein, um diese Funktion nutzen zu können.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Die Netzzählung muss auf Externer Zähler eingestellt sein, um diese Funktion nutzen zu können.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Maximaler Systemausgangsstrom (pro Phase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Maximaler Systemausgangsstrom (pro Phase)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Verkabelt</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Verkabelt</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Kurz</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Hohe Systemlast. Schließen der Seitenwand zur Reduzierung der CPU-Last</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Hohe Systemlast. Schließen der Seitenwand zur Reduzierung der CPU-Last</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Eingangsstrombegrenzung</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Eingangsstrombegrenzung</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Kurzschluss</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Kurzschluss</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Kaufen</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Kaufen</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Verkaufen</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Verkaufen</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Ziel-SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Ziel-SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC-Ausgang %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC-Ausgang %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Tracker</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Tracker</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>RS-Geräte</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>RS-Geräte</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Elektronenanimationen pausieren</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Elektronenanimationen pausieren</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Gesamtkapazität</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Gesamtkapazität</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Anzahl der BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Anzahl der BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-Bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-Bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-Bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-Bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Begrenzung des System-AC-Exportstroms</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Begrenzung des System-AC-Exportstroms</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Modbus TCP/UDP-Geräte</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Modbus TCP/UDP-Geräte</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Gerät hinzufügen</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Gerät hinzufügen</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Nach Geräten scannen</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Nach Geräten scannen</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Gespeicherte Geräte</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Gespeicherte Geräte</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Entdeckte Geräte</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Entdeckte Geräte</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Modbus TCP/UDP-Gerät hinzufügen</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Modbus TCP/UDP-Gerät hinzufügen</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protokoll</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protokoll</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Port</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Port</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Einheit</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Einheit</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Keine Modbus-Geräte gespeichert</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Keine Modbus-Geräte gespeichert</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Gerät %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Gerät %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Modbus-Gerät entfernen?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Modbus-Gerät entfernen?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Keine Modbus-Geräte gefunden</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Keine Modbus-Geräte gefunden</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Batterie %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Batterie %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>Wechselstrom</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>Wechselstrom</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Generator Start/Stop deaktiviert</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Generator Start/Stop deaktiviert</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Die Fernstartfunktion ist am Aggregat deaktiviert. Der GX kann das Aggregat jetzt nicht starten oder stoppen. Aktivieren Sie die Funktion auf dem Bedienfeld des Aggregats.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Die Fernstartfunktion ist am Aggregat deaktiviert. Der GX kann das Aggregat jetzt nicht starten oder stoppen. Aktivieren Sie die Funktion auf dem Bedienfeld des Aggregats.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Autostart-Funktion</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Autostart-Funktion</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Aktuelle Laufzeit</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Kontrollstatus</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Kontrollstatus</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Aggregatstatus</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Aggregatstatus</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Fernstart-Modus</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Fernstart-Modus</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Öldruck</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Öldruck</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Geplante Ladestufen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Geplante Ladestufen</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Aktiv (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Aktiv (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Manuelles Anhalten</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Manuelles Anhalten</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Offener Stromkreis</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Offener Stromkreis</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (nicht verfügbar)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (nicht verfügbar)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Touch-Eingabe An</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Touch-Eingabe An</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Touch-Eingabe Aus</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Touch-Eingabe Aus</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Touch-Eingabe deaktiviert</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Touch-Eingabe deaktiviert</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Alarme bestätigen</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Alarme bestätigen</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Fehlercode der Steuerung</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Fehlercode der Steuerung</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Verwenden Sie dieses Menü, um die Batteriedaten festzulegen, die angezeigt werden, wenn Sie auf der Übersichtsseite auf das Batteriesymbol klicken. Die gleiche Auswahl ist auch auf dem VRM Portal sichtbar.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Verwenden Sie dieses Menü, um die Batteriedaten festzulegen, die angezeigt werden, wenn Sie auf der Übersichtsseite auf das Batteriesymbol klicken. Die gleiche Auswahl ist auch auf dem VRM Portal sichtbar.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Systemspannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Systemspannung</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Verbindungsinformation</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Verbindungsinformation</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Bitte wählen Sie...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Bitte wählen Sie...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Gesichert</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Gesichert</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Passwortgeschützt und die Netzwerkkommunikation ist verschlüsselt</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Passwortgeschützt und die Netzwerkkommunikation ist verschlüsselt</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Schwach</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Schwach</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Passwortgeschützt, aber die Netzwerkkommunikation ist nicht verschlüsselt</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Passwortgeschützt, aber die Netzwerkkommunikation ist nicht verschlüsselt</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Ungesichert</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Ungesichert</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Kein Passwort und die Netzwerkkommunikation ist nicht verschlüsselt</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Kein Passwort und die Netzwerkkommunikation ist nicht verschlüsselt</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Das Passwort muss mindestens 8 Zeichen lang sein.</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Passwort eingeben</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Das Passwort muss mindestens 8 Zeichen lang sein.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Das Passwort muss mindestens 8 Zeichen lang sein.</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Profil 'Gesichert' auswählen?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Profil &apos;Gesichert&apos; auswählen?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Profil "Schwach" wählen?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Profil &quot;Schwach&quot; wählen?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Profil "Ungesichert" wählen?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Profil &quot;Ungesichert&quot; wählen?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Lokale Netzwerkdienste sind passwortgeschützt
+        <translation>- Lokale Netzwerkdienste sind passwortgeschützt
 - Die Netzwerkkommunikation ist verschlüsselt
 - Eine sichere Verbindung mit VRM ist aktiviert
 - Unsichere Einstellungen können nicht aktiviert werden</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokale Netzwerkdienste sind passwortgeschützt
+        <translation>- Lokale Netzwerkdienste sind passwortgeschützt
 - Unverschlüsselter Zugang zu lokalen Websites ist ebenfalls aktiviert (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokale Netzwerkdienste benötigen kein Passwort
+        <translation>- Lokale Netzwerkdienste benötigen kein Passwort
 - Unverschlüsselter Zugriff auf lokale Websites ist ebenfalls möglich (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Root-Passwort</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Root-Passwort</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Abmelden</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Abmelden</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Jetzt abmelden</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Jetzt abmelden</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Abmelden?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Abmelden?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Dadurch werden alle lokalen Netzwerkverbindungen unterbrochen.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Dadurch werden alle lokalen Netzwerkverbindungen unterbrochen.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Abmelden</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Abmelden</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Schreibgeschützt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Schreibgeschützt</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Vollständig</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Vollständig</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Sind Sie sicher?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Sind Sie sicher?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Wenn Sie diese Einstellung auf Schreibgeschützt oder Aus ändern, werden Sie ausgesperrt.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Wenn Sie diese Einstellung auf Schreibgeschützt oder Aus ändern, werden Sie ausgesperrt.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>MQTT-Zugang</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>MQTT-Zugang</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>%1' ist keine Zahl.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>%1&apos; ist keine Zahl.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Bestätigen</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Bestätigen</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Verwenden Sie eine Zahl mit %1 Ziffern oder weniger.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Verwenden Sie eine Zahl mit %1 Ziffern oder weniger.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' ist keine gültige IP-Adresse.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; ist keine gültige IP-Adresse.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' ist keine gültige Anschlussnummer. Verwenden Sie eine Zahl zwischen 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; ist keine gültige Anschlussnummer. Verwenden Sie eine Zahl zwischen 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 ist keine gültige Einheitennummer. Verwenden Sie eine Zahl zwischen 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 ist keine gültige Einheitennummer. Verwenden Sie eine Zahl zwischen 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Aktuelle Laufzeit</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Aktuelle Laufzeit</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Fehlercodes des Stromaggregats</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Fehlercodes des Stromaggregats</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Kühlkörpertemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Kühlkörpertemperatur</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Ladespannung</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Die Ladespannung wird derzeit durch das BMS gesteuert.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Die Ladespannung wird derzeit durch das BMS gesteuert.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Ladestrombegrenzung</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Ladestrombegrenzung</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>BMS-gesteuert</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>BMS-gesteuert</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Die BMS-Steuerung wird automatisch aktiviert, wenn ein BMS vorhanden ist. Setzen Sie sie zurück, wenn sich die Systemkonfiguration geändert hat oder wenn kein BMS vorhanden ist.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Die BMS-Steuerung wird automatisch aktiviert, wenn ein BMS vorhanden ist. Setzen Sie sie zurück, wenn sich die Systemkonfiguration geändert hat oder wenn kein BMS vorhanden ist.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Service-Timer deaktiviert.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Service-Timer deaktiviert.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>VRM Portal</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>VRM Portal</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (VPN-Fernzugang)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (VPN-Fernzugang)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Bevor die Netzwerkdienste aktiviert werden können, muss ein Sicherheitsprofil konfiguriert werden, siehe Einstellungen - Allgemein</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Bevor die Netzwerkdienste aktiviert werden können, muss ein Sicherheitsprofil konfiguriert werden, siehe Einstellungen - Allgemein</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>%1" wurde durch "%2" ersetzt, da es ungültige Zeichen enthielt.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>%1&quot; wurde durch &quot;%2&quot; ersetzt, da es ungültige Zeichen enthielt.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Initialisierung...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Initialisierung...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Backend startet...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Backend startet...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend gestoppt.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend gestoppt.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Verbindung fehlgeschlagen.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Verbindung fehlgeschlagen.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Dieses GX-Gerät ist bei Tailscale abgemeldet.
+        <translation>Dieses GX-Gerät ist bei Tailscale abgemeldet.
 
 Bitte warten Sie oder überprüfen Sie Ihre Internetverbindung.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Ich warte auf eine Antwort von Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Ich warte auf eine Antwort von Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Verbinden Sie dieses GX-Gerät mit Ihrem Tailscale-Konto, indem Sie diesen Link öffnen:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Verbinden Sie dieses GX-Gerät mit Ihrem Tailscale-Konto, indem Sie diesen Link öffnen:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Bitte warten Sie oder überprüfen Sie Ihre Internetverbindung.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Bitte warten Sie oder überprüfen Sie Ihre Internetverbindung.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Unbekannter Zustand: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Unbekannter Zustand: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Fehler: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Fehler: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Deaktivieren Sie Tailscale, um diese Einstellungen zu bearbeiten.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Deaktivieren Sie Tailscale, um diese Einstellungen zu bearbeiten.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Tailscale einschalten</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Tailscale einschalten</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Name der Maschine</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Name der Maschine</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Abmelden vom Tailscale-Konto</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Abmelden vom Tailscale-Konto</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Lokaler Netzzugang</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Lokaler Netzzugang</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Zugang zum lokalen Ethernet-Netzwerk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Zugang zum lokalen Ethernet-Netzwerk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Zugang zum lokalen WiFi-Netzwerk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Zugang zum lokalen WiFi-Netzwerk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Benutzerdefinierte(s) Netzwerk(e)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Benutzerdefinierte(s) Netzwerk(e)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Beispiel: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Beispiel: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Erläuterung:
+        <translation>Erläuterung:
 
 Diese Funktion, von Tailscale Subnetz-Routen genannt, ermöglicht den Fernzugriff auf andere Geräte im lokalen Netzwerk.
 
@@ -7386,2989 +8027,3057 @@ Das Feld für benutzerdefinierte Netzwerke akzeptiert eine kommagetrennte Liste 
 Nachdem Sie ein neues Netzwerk hinzugefügt/aktiviert haben, müssen Sie es einmalig in der Tailscale-Administrationskonsole bestätigen.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Benutzerdefinierte "tailscale up"-Argumente</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Benutzerdefinierte &quot;tailscale up&quot;-Argumente</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Benutzerdefinierte Server-URL (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Benutzerdefinierte Server-URL (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Diese Aggregatesteuerung benötigt ein Hilfsrelais, um gesteuert zu werden, aber das Hilfsrelais ist nicht konfiguriert. Bitte konfigurieren Sie Relais 1 unter Einstellungen → Relais auf "Angeschlossenes Aggregat-Hilfsrelais".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Diese Aggregatesteuerung benötigt ein Hilfsrelais, um gesteuert zu werden, aber das Hilfsrelais ist nicht konfiguriert. Bitte konfigurieren Sie Relais 1 unter Einstellungen → Relais auf &quot;Angeschlossenes Aggregat-Hilfsrelais&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarme bei hoher Starterbatteriespannung</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarme bei hoher Starterbatteriespannung</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Generatoraufwärmung überspringen</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Generatoraufwärmung überspringen</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Verfügbar, aber keine Dienste (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Verfügbar, aber keine Dienste (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Root-Passwort auf %1 geändert</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Root-Passwort auf %1 geändert</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Angeschlossenes Aggregat-Hilfsrelais</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Angeschlossenes Aggregat-Hilfsrelais</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Position der AC-Lasten</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Position der AC-Lasten</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>AC-Eingang und -Ausgang</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>AC-Eingang und -Ausgang</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Verwenden Sie diese Option, wenn am Eingang des Wechselrichters/Ladegeräts AC-Lasten vorhanden sind. Verwenden Sie diese Option, wenn Sie unsicher sind.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Verwenden Sie diese Option, wenn am Eingang des Wechselrichters/Ladegeräts AC-Lasten vorhanden sind. Verwenden Sie diese Option, wenn Sie unsicher sind.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Nur AC-Ausgang</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Nur AC-Ausgang</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Verwenden Sie diese Option, wenn das System einen Netzzähler verwendet, aber alle AC-Lasten am Ausgang des Wechselrichters/Ladegeräts angeschlossen sind.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Verwenden Sie diese Option, wenn das System einen Netzzähler verwendet, aber alle AC-Lasten am Ausgang des Wechselrichters/Ladegeräts angeschlossen sind.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Monatlich</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Monatlich</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>EV Ladegerät</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>EV Ladegerät</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Wärmepumpe</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Wärmepumpe</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Essentielle Lasten</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Essentielle Lasten</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Starten und stoppen Sie den Generator basierend auf den konfigurierten Autostart-Bedingungen.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Starten und stoppen Sie den Generator basierend auf den konfigurierten Autostart-Bedingungen.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>DC-Generatoreinstellungen</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>DC-Generatoreinstellungen</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Lichtmaschinentemperatur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Lichtmaschinentemperatur</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Motortemperatur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Motortemperatur</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Laufzeit gesamt</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Laufzeit gesamt</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Netzwerksicherheitsprofil</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Netzwerksicherheitsprofil</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Letzten %1 Tage</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Letzten %1 Tage</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Der Generator wird in %1 anhalten, es sei denn, es sind Autostart-Bedingungen aktiviert, die ihn am Laufen halten.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Der Generator wird in %1 anhalten, es sei denn, es sind Autostart-Bedingungen aktiviert, die ihn am Laufen halten.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Der Generator läuft, bis er manuell gestoppt wird, es sei denn, es sind Autostart-Bedingungen aktiviert, die ihn am Laufen halten.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Der Generator läuft, bis er manuell gestoppt wird, es sei denn, es sind Autostart-Bedingungen aktiviert, die ihn am Laufen halten.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Klassische UI</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Klassische UI</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Neue UI</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Neue UI</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Sprache erfolgreich geändert!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Leistungsbegrenzung</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Sprache erfolgreich geändert!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Für Multi-RS- und HS19-Geräte sind die ESS-Einstellungen auf der Produktseite des RS-Systems verfügbar.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Für Multi-RS- und HS19-Geräte sind die ESS-Einstellungen auf der Produktseite des RS-Systems verfügbar.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Aggregat Start/Stopp</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Aggregat Start/Stopp</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Ein Wechsel der Firmware-Version ist nicht möglich, ohne dass "Netzwerksicherheitsprofil" unter "Einstellungen / Allgemein" ausgewählt ist.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Ein Wechsel der Firmware-Version ist nicht möglich, ohne dass &quot;Netzwerksicherheitsprofil&quot; unter &quot;Einstellungen / Allgemein&quot; ausgewählt ist.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Dauer</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Dauer</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Systemalarme</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Systemalarme</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Keine Systemalarme</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Keine Systemalarme</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Zurück</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Zurück</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Was ist neu</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Was ist neu</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>Überspringen</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>Überspringen</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Willkommen!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Willkommen!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Wir freuen uns, Ihnen eine völlig neu gestaltete Benutzeroberfläche vorstellen zu können, die sowohl die Benutzerfreundlichkeit als auch die Ästhetik Ihres GX verbessert.
+        <translation>Wir freuen uns, Ihnen eine völlig neu gestaltete Benutzeroberfläche vorstellen zu können, die sowohl die Benutzerfreundlichkeit als auch die Ästhetik Ihres GX verbessert.
 
 Dank optimierter Navigation und neuem Look ist alles, was Sie lieben, jetzt noch einfacher zugänglich und optisch ansprechender.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Dunkel-Hell-Modus</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Dunkel-Hell-Modus</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Unterschiedliche Umgebungen erfordern unterschiedliche Bildschirmeinstellungen. Die Modi "Dunkel" und "Hell" sorgen für ein optimales Seherlebnis, egal wo Sie sind.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Unterschiedliche Umgebungen erfordern unterschiedliche Bildschirmeinstellungen. Die Modi &quot;Dunkel&quot; und &quot;Hell&quot; sorgen für ein optimales Seherlebnis, egal wo Sie sind.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Alle wichtigen Informationen, die Sie benötigen, werden in einem klaren und einfachen Layout präsentiert. Das Herzstück ist ein anpassbares Widget mit Ringen, das Ihnen schnellen Zugriff auf Ihre Systemeinblicke auf einen Blick ermöglicht.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Alle wichtigen Informationen, die Sie benötigen, werden in einem klaren und einfachen Layout präsentiert. Das Herzstück ist ein anpassbares Widget mit Ringen, das Ihnen schnellen Zugriff auf Ihre Systemeinblicke auf einen Blick ermöglicht.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Mit unserem aktualisierten Übersichts-Panel, das Systemdaten in Echtzeit anzeigt, haben Sie eine bessere Kontrolle - alles an einem Ort zur einfachen Überwachung.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Mit unserem aktualisierten Übersichts-Panel, das Systemdaten in Echtzeit anzeigt, haben Sie eine bessere Kontrolle - alles an einem Ort zur einfachen Überwachung.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Steuerung</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Steuerung</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Alle alltäglichen Steuerelemente sind jetzt im neuen Fenster "Steuerelemente" zusammengefasst. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Alle alltäglichen Steuerelemente sind jetzt im neuen Fenster &quot;Steuerelemente&quot; zusammengefasst. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watt &amp; Ampere</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watt &amp; Ampere</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Sie können jetzt zwischen Watt und Ampere umschalten. Wählen Sie die Einheit, die Ihren Wünschen am besten entspricht.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Sie können jetzt zwischen Watt und Ampere umschalten. Wählen Sie die Einheit, die Ihren Wünschen am besten entspricht.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Mehr erfahren</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Mehr erfahren</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Unter dem folgenden Link finden Sie weitere Informationen über die erneuerte UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Unter dem folgenden Link finden Sie weitere Informationen über die erneuerte UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Scannen Sie den QR-Code, um mehr über die erneuerte UI zu erfahren.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Scannen Sie den QR-Code, um mehr über die erneuerte UI zu erfahren.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Erledigt</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Erledigt</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Weiter</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Weiter</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Fehler: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Fehler: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Aktiver Fehler</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Aktiver Fehler</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Gesamtlaufzeit Generator (Stunden)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Gesamtlaufzeit Generator (Stunden)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Startseite</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Startseite</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Benutzeroberfläche</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Benutzeroberfläche</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Benutzeroberfläche (Remote Konsole)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Benutzeroberfläche (Remote Konsole)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 aktualisiert</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 aktualisiert</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>Die Benutzeroberfläche wird zu %1 wechseln.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>Die Benutzeroberfläche wird zu %1 wechseln.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 ist auf %2 gesetzt</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Dieser PV-Wechselrichter unterstützt eine Leistungsbegrenzung. Deaktivieren Sie diese Einstellung, wenn sie den normalen Betrieb stört.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 ist auf %2 gesetzt</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Drücken Sie zum Neustart 'OK'.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Drücken Sie zum Neustart &apos;OK&apos;.</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Node-RED Werksreset</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Node-RED Werksreset</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Sind Sie sicher, dass Sie Node-RED auf die Werkseinstellungen zurücksetzen wollen? Dadurch werden alle Ihre Flows gelöscht.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Sind Sie sicher, dass Sie Node-RED auf die Werkseinstellungen zurücksetzen wollen? Dadurch werden alle Ihre Flows gelöscht.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Verbindungsstatus</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Verbindungsstatus</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Verbindungsstatus (HTTPS-Kanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Verbindungsstatus (HTTPS-Kanal)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Verbindungsstatus (HTTP-Kanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Verbindungsstatus (HTTP-Kanal)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Verbindungsstatus (MQTT-Echtzeitkanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Verbindungsstatus (MQTT-Echtzeitkanal)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Verbindungsstatus (MQTT RPC-Kanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Verbindungsstatus (MQTT RPC-Kanal)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Automatisch gestartet - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Automatisch gestartet - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Deaktivierungswert</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Deaktivierungswert</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Läuft nicht</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Läuft nicht</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Kommunikationsverlust</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Kommunikationsverlust</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>SOC-Zustand</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>SOC-Zustand</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>AC-Lastzustand</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>AC-Lastzustand</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Batterie Stromzustand</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Batterie Stromzustand</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Batterie Spannungszustand</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Batterie Spannungszustand</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Wechselrichter Überlastungszustand</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Wechselrichter Überlastungszustand</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Laden/Entladen Deaktiviert</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Laden/Entladen Deaktiviert</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Laden Deaktiviert</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Laden Deaktiviert</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Entladen Deaktiviert</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Entladen Deaktiviert</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Kurz</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Kurzansicht (Seitenbereich offen)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Kurzansicht (Seitenbereich offen)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Übersicht</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Füllstände (Tanks)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Füllstände (Tanks)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Füllstände (Umgebung)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Füllstände (Umgebung)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Batterieliste</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Batterieliste</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>Das GX-Gerät wurde aktualisiert</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>Das GX-Gerät wurde aktualisiert</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Nach %n Minute(n)</numerusform>
-        <numerusform>Nach %n Minute(n)</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Nach %n Minute(n)</numerusform>
+            <numerusform>Nach %n Minute(n)</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Rufen Sie diese Seite auf, wenn die Anwendung gestartet wird.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Rufen Sie diese Seite auf, wenn die Anwendung gestartet wird.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Zeitüberschreitung</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Zeitüberschreitung</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Zur Startseite zurückkehren, wenn die Anwendung inaktiv ist.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Zur Startseite zurückkehren, wenn die Anwendung inaktiv ist.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Nach einer Minute Inaktivität wird die aktuelle Seite als Startseite ausgewählt, sofern sie in dieser Liste enthalten ist.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Nach einer Minute Inaktivität wird die aktuelle Seite als Startseite ausgewählt, sofern sie in dieser Liste enthalten ist.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Diese Stromgrenze ist in der Systemkonfiguration festgelegt. Er kann nicht angepasst werden.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Diese Stromgrenze ist in der Systemkonfiguration festgelegt. Er kann nicht angepasst werden.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Der Modus ist in der Systemkonfiguration festgelegt. Er kann nicht angepasst werden.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Der Modus ist in der Systemkonfiguration festgelegt. Er kann nicht angepasst werden.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Die Start-/Stoppfunktion des Generators ist nicht aktiviert. Gehen Sie zu den Relaiseinstellungen und stellen Sie die Funktion auf „Generator Start/Stopp“ ein.</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Morocco Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>W. Central Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>South Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Namibia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Egypt Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Argentina Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>E. South America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Greenland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Montevideo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Newfoundland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>SA Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Central Brazilian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Paraguay Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Venezuela Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>SA Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>US Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Canada Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Central America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Central Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Zentrale Standardzeit CST</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Mountain Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>US Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacific Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Alaskan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutian</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Kamchatka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Magadan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Vladivostok Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Yakutsk Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Tokyo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Korea Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Singapore Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ulaanbaatar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Taipei Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>North Asia East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>China Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>North Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>N. Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Bangladesh Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Nepal Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Sri Lanka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>India Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Pakistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Ekaterinburg Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Georgian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Caucasus Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Azerbaijan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Afghanistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Iran Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arab Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Syria Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Middle East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Jordan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Israel Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Azores Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Cape Verde Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Tasmania Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>E. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>AUS Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Cen. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>AUS Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT </translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Datumsgrenze Standardzeit</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Mitteleuropäische Standardzeit</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Mitteleuropäische Standardzeit</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>E. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Weißrussische Standardzeit</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Russian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Türkei Standardzeit</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Mauritius Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Weihnachtsinsel Standardzeit</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Tonga Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fiji Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hawaiian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Osterinsel Normalzeit</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Die Start-/Stoppfunktion des Generators ist nicht aktiviert. Gehen Sie zu den Relaiseinstellungen und stellen Sie die Funktion auf „Generator Start/Stopp“ ein.</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Unbekannt</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Solarertrag</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">DC-Eingang</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC-Lasten</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">DC-Lasten</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Übersicht</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Zustand</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Gesamtertrag</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Systemertrag</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Nur Alarm</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarme &amp; Warnungen</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Warnung</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Kein Fehler</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Kein Fehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Unbekannter Fehler: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Unbekannter Fehler: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Kein Fehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Kein Fehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Fehler Batterieinitialisierung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Fehler Batterieinitialisierung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Keine Batterien angeschlossen</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Keine Batterien angeschlossen</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Batterie unbekannt</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Batterie unbekannt</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Unterschiedliche Batterietypen</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Unterschiedliche Batterietypen</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Anz. d. Batterien falsch</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Anz. d. Batterien falsch</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt nicht gefunden</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt nicht gefunden</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Fehler Batteriemessung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Fehler Batteriemessung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Interner Berechnungsfehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Interner Berechnungsfehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Anz. d. Batterien in Reihe falsch</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Anz. d. Batterien in Reihe falsch</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Hardwarefehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Hardwarefehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Watchdog-Fehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Watchdog-Fehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Überspannung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Überspannung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Unterspannung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Unterspannung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Übertemperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Übertemperatur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Untertemperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Untertemperatur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Standby wegen zu niedriger Ladung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Standby wegen zu niedriger Ladung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>ADC-Fehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>ADC-Fehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Fehler Datenaustausch m. Batterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Fehler Datenaustausch m. Batterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Fehler Vorladen</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Fehler Vorladen</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Fehler Sicherheitsschütz</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Fehler Sicherheitsschütz</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Fehler Batterie-Update</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Fehler Batterie-Update</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>BMS Kabelfehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>BMS Kabelfehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Referenzspannungsfehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Referenzspannungsfehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Falsche Systemspannung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Falsche Systemspannung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Vorladung Zeitüberschreitung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Vorladung Zeitüberschreitung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>ATC/ATD-Fehler</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>ATC/ATD-Fehler</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Kallibrierungsdaten verloren</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Kallibrierungsdaten verloren</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Einstellungen ungültig</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Einstellungen ungültig</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Verriegelung</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Verriegelung</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Notaus</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Notaus</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Zeitüberschreitung bei der Kommunikation</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Zeitüberschreitung bei der Kommunikation</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Sicherheitssperre</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Sicherheitssperre</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Klemme Übertemperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Klemme Übertemperatur</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Kein Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Hohe Batterietemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Hohe Batteriespannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Tsensor d. Batt. falsch angeschlossen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Tsense Batterie fehlt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Vsensor Batt. falsch angeschlossen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Vsensor der Batterie fehlt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Hohe Kabelverluste Batterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Niedrige Batteriespannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>DC-Brummspannung hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Niedriger Batterieladezustand</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Batterie Mittelpunktspannungsproblem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Batterietemperatur zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Hohe Ladegerättemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Überhöhter Ladegerätstrom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Negativer Ladegerätstrom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Bulk-Zeit Ladegerät abgelaufen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problem am Stromsens d. Ladegeräts</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Interner Tsensor falsch angeschlossen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Interner Tsensor fehlt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Ladegerätlüfter nicht erkannt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Überstrom am Ladegerätlüfter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Überhitzung Ladegerätanschluss</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Kurzschluss Ladegerät</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Problem mit der Ladegerätleistungsstufe</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Überladungsschutz</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Hohe Spannung am Eingang</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Übermäßige Stromlast am Eingang</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Zu viel Leistung am Eingang</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Polaritätsproblem am Eingang</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Eingangsspannung fehlt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Abschaltung des Eingangs (keine Wiederholungsversuche)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Abschaltung des Eingangs (Wiederholung)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Interner Fehler am Eingang</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>PV-Isolationsfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Erdschlussfehler entdeckt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Überlastung Wechselrichter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Wechselrichtertemp. zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Wechselrichter-Spitzenstrom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Wechselrichter-interner DC-Pegel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Wechselrichter falscher ACout-Level</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Fehler in der Leistungsstufe des Wechselrichters</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Wechselrichter an AC angeschlossen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>ACIN1-Relaistestfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>ACIN2-Relaistestfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Gerät nicht mehr vorhanden</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Gerät nicht kompatibel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Verbindung zum BMS unterbrochen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Netzwerk falsch konfiguriert</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Phasendrehung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Mehrere AC-Eingänge</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Phasenüberlastung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Fehler beim Schreiben auf Speicher</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>CPU Temperatur zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Verbindung unterbrochen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Kallibrierungsdaten verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Firmware nicht kompatibel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Hardware nicht kompatibel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Einstellungen ungültig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Referenz-Spannung fehlgeschlagen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Fehler am Prüfgerät</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Verlauf ungültig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>kWh-Zähler ungültig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Gleichspannungsfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>GFCI-Sensorfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>3V3 Versorgungsfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>5V Versorgungsfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>12V Versorgungsfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>15V Versorgungsfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>PV-Eingang Abschaltung</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Stellen Sie den Schalter in eine entriegelte Position, um die Einstellungen zu ändern.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>D-Bus-Datenquelle verwenden: Verbindung mit der angegebenen D-Bus-Adresse.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>Adresse</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>D-Bus-Datenquelle verwenden: Verbindung mit der Standard-D-Bus-Adresse</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>MQTT-Datenquelle verwenden: Verbindung zur angegebenen MQTT-Broker-Adresse.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>Adresse</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>MQTT-Datenquellen-Geräteportal-ID.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>Portal-ID</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>MQTT VRM-Webhost-Shard</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>Shard</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Benutzername der MQTT-Datenquelle</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Benutzer</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Passwort für die MQTT-Datenquelle</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>Pass</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>MQTT-Datenquellentoken</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Token</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>FPS-Zähler aktivieren</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Begrüßungsbildschirm überspringen</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Verwenden Sie zum Testen eine Scheindatenquelle.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Gerät ausgeschaltet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>altes/neues MK2 gemischt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Fehler bei erwarteten Geräten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Kein anderes Gerät erkannt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Überspannung am AC-Ausgang</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>DDC-Programmfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS ohne Assistent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Erdungsrelaistest fehlgeschlagen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Systemzeit sync Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Netzrelais Testfehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Konfigurations-Fehlanpassung mit 2. mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Übertragungsfehler des Gerätes</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Warte auf Konfiguration oder Dongle fehlt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Phasen-Master fehlt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Überspannung ist aufgetreten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Slave hat keinen AC-Eingang!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Gerät kann nicht Slave sein</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Systemschutz initialisiert</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Firmware Inkompatibilität</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Interner Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Fehlgeschlagener Relaistest verhindert Verbindung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Fehler VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Unbekannter Fehler: </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Interner Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Kein Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Hohe Batterietemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Hohe Batteriespannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Niedrige Batteriespannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Batteriespannung hat konfig. max. überschritten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Hohe Lichtmaschinentemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Hohe Lichtmaschinedrehzahl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Hohe Feldantriebstemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Erforderlicher Sensor fehlt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Niedrige Lichtmaschinenspannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Hohes Lichtmaschinen-Spannungsoffset</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Lichtmaschinenspannung hat konf. max. überschritten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Hochspannung der Lichtmaschine</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Batterie getrennt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Batterie Überspannungsabschaltung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Batterieinstanz außerhalb des Bereichs</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Zu viele BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Batterie kurz vor Abtrennung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Zu viele Geräte zum Nachverfolgen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Batterie Unterspannungsabschaltung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Batterie Überstromabschaltung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Batterie Hochtemperaturabschaltung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Batterie Untertemperaturabschaltung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Verbindung zum BMS unterbrochen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC deaktiviert</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>DC/DC Konverter nicht bereit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC hohe Primärspannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC niedrige Primärspannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC hohe Sekundärspannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC niedrige Sekundärspannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC hohe Temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>DC/DC-Fehlkonfiguration</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Batterietemperatursensor defekt</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Unbekannter Fehler: </translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Unbekannter Fehler: </translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Kein Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Hohe Batterietemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Hohe Batteriespannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Tsensor d. Batt. falsch angeschlossen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Tsense Batterie fehlt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Vsensor Batt. falsch angeschlossen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Vsensor der Batterie fehlt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Hohe Kabelverluste Batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Niedrige Batteriespannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>DC-Brummspannung hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Niedriger Batterieladezustand</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Batterie Mittelpunktspannungsproblem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Batterietemperatur zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Hohe Ladegerättemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Überhöhter Ladegerätstrom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Negativer Ladegerätstrom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Bulk-Zeit Ladegerät abgelaufen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Problem am Stromsens d. Ladegeräts</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Interner Tsensor falsch angeschlossen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Interner Tsensor fehlt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Ladegerätlüfter nicht erkannt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Überstrom am Ladegerätlüfter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Überhitzung Ladegerätanschluss</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Kurzschluss Ladegerät</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Problem mit der Ladegerätleistungsstufe</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Überladungsschutz</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Hohe Spannung am Eingang</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Übermäßige Stromlast am Eingang</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Zu viel Leistung am Eingang</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Polaritätsproblem am Eingang</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Eingangsspannung fehlt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Abschaltung des Eingangs (keine Wiederholungsversuche)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Abschaltung des Eingangs (Wiederholung)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Interner Fehler am Eingang</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>PV-Isolationsfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Erdschlussfehler entdeckt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Überlastung Wechselrichter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Wechselrichtertemp. zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Wechselrichter-Spitzenstrom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Wechselrichter-interner DC-Pegel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Wechselrichter falscher ACout-Level</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Fehler in der Leistungsstufe des Wechselrichters</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Wechselrichter an AC angeschlossen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>ACIN1-Relaistestfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>ACIN2-Relaistestfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Gerät nicht mehr vorhanden</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Gerät nicht kompatibel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Verbindung zum BMS unterbrochen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Netzwerk falsch konfiguriert</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Phasendrehung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Mehrere AC-Eingänge</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Phasenüberlastung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Fehler beim Schreiben auf Speicher</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>CPU Temperatur zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Verbindung unterbrochen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Kallibrierungsdaten verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Firmware nicht kompatibel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Hardware nicht kompatibel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Einstellungen ungültig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Referenz-Spannung fehlgeschlagen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Fehler am Prüfgerät</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Verlauf ungültig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>kWh-Zähler ungültig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Gleichspannungsfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>GFCI-Sensorfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>3V3 Versorgungsfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>5V Versorgungsfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>12V Versorgungsfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>15V Versorgungsfehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>PV-Eingang Abschaltung</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Unbekannter Fehler: </translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Unbekannter Fehler: </translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Unbekannter Fehler: </translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Unbekannter Fehler: </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Kein Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>AC Spannung L1 zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>AC-Spannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>AC Spannung L1 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>AC-Spannung zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>AC-Frequenz L1 zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>AC-Frequenz zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>AC-Frequenz L1 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>AC-Frequenz zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC-Strom L1 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>AC-Strom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>AC-Leistung L1 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>AC-Leistung zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Notaus</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Servo-Strom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Öldruck zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Öldruck zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Motortemperatur zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Motortemperatur zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Wicklungstemperatur zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Wicklungstemperatur zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Auspufftemperatur zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Auspufftemperatur zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Elektronik Temperatur niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Elektronik Temperatur hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Starterspannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Starterstrom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Glühspannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Glühstrom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Kaltstarthilfe Spannung zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Kaltstarthilfe Strom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Spannung des Kraftstoff-Haftmagneten zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Treibstoff-Haftmagnet-Strom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Spannung der Haltespule des Stoppmagneten zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Strom der Haltespule am Abstellmagnet zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Spannung der Zugspule des Stoppmagneten zu niedrig </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Strom der Anzugsspule am Abstellmagnet zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Lüfter-/Wasserpumpenspannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Lüfter-/Wasserpumpenstrom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Stromsensor Spannung niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Stromsensor Strom hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Boost-Ausgangsspannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Strom am Boost-Ausgang zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Bus-Versorgungsspannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Bus-Versorgungsstrom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Starterbatteriespannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Starterbatteriespannung zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Rotation zu schwach</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Rotation zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Unerwarteter Stopp/Problem mit der Kraftstoffzufuhr</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Spannung des Leistungsschützes zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Strom am Leistungsschütz zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>AC-Spannung L2 zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>AC-Spannung L2 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>AC-Frequenz L2 zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>AC-Frequenz L2 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>AC-Strom L2 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>AC-Leistung L2 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>AC-Spannung L3 zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>AC-Spannung L3 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>AC-Frequenz L3 zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>AC-Frequenz L3 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC-Strom L3 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>AC-Leistung L3 zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Ausgang Wechselrichterspannung zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Ausgang Wechselrichterstrom zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Spannung am Universalausgang (1A) zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Strom am Universalausgang (1A) zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Spannung am Universalausgang (5A) zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Strom am Universalausgang (5A) zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT DC Spannung 1 niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>AGT DC Spannung 1 hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT DC Strom 1 niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT DC Strom 1 hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>AGT DC Spannung 2 niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>AGT DC Spannung 2 hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT DC Strom 2 niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT DC Strom 2 hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 Kühler niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 Kühler hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 Schiene (-) niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 Schiene (-) hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 Schiene (+) niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 Schiene (+) hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Treibstofftemperatur zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Treibstofftemperatur zu hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Treibstoffstand zu niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Steuergerät verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Panel verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Wartung erforderlich</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>3-Phasen-Modul verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>AGT-Modul verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Synchronisierung fehlgeschlagen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Externe ECU verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Ansaugung Luftfilter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Diagnosemeldung (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Sync. Modul verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Lastausgleich fehlgeschlagen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Sync-Modus deaktiviert</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Rote Stoppleuchte (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Gelbe Warnleuchte (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Funktionskontrollleuchte (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Schutzleuchte (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Drehfeld falsch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Treibstoffstandssensor verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Starten ohne Wechselrichter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Bus #1 tot</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Startanfrage abgelehnt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Fernstart verweigert</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Zwangsabschaltung des Lastrelais</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Das Synchronisationsmodul ist offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>BMS verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Wandler DC-Link-Spannung niedrig/umgekehrt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Wandler DC-Link-Strom Niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Wandler DC-Vorladespannung niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Wandler DC-Vorladespannung hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Wandler IGBT/MOSFET-Treiber Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Wandlerfehler Leistungsregelkreis</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Wandler AC-Frequenz-Erkennung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Konverter-Steuerungswert-Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Werkseinstellung geändert</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parameter im Admin-Modus geändert</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Manuelle Intervention (ext. System)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Init fehlgeschlagen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Wechselrichtertemperatur hoch L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Wechselrichtertemperatur hoch L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Umrichtertemperatur hoch L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Wechselrichtertemperatur hoch DC-Link</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Überlastung Wechselrichter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Kommunikation zu Wechselrichter verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>DC-Überlast</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>DC-Überspannung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Keine Verbindung</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Kein Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Unbekannter Fehler: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Unbekannter Fehler: </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Öldruck</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Übertemperatur des Zylinderkopfes</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Ladekontrolle</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Geschwindigkeit höher als erwartet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Geschwindigkeitsüberschreitung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Öltemperatur höher als erwartet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Öltemperatur Unterbrechung / Kurzschluss zur Stromversorgung</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Öltemperatur Kurzschluss gegen Masse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analoger Sollwert hoch / Kurzschluss zum Strom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analoger Sollwert niedrig / Kurzschluss gegen Masse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Zeitüberschreitung beim Empfang von TSC1-Nachrichten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Zeitüberschreitung beim Empfang von CM1-Nachrichten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Batteriespannung hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Batteriespannung niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Geschwindigkeitssignal verzerrt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Interne 5V-Sensorversorgung hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Interne 5V-Sensorversorgung niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Barometrischer Druck hoch</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Barometrischer Druck niedrig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Ausgang Kraftstoffpumpe Kurzschluss mit Strom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Ausgang Kraftstoffpumpe Kurzschluss gegen Masse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Ausgang Glühkerze Kurzschluss zum Strom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Ausgang Glühkerze Kurzschluss gegen Masse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Injektor offener Stromkreis/Niederdruckseite Kurzschluss gegen Masse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Interner Kurzschluss der Einspritzspule</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Kurzschluss auf der Niederspannungsseite des Injektors</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Servicezeiten abgelaufen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Prozessorausfall</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Unbekannter Fehler: </translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Batterie</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Batterie</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Kühlschrank</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Kühlschrank</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Allgemein</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Allgemein</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Zimmer</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Zimmer</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Draußen</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Draußen</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Warmwasserboiler</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Warmwasserboiler</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Gefrierschrank</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Gefrierschrank</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Unbekannter Fehler: </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Kein Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>AC Spannung L1 zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>AC-Spannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>AC Spannung L1 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>AC-Spannung zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>AC-Frequenz L1 zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>AC-Frequenz zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>AC-Frequenz L1 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>AC-Frequenz zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC-Strom L1 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>AC-Strom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>AC-Leistung L1 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>AC-Leistung zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Notaus</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Servo-Strom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Öldruck zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Öldruck zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Motortemperatur zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Motortemperatur zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Wicklungstemperatur zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Wicklungstemperatur zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Auspufftemperatur zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Auspufftemperatur zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Elektronik Temperatur niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Elektronik Temperatur hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Starterspannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Starterstrom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Glühspannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Glühstrom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Kaltstarthilfe Spannung zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Kaltstarthilfe Strom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Spannung des Kraftstoff-Haftmagneten zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Treibstoff-Haftmagnet-Strom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Spannung der Haltespule des Stoppmagneten zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Strom der Haltespule am Abstellmagnet zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Spannung der Zugspule des Stoppmagneten zu niedrig </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Strom der Anzugsspule am Abstellmagnet zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Lüfter-/Wasserpumpenspannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Lüfter-/Wasserpumpenstrom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Stromsensor Spannung niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Stromsensor Strom hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Boost-Ausgangsspannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Strom am Boost-Ausgang zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Bus-Versorgungsspannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Bus-Versorgungsstrom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Starterbatteriespannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Starterbatteriespannung zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Rotation zu schwach</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Rotation zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Unerwarteter Stopp/Problem mit der Kraftstoffzufuhr</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Spannung des Leistungsschützes zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Strom am Leistungsschütz zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>AC-Spannung L2 zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>AC-Spannung L2 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>AC-Frequenz L2 zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>AC-Frequenz L2 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>AC-Strom L2 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>AC-Leistung L2 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>AC-Spannung L3 zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>AC-Spannung L3 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>AC-Frequenz L3 zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>AC-Frequenz L3 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC-Strom L3 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>AC-Leistung L3 zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Ausgang Wechselrichterspannung zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Ausgang Wechselrichterstrom zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Spannung am Universalausgang (1A) zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Strom am Universalausgang (1A) zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Spannung am Universalausgang (5A) zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Strom am Universalausgang (5A) zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT DC Spannung 1 niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>AGT DC Spannung 1 hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT DC Strom 1 niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT DC Strom 1 hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>AGT DC Spannung 2 niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>AGT DC Spannung 2 hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT DC Strom 2 niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT DC Strom 2 hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 Kühler niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 Kühler hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 Schiene (-) niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 Schiene (-) hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 Schiene (+) niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 Schiene (+) hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Treibstofftemperatur zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Treibstofftemperatur zu hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Treibstoffstand zu niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Steuergerät verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Panel verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Wartung erforderlich</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>3-Phasen-Modul verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>AGT-Modul verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Synchronisierung fehlgeschlagen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Externe ECU verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Ansaugung Luftfilter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Diagnosemeldung (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Sync. Modul verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Lastausgleich fehlgeschlagen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Sync-Modus deaktiviert</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Rote Stoppleuchte (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Gelbe Warnleuchte (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Funktionskontrollleuchte (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Schutzleuchte (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Drehfeld falsch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Treibstoffstandssensor verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Starten ohne Wechselrichter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Bus #1 tot</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Startanfrage abgelehnt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Fernstart verweigert</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Zwangsabschaltung des Lastrelais</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Das Synchronisationsmodul ist offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>BMS verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Wandler DC-Link-Spannung niedrig/umgekehrt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Wandler DC-Link-Strom Niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Wandler DC-Vorladespannung niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Wandler DC-Vorladespannung hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Wandler IGBT/MOSFET-Treiber Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Wandlerfehler Leistungsregelkreis</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Wandler AC-Frequenz-Erkennung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Konverter-Steuerungswert-Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Werkseinstellung geändert</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parameter im Admin-Modus geändert</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Manuelle Intervention (ext. System)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Init fehlgeschlagen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Wechselrichtertemperatur hoch L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Wechselrichtertemperatur hoch L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Umrichtertemperatur hoch L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Wechselrichtertemperatur hoch DC-Link</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Überlastung Wechselrichter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Kommunikation zu Wechselrichter verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>DC-Überlast</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>DC-Überspannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Keine Verbindung</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Kein Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Unbekannter Fehler: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Unbekannter Fehler: </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Öldruck</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Übertemperatur des Zylinderkopfes</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Ladekontrolle</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Geschwindigkeit höher als erwartet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Geschwindigkeitsüberschreitung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Öltemperatur höher als erwartet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Öltemperatur Unterbrechung / Kurzschluss zur Stromversorgung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Öltemperatur Kurzschluss gegen Masse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Analoger Sollwert hoch / Kurzschluss zum Strom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Analoger Sollwert niedrig / Kurzschluss gegen Masse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Zeitüberschreitung beim Empfang von TSC1-Nachrichten</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Zeitüberschreitung beim Empfang von CM1-Nachrichten</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Batteriespannung hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Batteriespannung niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Geschwindigkeitssignal verzerrt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Interne 5V-Sensorversorgung hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Interne 5V-Sensorversorgung niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Barometrischer Druck hoch</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Barometrischer Druck niedrig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Ausgang Kraftstoffpumpe Kurzschluss mit Strom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Ausgang Kraftstoffpumpe Kurzschluss gegen Masse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Ausgang Glühkerze Kurzschluss zum Strom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Ausgang Glühkerze Kurzschluss gegen Masse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Injektor offener Stromkreis/Niederdruckseite Kurzschluss gegen Masse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Interner Kurzschluss der Einspritzspule</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Kurzschluss auf der Niederspannungsseite des Injektors</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Servicezeiten abgelaufen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Prozessorausfall</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Stellen Sie den Schalter in eine entriegelte Position, um die Einstellungen zu ändern.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>D-Bus-Datenquelle verwenden: Verbindung mit der angegebenen D-Bus-Adresse.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>D-Bus-Datenquelle verwenden: Verbindung mit der Standard-D-Bus-Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>MQTT-Datenquelle verwenden: Verbindung zur angegebenen MQTT-Broker-Adresse.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>MQTT-Datenquellen-Geräteportal-ID.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>Portal-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>MQTT VRM-Webhost-Shard</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>Shard</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Benutzername der MQTT-Datenquelle</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Benutzer</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Passwort für die MQTT-Datenquelle</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>Pass</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>MQTT-Datenquellentoken</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Token</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>FPS-Zähler aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Begrüßungsbildschirm überspringen</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Verwenden Sie zum Testen eine Scheindatenquelle.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Morocco Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>W. Central Africa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>South Africa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Namibia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Egypt Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>E. Africa Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Argentina Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>E. South America Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Greenland Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Montevideo Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Newfoundland Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>SA Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Atlantic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Central Brazilian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Paraguay Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>SA Western Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Venezuela Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>SA Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>US Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Canada Central Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Central America Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Central Standard Time (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Zentrale Standardzeit CST</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Mountain Standard Time (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Mountain Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>US Mountain Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Pacific Standard Time (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Alaskan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hawaii-Aleutian</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>W. Australia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>E. Africa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>SA Western Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>W. Europe Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Kamchatka Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Magadan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Vladivostok Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Yakutsk Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Tokyo Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Korea Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Singapore Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Ulaanbaatar Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Taipei Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>North Asia East Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>China Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>North Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Myanmar Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>N. Central Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Bangladesh Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Nepal Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Sri Lanka Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>India Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Pakistan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Ekaterinburg Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Georgian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Caucasus Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Azerbaijan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Arabian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Afghanistan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Iran Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Arabic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Arab Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Syria Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Middle East Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Jordan Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Israel Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Greenwich Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Azores Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Cape Verde Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Tasmania Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>E. Australia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>AUS Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Cen. Australia Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>AUS Central Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>W. Australia Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT </translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Mid-Atlantic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Datumsgrenze Standardzeit</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>GMT Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Mitteleuropäische Standardzeit</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Mitteleuropäische Standardzeit</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>W. Europe Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>E. Europe Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>FLE Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>GTB Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Weißrussische Standardzeit</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Russian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Türkei Standardzeit</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Mauritius Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Weihnachtsinsel Standardzeit</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Tonga Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Fiji Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Samoa Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Hawaiian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Osterinsel Normalzeit</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Interner Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Unbekannter Fehler: </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Interner Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Kein Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Hohe Batterietemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Hohe Batteriespannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Niedrige Batteriespannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Batteriespannung hat konfig. max. überschritten</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Hohe Lichtmaschinentemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Hohe Lichtmaschinedrehzahl</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Hohe Feldantriebstemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Erforderlicher Sensor fehlt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Niedrige Lichtmaschinenspannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Hohes Lichtmaschinen-Spannungsoffset</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Lichtmaschinenspannung hat konf. max. überschritten</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Hochspannung der Lichtmaschine</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Batterie getrennt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Batterie Überspannungsabschaltung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Batterieinstanz außerhalb des Bereichs</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Zu viele BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Batterie kurz vor Abtrennung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Zu viele Geräte zum Nachverfolgen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Batterie Unterspannungsabschaltung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Batterie Überstromabschaltung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Batterie Hochtemperaturabschaltung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Batterie Untertemperaturabschaltung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Verbindung zum BMS unterbrochen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC deaktiviert</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>DC/DC Konverter nicht bereit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC hohe Primärspannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC niedrige Primärspannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC hohe Sekundärspannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC niedrige Sekundärspannung</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC hohe Temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>DC/DC-Fehlkonfiguration</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Batterietemperatursensor defekt</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_es.ts
+++ b/i18n/venus-gui-v2_es.ts
@@ -1,7381 +1,8023 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="es">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Deshabilitado</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Deshabilitado</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Sobrecarga del inversor</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Sobrecarga del inversor</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Potencia</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Potencia</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Apagado</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Apagado</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Automático</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Automático</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Batería</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectado</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Desconectado</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generador</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Alta tensión de la batería</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Alta tensión de la batería</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Inversor / cargador</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Inversor / cargador</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Tensión batería baja</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Tensión batería baja</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manual</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manual</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Ninguno</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Ninguno</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Posición</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Posición</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Velocidad</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Velocidad</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Estado</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Estado</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instalando %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instalando %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Error desconocido</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Error desconocido</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Estado de carga mínimo</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Estado de carga mínimo</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconocido</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Introducir contraseña</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Introducir contraseña</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Pulsar para comprobar</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Pulsar para comprobar</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Red eléctrica</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Red eléctrica</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Rendimiento solar</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Rendimiento solar</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Control externo</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Control externo</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Depósitos</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Depósitos</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Ambiente</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Ambiente</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>No hay alertas actualmente</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>No hay alertas actualmente</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>General</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>General</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Fecha &amp; Hora</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Fecha &amp; Hora</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Configuración sistema</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Configuración sistema</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Pantalla &amp; idioma</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Pantalla &amp; idioma</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>Portal online VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>Portal online VRM</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Contadores de energía</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Contadores de energía</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>Inversores FV</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>Inversores FV</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>Módem GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>Módem GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Arranque/parada generador</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Arranque/parada generador</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Bomba del depósito</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Bomba del depósito</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Servicio al cliente</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Servicio al cliente</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Características de Venus OS Large</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Características de Venus OS Large</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Límite de vida de la batería: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Límite de vida de la batería: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Arranque automático</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Autostart se deshabilitará y el generador no arrancará de forma automática en función de las condiciones configuradas.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Autostart se deshabilitará y el generador no arrancará de forma automática en función de las condiciones configuradas.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Parada manual</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Parada manual</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>INICIO MANUAL</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>INICIO MANUAL</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Posición</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Arranque automático</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Arranque automático</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Interruptores</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Interruptores</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Nivel de acceso</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Nivel de acceso</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Usuario</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Usuario</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Usuario &amp; Instalador</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Usuario &amp; Instalador</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superusuario</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superusuario</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Servicio</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Servicio</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Asegúrese de reiniciar también el sistema VE.Bus tras deshabilitar DVCC</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Asegúrese de reiniciar también el sistema VE.Bus tras deshabilitar DVCC</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Limitar corriente de carga</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Limitar corriente de carga</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Máxima corriente de carga</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Máxima corriente de carga</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Usar %1 para arranque/parada</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Usar %1 para arranque/parada</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Arrancar cuando %1 sea mayor que</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Arrancar cuando %1 sea mayor que</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Arrancar cuando %1 sea menor que</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Arrancar cuando %1 sea menor que</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Detener cuando %1 sea mayor que</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Detener cuando %1 sea mayor que</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Detener cuando %1 sea menor que</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Detener cuando %1 sea menor que</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>¿Borrar dirección IP?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>¿Borrar dirección IP?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Máx.: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Máx.: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Conexión</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Conexión</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Producto</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Producto</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Nombre</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Nombre</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>ID del producto</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>ID del producto</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Versión de hardware</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Versión de hardware</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Nombre del dispositivo</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Nombre del dispositivo</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Control del conmutador remoto deshabilitado</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Control del conmutador remoto deshabilitado</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Condición de fallo del generador</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Condición de fallo del generador</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Generador no detectado en la entrada CA</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Generador no detectado en la entrada CA</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Tiempo de funcionamiento desde el último test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Tiempo de funcionamiento desde el último test</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Tiempo restante para el siguente test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Tiempo restante para el siguente test</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>En marcha ahora</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>En marcha ahora</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>INICIO MANUAL</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>INICIO MANUAL</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Arrancar generador</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Arrancar generador</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Tiempo de funcionamiento diario</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Tiempo de funcionamiento diario</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>El valor debe ser mayor que el valor de parada</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>El valor debe ser mayor que el valor de parada</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>El valor debe de ser menor que el valor de arranque</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>El valor debe de ser menor que el valor de arranque</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>Salida CA</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>Salida CA</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">Salida CA</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Usar carga CA para arranque/parada</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Usar carga CA para arranque/parada</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Medición</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Medición</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Consumo total</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Consumo total</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Carga total en salida CA del inversor</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Carga total en salida CA del inversor</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Fase más alta en la salida CA del inversor</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Fase más alta en la salida CA del inversor</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Arrancar cuando la potencia sea mayor de</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Arrancar cuando la potencia sea mayor de</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Parar cuando la potencia sea menor de</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Parar cuando la potencia sea menor de</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Monitor de batería</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Monitor de batería</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Monitor no disponible, selecciona otro</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Monitor no disponible, selecciona otro</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Monitor de batería</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Monitor no disponible, selecciona otro</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Al perder comunicación</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Al perder comunicación</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Detener generador</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Detener generador</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Mantener generador en marcha</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Mantener generador en marcha</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Detener el generador cuando haya entrada de CA disponible</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Detener el generador cuando haya entrada de CA disponible</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>Estado de carga de la batería</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>Estado de carga de la batería</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Alta temperatura inversor</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Alta temperatura inversor</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Alta temperatura inversor</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Arrancar por aviso de alta temperatura</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Arrancar por aviso de alta temperatura</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Arrancar por aviso de sobrecarga</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Arrancar por aviso de sobrecarga</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Funcionamiento periódico</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Funcionamiento periódico</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Intervalo de funcionamiento</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Intervalo de funcionamiento</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 día(s)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 día(s)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Omitir funcionamiento si ha estado funcionando durante</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Omitir funcionamiento si ha estado funcionando durante</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Arrancar siempre</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Arrancar siempre</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Fecha de inicio de intervalo de funcionamiento</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Fecha de inicio de intervalo de funcionamiento</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>En marcha durante (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>En marcha durante (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Marcha hasta batería cargada</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Marcha hasta batería cargada</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (fijado)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (fijado)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS conectado, pero sin posición</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS conectado, pero sin posición</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>GPS no conectado</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>GPS no conectado</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Latitud</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Latitud</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Longitud</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Longitud</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Curso</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Curso</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Altitud</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Altitud</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Número de satélites</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Número de satélites</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Objetivo red</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Objetivo red</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Objetivo entrada CA</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Objetivo entrada CA</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Corriente: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Corriente: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Tensión: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Tensión: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Límites (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Límites (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Carga: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Carga: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Descarga: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Descarga: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Límites (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Límites (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Visible</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Visible</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Oculto</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Oculto</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Mediciones auxiliares)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Mediciones auxiliares)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Salida %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Salida %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Monitor de baterías activo</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Monitor de baterías activo</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Nombre</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Introduzca el nombre</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Introduzca el nombre</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Introduzca el nombre</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Detección continua</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Detección continua</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Adaptadores Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Adaptadores Bluetooth</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Código PIN</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Código PIN</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Puede que sea necesario eliminar la información de emparejamiento antes de conectarlo.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Puede que sea necesario eliminar la información de emparejamiento antes de conectarlo.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Tipo de fase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Tipo de fase</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Monofase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Monofase</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Multifase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Multifase</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>Inversor FV en fase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>Inversor FV en fase 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>Posicion de inversor FV en fase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>Posicion de inversor FV en fase 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>Perfil de CAN-bus</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>Perfil de CAN-bus</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deshabilitado</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can y Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can y Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can y CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can y CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Activo, pero sin servicios (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Activo, pero sin servicios (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Dispositivos</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Dispositivos</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>Función de salida NMEA 2000</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>Función de salida NMEA&#xa0;2000</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Selector del número de identidad único</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Selector del número de identidad único</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Por favor espere, cambiar y comprobar el número único tardará un poco</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Por favor espere, cambiar y comprobar el número único tardará un poco</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>El selector anterior establece qué bloque de números de identidad únicos se usa para los Números de identidad únicos NAME en el campo PGN 60928 NAME. Cámbielo solo cuando use varios dispositivos GX en la misma red VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>El selector anterior establece qué bloque de números de identidad únicos se usa para los Números de identidad únicos NAME en el campo PGN 60928 NAME. Cámbielo solo cuando use varios dispositivos GX en la misma red VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>El selector anterior establece qué bloque de números de identidad únicos se usa para el número de serie en el campo DGN 60928 ADDRESS_CLAIM. Cámbielo solo cuando use varios dispositivos GX en la misma red RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>El selector anterior establece qué bloque de números de identidad únicos se usa para el número de serie en el campo DGN 60928 ADDRESS_CLAIM. Cámbielo solo cuando use varios dispositivos GX en la misma red RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Compruebe los números de identificación únicos</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Compruebe los números de identificación únicos</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Pulsar para comprobar</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Hay otro dispositivo conectado con este número único, seleccione un número nuevo.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Hay otro dispositivo conectado con este número único, seleccione un número nuevo.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: No hay ningún otro dispositivo conectado con este número único.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: No hay ningún otro dispositivo conectado con este número único.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Estado de la red</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Estado de la red</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Brillo adaptable</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Brillo adaptable</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Brillo</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Brillo</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Tiempo desconexión pantalla</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Tiempo desconexión pantalla</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 s</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 s</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Nunca</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Nunca</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Modo de visualización</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Modo de visualización</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Oscuro</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Oscuro</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Claro</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Claro</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Vista breve de los niveles</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Vista breve de los niveles</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Idioma</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Cambiando idioma</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Cambiando idioma</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Visualización de la potencia eléctrica</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Visualización de la potencia eléctrica</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Potencia (vatios)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Potencia (vatios)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Corriente (amperios)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Corriente (amperios)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Unidades</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Unidades</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Nivel %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Nivel %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Centígrado</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Centígrado</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;PRECAUCIÓN:&lt;/b&gt; Lea el manual antes de hacer ajustes.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;PRECAUCIÓN:&lt;/b&gt; Lea el manual antes de hacer ajustes.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Limite la tensión de carga de la batería gestionada</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Limite la tensión de carga de la batería gestionada</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Máxima tensión de carga</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Máxima tensión de carga</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>STS - Sensor de tensión compartida</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>STS - Sensor de tensión compartida</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Sensor de temperatura compartida</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Sensor de temperatura compartida</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Sensor no disponible, ponga otro</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Sensor no disponible, ponga otro</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Sensor no disponible, ponga otro</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Sensor utilizado</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Sensor utilizado</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Sensor de corriente compartida</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Sensor de corriente compartida</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Estado SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Estado SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Deshabilitado (control externo)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Deshabilitado (control externo)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Deshabilitado (ningún cargador)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Deshabilitado (ningún cargador)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Deshabilitado (ningún monitor de baterías)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Deshabilitado (ningún monitor de baterías)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Selección automática</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Selección automática</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Sin control por BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Sin control por BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>BMS controlando</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>BMS controlando</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>No disponible, seleccione otro</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>No disponible, seleccione otro</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Seleccionado automáticamente</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Seleccionado automáticamente</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Ninguno</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Fecha/hora creación</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Fecha/hora creación</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Actualizaciones en línea</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Actualizaciones en línea</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Instalar firmware desde SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Instalar firmware desde SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Firmware de respaldo</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Firmware de respaldo</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Revisar si hay actualizaciones en SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Revisar si hay actualizaciones en SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Firmware encontrado</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Firmware encontrado</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instalando %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instalando %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Presiona para actualizar a %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Presiona para actualizar a %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Presiona para actualizar a %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Fecha/hora de creación del firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Fecha/hora de creación del firmware</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Actualización automática</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Actualización automática</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Solo comprobar</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Solo comprobar</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Solo comprobar y descargar</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Solo comprobar y descargar</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Comprobar y actualizar</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Comprobar y actualizar</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Actualizar alimentación</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Actualizar alimentación</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Tipo de imagen</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Tipo de imagen</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normal</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normal</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Grande</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Grande</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Comprobar actualizaciones</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Comprobar actualizaciones</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Actualización disponible</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Actualización disponible</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Instalando %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Instalando %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Instalando %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Fecha/hora creación</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Fecha/hora creación</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Inversores</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Inversores</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Buscar inversores FV</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Buscar inversores FV</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Direcciones IP detectadas</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Direcciones IP detectadas</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Introducir dirección IP manualmente</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Introducir dirección IP manualmente</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>Puerto TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>Puerto TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Multifase</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Multifase</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Fase dividida (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Fase dividida (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Mostrar</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Mostrar</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>¿Volver a buscar la dirección IP?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>¿Volver a buscar la dirección IP?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Volver a escanear</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Volver a escanear</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH en LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH en LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Soporte remoto</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Soporte remoto</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Túnel de soporte remoto</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Túnel de soporte remoto</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>Puerto e IP de soporte remoto</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>Puerto e IP de soporte remoto</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Cerrar sesión ahora</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Reiniciar ahora</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Reiniciar ahora</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">El dispositivo se ha reiniciado.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Alarma sonora</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Alarma sonora</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Modo demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Modo demo</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>Demo ESS</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>Demo ESS</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Demo 1 barco/caravana</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Demo 1 barco/caravana</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Demo 2 barco/caravana</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Demo 2 barco/caravana</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Al iniciar el modo demostración algunos parámetros cambiarán y la interfaz de usuario quedará bloqueada por un momento.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Al iniciar el modo demostración algunos parámetros cambiarán y la interfaz de usuario quedará bloqueada por un momento.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Condiciones</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Condiciones</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Tiempo mínimo de funcionamiento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Tiempo mínimo de funcionamiento</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Periodo de calentamiento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Periodo de calentamiento</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Periodo de enfriamiento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Periodo de enfriamiento</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Detectar generador en entrada CA</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Detectar generador en entrada CA</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Ninguna de las entradas CA está configurada para el generador. Ir a la página de configuración del sistema y configure la entrada CA correcta para el generador para habilitar esta funcionalidad.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Ninguna de las entradas CA está configurada para el generador. Ir a la página de configuración del sistema y configure la entrada CA correcta para el generador para habilitar esta funcionalidad.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Se disparará una alarma cuando no se detecte electricidad procedente del generador en la entrada CA del inversor. Asegúrese de que se ha configurado la entrada CA correcta para el generador en la página de configuración del sistema.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Se disparará una alarma cuando no se detecte electricidad procedente del generador en la entrada CA del inversor. Asegúrese de que se ha configurado la entrada CA correcta para el generador en la página de configuración del sistema.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Comienzo horario silencioso</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Comienzo horario silencioso</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Fin horario silencioso</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Fin horario silencioso</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Tiempo de funcionamiento y mantenimiento</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Tiempo de funcionamiento y mantenimiento</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Reinicializar contadores diarios</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Reinicializar contadores diarios</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Los contadores diarios de ejecucion se han reinicializado</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Los contadores diarios de ejecucion se han reinicializado</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>No es posible modificar los contadores mientras el generador está en marcha</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>No es posible modificar los contadores mientras el generador está en marcha</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Intervalo de mantenimiento del generador (horas)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Intervalo de mantenimiento del generador (horas)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Intervalo de mantenimiento establecido en %1h. Use el botón “Reset service timer” (reiniciar el temporizador de mantenimiento) para reiniciar el temporizador de mantenimiento.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Intervalo de mantenimiento establecido en %1h. Use el botón “Reset service timer” (reiniciar el temporizador de mantenimiento) para reiniciar el temporizador de mantenimiento.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Reiniciar el temporizador de mantenimiento</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Reiniciar el temporizador de mantenimiento</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Ajustes del GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Ajustes del GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>yyyy-mm-dd</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>yyyy-mm-dd</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20,693 N, 5° 13,205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20,693 N, 5° 13,205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Unidad velocidad</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Unidad velocidad</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilómetros por hora</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilómetros por hora</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Metros por segundo</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Metros por segundo</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Millas por hora</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Millas por hora</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Nudos</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Nudos</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>No hay un módem GSM conectado</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>No hay un módem GSM conectado</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Operador</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Operador</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Puede ser necesario configurar los parámetros APN que se encuentran más abajo en esta página; póngase en contacto con su operador para más información.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Puede ser necesario configurar los parámetros APN que se encuentran más abajo en esta página; póngase en contacto con su operador para más información.
 Si esto no funcionara, compruebe el buen funcionamiento de la tarjeta SIM en un teléfono para asegurarse de que dispone de saldo y/o está habilitada para datos.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Permitir roaming</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Permitir roaming</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Estado SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Estado SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM no insertada</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM no insertada</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN requerido</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN requerido</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK requerido</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK requerido</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Fallo SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Fallo SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM ocupada</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM ocupada</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>SIM incorrecta</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>SIM incorrecta</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Pin erróneo</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Pin erróneo</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Preparado</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Preparado</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Error desconocido</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Predeterminado</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Predeterminado</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Usar APN predeterminado</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Usar APN predeterminado</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Nombre de APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Nombre de APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Usar autenticación</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Usar autenticación</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Nombre del usuario</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Nombre del usuario</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Autoconsumo</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Autoconsumo</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Asistente ESS no encontrado</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Asistente ESS no encontrado</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Contador de red</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Contador de red</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Contador externo</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Contador externo</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Inversor/cargador</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Inversor/cargador</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Salida CA del inversor en uso</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Salida CA del inversor en uso</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Regulación multifásica</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Regulación multifásica</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Total de todas las fases</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Total de todas las fases</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Fase individual</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Fase individual</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Cada fase está regulada para alcanzar individualmente el punto de referencia de la red (se reduce la eficiencia del sistema).
+        <translation>Cada fase está regulada para alcanzar individualmente el punto de referencia de la red (se reduce la eficiencia del sistema).
 
 PRECAUCIÓN: Úselo solo si lo requiere el proveedor de suministros.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>El total de todas las fases está regulado de forma inteligente para alcanzar el punto de referencia de la red (se optimiza la eficiencia del sistema).
+        <translation>El total de todas las fases está regulado de forma inteligente para alcanzar el punto de referencia de la red (se optimiza la eficiencia del sistema).
 
 Úselo a menos que el proveedor de suministros lo prohíba.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inactivo</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">ESS dinámico</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Estado de carga (SoC) mínimo (salvo fallo de red)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Estado de carga (SoC) mínimo (salvo fallo de red)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Límite real de estado de carga</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Límite real de estado de carga</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Sostener</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Cargando</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Recorte de picos (peak shaving)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Recorte de picos (peak shaving)</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Solo por encima del estado de carga mínimo</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Solo por encima del estado de carga mínimo</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Siempre</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Siempre</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Descarga deshabilitada</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Descarga deshabilitada</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Carga lenta</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Carga lenta</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Sostener</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Sostener</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Cargando</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Cargando</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Limitar potencia de carga</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Limitar potencia de carga</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Máxima potencia de carga</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Máxima potencia de carga</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Limitar la potencia del inversor</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Limitar la potencia del inversor</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Potencia máxima del inversor</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Potencia máxima del inversor</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Objetivo red</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Objetivo red</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Inyección a red</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Inyección a red</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>FV acoplado a CA - inyectar exceso</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>FV acoplado a CA - inyectar exceso</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>FV acoplada a CC - inyectar exceso</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>FV acoplada a CC - inyectar exceso</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Limitar inyección del sistema a la red</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Limitar inyección del sistema a la red</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Potencia máxima de inyección a red</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Potencia máxima de inyección a red</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Limitación de inyección activa</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Limitación de inyección activa</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Entradas analógicas</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Entradas analógicas</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Entradas digitales</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Entradas digitales</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Entrada digital %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Entrada digital %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Contador de impulsos</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Contador de impulsos</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Alarma de puerta</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Alarma de puerta</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Bomba de sentina</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Bomba de sentina</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Alarma de sentina</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Alarma de sentina</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Alarma antirrobo</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Alarma antirrobo</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Alarma antihumos</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Alarma antihumos</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Alarma antiincendios</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Alarma antiincendios</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>Alarma de CO2</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>Alarma de CO2</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Sensores de Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Sensores de Bluetooth</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Tenga en cuenta que estas funciones no cuentan con asistencia técnica oficial de Victron. Le rogamos que dirija sus preguntas a community.victronenergy.com.
+        <translation>Tenga en cuenta que estas funciones no cuentan con asistencia técnica oficial de Victron. Le rogamos que dirija sus preguntas a community.victronenergy.com.
 
 Documentación en https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Habilitado (modo seguro)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Habilitado (modo seguro)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Retrasado %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Retrasado %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID de portal VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID de portal VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Intervalo entre registros</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Intervalo entre registros</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 hora</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 hora</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 horas</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 horas</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 horas</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 horas</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 horas</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 horas</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 día</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 día</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Utilizar conexión segura (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Utilizar conexión segura (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Último contacto</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Último contacto</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Texto de respuesta inesperado</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Texto de respuesta inesperado</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Respuesta HTTP inesperada</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Respuesta HTTP inesperada</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Tiempo de espera de la conexión agotado</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Tiempo de espera de la conexión agotado</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Error de conexión</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Error de conexión</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Fallo DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Fallo DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Error de enrutamiento</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Error de enrutamiento</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM no disponible</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM no disponible</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Error desconocido</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Error desconocido</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Mensaje de error: 
+        <translation>Mensaje de error: 
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Reiniciar dispositivo si no hay contacto</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Reiniciar dispositivo si no hay contacto</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Demora de reinicio por no contacto (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Demora de reinicio por no contacto (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Ubicación almacenamiento</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Ubicación almacenamiento</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Buffer no activo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Buffer no activo</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Almacenamiento interno</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Almacenamiento interno</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Transfiriendo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Transfiriendo</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Almacenamiento externo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Almacenamiento externo</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Error desconocido</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Ningún error</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Ningún error</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Espacio almacenamiento lleno</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Espacio almacenamiento lleno</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Error IO</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Error IO</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Error al montar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Error al montar</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Contiene imagen firmware. No se utiliza.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Contiene imagen firmware. No se utiliza.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>Tarjeta SD / USB no escribible</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>Tarjeta SD / USB no escribible</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Espacio en disco libre</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Espacio en disco libre</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>byte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>byte</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bytes</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bytes</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Registros almacenados</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Registros almacenados</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 registros</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 registros</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Edad registro mas antiguo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Edad registro mas antiguo</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Habilitar Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Habilitar Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Ningún error reportado</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Ningún error reportado</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Hora del último error</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Hora del último error</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Servicios disponibles</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Servicios disponibles</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>ID de la unidad: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>ID de la unidad: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Función (Relé 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Función (Relé 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Función</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Función</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Relé de alarma</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Relé de alarma</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Bomba del depósito</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polaridad relé de alarma</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polaridad relé de alarma</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normalmente abierto</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normalmente abierto</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normalmente cerrado</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normalmente cerrado</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relé 1 activado</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relé 1 activado</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relay activado</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relay activado</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Función (Relé 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Función (Relé 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relé 2 activado</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relé 2 activado</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Reglas de control de temperatura</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Reglas de control de temperatura</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Activación del relé por la temperatura</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Activación del relé por la temperatura</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>No hay ningún relé configurado para activarse con la temperatura. Vaya a la página de ajustes del relé situada en el menú principal de ajustes y fije la función del relé en "Temperature".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>No hay ningún relé configurado para activarse con la temperatura. Vaya a la página de ajustes del relé situada en el menú principal de ajustes y fije la función del relé en &quot;Temperature&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Esta opción le permite cambiar entre la versión de firmware actual y la anterior. No requiere Internet o tarjeta SD.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Esta opción le permite cambiar entre la versión de firmware actual y la anterior. No requiere Internet o tarjeta SD.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Presiona para iniciar</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Presiona para iniciar</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Reinicio a %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Reinicio a %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>No es posible cambiar la versión de firmware si la actualización automática está en "Check and update" (Revisar y actualizar). Cambie la actualización automática a "Disabled" (Deshabilitada) o "Check only" (Solo revisar) para habilitar esta opción.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>No es posible cambiar la versión de firmware si la actualización automática está en &quot;Check and update&quot; (Revisar y actualizar). Cambie la actualización automática a &quot;Disabled&quot; (Deshabilitada) o &quot;Check only&quot; (Solo revisar) para habilitar esta opción.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Firmware de respaldo no disponible</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Firmware de respaldo no disponible</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Consola en VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-bus por TCP/IP (depuración)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-bus por TCP/IP (depuración)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Alimentación de la red</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Alimentación de la red</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Vehículo</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Vehículo</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Barco</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Barco</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Nombre del sistema</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Nombre del sistema</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automático</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automático</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Red eléctrica</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automático</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Definido por el usuario</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Definido por el usuario</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Nombre definido por usuario</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Nombre definido por usuario</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>Entrada CA 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>Entrada CA 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>Entrada CA 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>Entrada CA 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Monitor para fallo de red</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Monitor para fallo de red</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Monitor para desconexión de toma de puerto</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Monitor para desconexión de toma de puerto</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Seleccionado automáticamente</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Seleccionado automáticamente</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Sistema CC disponible</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Sistema CC disponible</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Sincronizar SOC de VE.Bus con bateria</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Sincronizar SOC de VE.Bus con bateria</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Mejorar estado de carga VE.Bus con corriente del cargador solar</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Mejorar estado de carga VE.Bus con corriente del cargador solar</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Control de tensión del cargador solar</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Control de tensión del cargador solar</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Control de corriente del cargador solar</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Control de corriente del cargador solar</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Control por BMS</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>Control por BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>Control por BMS</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>La función de arranque/parada de la bomba del depósito no está habilitada. Vaya a los ajustes del relé y  ajuste la función a "Tank pump".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>La función de arranque/parada de la bomba del depósito no está habilitada. Vaya a los ajustes del relé y  ajuste la función a &quot;Tank pump&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Estado de la bomba</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Estado de la bomba</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Sensor nivel tanque</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Sensor nivel tanque</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Nivel de arranque</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Nivel de arranque</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Nivel de parada</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Nivel de parada</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Conexión perdida</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Conexión perdida</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Desconectado</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Desconectado</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Oculto]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Oculto]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>¿Conectar a la red?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>¿Conectar a la red?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Conectar</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Conectar</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Olvidar red?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Olvidar red?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Omitir</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Omitir</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>¿Está seguro de que desea olvidar esta red?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>¿Está seguro de que desea olvidar esta red?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>Dirección MAC</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>Dirección MAC</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>Configuración IP</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>Configuración IP</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Apagado</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Fija</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Fija</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Máscara de red</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Máscara de red</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Puerta de enlace</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Puerta de enlace</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>Servidor DNS</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>Servidor DNS</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Dirección IP de enlace local</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Dirección IP de enlace local</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Tenga cuidado, para sistemas ESS, así como para sistemas con una batería gestionada, la instancia del dispositivo CAN-bus debe permanecer configurada en 0. Para más información, véase el manual de GX.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Tenga cuidado, para sistemas ESS, así como para sistemas con una batería gestionada, la instancia del dispositivo CAN-bus debe permanecer configurada en 0. Para más información, véase el manual de GX.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Instancia del dispositivo</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Instancia del dispositivo</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Dirección de red</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Dirección de red</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Dispositivos VE.Can</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Dispositivos VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>N.º de dispositivo %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>N.º de dispositivo %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Nigún punto de acceso</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Nigún punto de acceso</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Ningún adaptador Wi-Fi conectado</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Ningún adaptador Wi-Fi conectado</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Crear punto de acceso</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Crear punto de acceso</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Redes Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Redes Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>¿Está seguro de que desea deshabilitar el punto de acceso?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>¿Está seguro de que desea deshabilitar el punto de acceso?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Fecha/Hora UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Fecha/Hora UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Fecha/Hora local</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Fecha/Hora local</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Zona horaria</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Zona horaria</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>África</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>África</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>América</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>América</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antártida</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antártida</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Ártico</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Ártico</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asia</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlántico</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlántico</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australia</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>India</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>India</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pacífico</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pacífico</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>No conectado %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>No conectado %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>¿Reiniciar ahora?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>¿Reiniciar ahora?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Los cambios en la instancia VRM no se aplicarán hasta que se reinicie el dispositivo.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Los cambios en la instancia VRM no se aplicarán hasta que se reinicie el dispositivo.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>El dispositivo se está reiniciando...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>El dispositivo se está reiniciando...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>El dispositivo se ha reiniciado.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>El dispositivo se ha reiniciado.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Alarma de tensión de batería baja</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Alarma de tensión de batería baja</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Alarma de tensión de batería alta</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Alarma de tensión de batería alta</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Último error</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Último error</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2º ultimo error</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2º ultimo error</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3&lt;sup&gt;er&lt;/sup&gt; ultimo error</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3&lt;sup&gt;er&lt;/sup&gt; ultimo error</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4º ultimo error</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4º ultimo error</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Interconectado</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Interconectado</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Configuración del modo</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Configuración del modo</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Autónomo</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Autónomo</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Autónomo</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Carga</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Carga</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Control externo</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Carga y Hub-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Carga y Hub-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Carga y BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Carga y BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Control externo y BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Control externo y BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Carga, Hub-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Carga, Hub-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Configuración del maestro</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Configuración del maestro</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Esclavo</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Esclavo</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Esclavo</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Maestro del grupo</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Maestro del grupo</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Maestro Carga</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Maestro Carga</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Maestro Grupo y Carga</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Maestro Grupo y Carga</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Tensión de carga</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Tensión de carga</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Restablecer</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Restablecer</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>El control BMS se habilita automáticamente cuando hay un BMS. Reinícielo si se ha cambiado la configuración del sistema o si no hay BMS:</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>El control BMS se habilita automáticamente cuando hay un BMS. Reinícielo si se ha cambiado la configuración del sistema o si no hay BMS:</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Potencia FV total</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Carga</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Carga</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 encontrado</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 encontrado</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Historia</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Historia</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Historia</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Operación interconectada</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Operación interconectada</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Vista en tabla</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Vista en tabla</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Gráfico</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Gráfico</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Advertencia</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Advertencia</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarma</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarma</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarma</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Volumen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Volumen</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Cortocircuito</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Cortocircuito</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Polaridad inversa</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Polaridad inversa</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Estaciones de carga de vehículos eléctricos</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Estaciones de carga de vehículos eléctricos</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Sesión</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Sesión</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Momento</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Momento</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Modo de carga</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Modo de carga</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Iniciar y detener el proceso usted mismo. Utilícelo para cargas rápidas y monitorización estrecha.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Iniciar y detener el proceso usted mismo. Utilícelo para cargas rápidas y monitorización estrecha.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Arranques y paradas en función del nivel de carga de la batería. Óptimo durante la noche y en cargas prolongadas para evitar la sobrecarga.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Arranques y paradas en función del nivel de carga de la batería. Óptimo durante la noche y en cargas prolongadas para evitar la sobrecarga.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Tarifas más bajas de la electricidad durante las horas con menos demanda o si quiere asegurarse de que su vehículo eléctrico está completamente cargado y listo para funcionar a una hora determinada.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Tarifas más bajas de la electricidad durante las horas con menos demanda o si quiere asegurarse de que su vehículo eléctrico está completamente cargado y listo para funcionar a una hora determinada.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Habilitar la carga</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Habilitar la carga</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Bloquear la pantalla del cargador</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Bloquear la pantalla del cargador</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Dirección de origen</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Dirección de origen</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Configuración</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Configuración</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Instancia de línea #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Instancia de línea #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Instancia de línea</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Instancia de línea</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Instancia del cargador</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Instancia del cargador</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Instancia del inversor</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Instancia del inversor</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Instancia de fuente de alimentación CC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Instancia de fuente de alimentación CC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Instancia de alimentación CC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Instancia de alimentación CC</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Prioridad de fuente de alimentación CC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Prioridad de fuente de alimentación CC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Prioridad de alimentación CC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Prioridad de alimentación CC</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Instancia del depósito</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Instancia del depósito</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Dispositivos RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Dispositivos RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Habilitar el visualizador de fotogramas por segundo</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Habilitar el visualizador de fotogramas por segundo</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>No compatible</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>No compatible</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Quitar dispositivos desconectados</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Quitar dispositivos desconectados</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Encontrado dispositivo no compatible</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Encontrado dispositivo no compatible</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Función del relé</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Función del relé</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarma</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Arranque/parada cargador o generador</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Arranque/parada cargador o generador</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Control manual</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Fusible fundido</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Control manual</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Control manual</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Siempre abierto( no usar relé)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Siempre abierto( no usar relé)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Tenga en cuenta que cambiando el ajuste Estado de carga bajo también cambia el ajuste Límite de descarga del tiempo restante en el menú de la batería.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Tenga en cuenta que cambiando el ajuste Estado de carga bajo también cambia el ajuste Límite de descarga del tiempo restante en el menú de la batería.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Fusible fundido</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Fusible fundido</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>LED de estado</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>LED de estado</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Ninguno</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Interruptor principal</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Interruptor principal</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Calentador</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Calentador</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Ventilador interno</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Ventilador interno</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Marcas de advertencia</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Marcas de advertencia</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Marcas de alarma</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Marcas de alarma</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Interruptor</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Interruptor</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Inicializando</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Inicializando</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Desconectar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Desconectar</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Actualizando</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Actualizando</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Se va a ejecutar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Se va a ejecutar</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Pre-cargando</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Pre-cargando</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Comprobación de contactor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Comprobación de contactor</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Estado de salud</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Estado de salud</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Temperatura de la batería</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Temperatura de la batería</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Temperature del aire</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Temperature del aire</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Tensión batería arranque</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Tensión batería arranque</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Tensión del bus</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Tensión del bus</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Tensión sección superior</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Tensión sección superior</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Error de comunicación</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Estado de salud</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Tensión del bus</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Tensión sección inferior</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Tensión sección inferior</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Desviación punto medio</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Desviación punto medio</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Ah consumidos</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Ah consumidos</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Tiempo restante</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Tiempo restante</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Detalles</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Detalles</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarmas a nivel de módulo</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarmas a nivel de módulo</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnósticos</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnósticos</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Fusibles</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Fusibles</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>Sistema</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>Sistema</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parámetros</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parámetros</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Volver a detectar bateria</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Volver a detectar bateria</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Presiona para detectar</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Presiona para detectar</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Presiona para detectar</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Volver a detectar la batería puede llevar hasta 60 segundos. Mientras tanto el nombre de la batería puede ser incorrecto.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Volver a detectar la batería puede llevar hasta 60 segundos. Mientras tanto el nombre de la batería puede ser incorrecto.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Corriente de carga alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Corriente de carga alta</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Corriente de descarga alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Corriente de descarga alta</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>SOC bajo</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>SOC bajo</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Alta tensión de la batería</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">SOC bajo</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Tensión baja de la batería de arranque</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Tensión baja de la batería de arranque</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Tensión batería arranque alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Tensión batería arranque alta</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Sensor de temperatura de la batería</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Sensor de temperatura de la batería</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Tensión punto medio</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Tensión punto medio</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Fusible fundido</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Alta temperatura interna</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Alta temperatura interna</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Temperatura de carga baja</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Temperatura de carga baja</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Temperatura de carga alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Temperatura de carga alta</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Fallo interno</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Fallo interno</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Disyuntor activado</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Disyuntor activado</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Celda desequilibrada</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Celda desequilibrada</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Baja tensión de celda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Baja tensión de celda</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Tensión mínima de la celda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Tensión mínima de la celda</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Tensión máxima de la celda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Tensión máxima de la celda</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Temperatura mínima de la celda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Temperatura mínima de la celda</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Temperatura de celda máxima</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Temperatura de celda máxima</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Módulos de batería</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Módulos de batería</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 conectado</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 conectado</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 desconectado</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 desconectado</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Número de módulos bloqueando la carga/descarga</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Número de módulos bloqueando la carga/descarga</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Capacidad instalada/disponible</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Capacidad instalada/disponible</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Descarga más profunda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Descarga más profunda</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Última descarga</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Última descarga</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Descarga media</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Descarga media</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Total de ciclos de carga</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Total de ciclos de carga</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Número de descargas completas</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Número de descargas completas</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Acumulado de Ah consumidos</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Acumulado de Ah consumidos</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Tensión mínima de la celda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Tensión mínima de la celda</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Tensión máxima de la celda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Tensión máxima de la celda</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Tiempo desde la última carga completa</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Tiempo desde la última carga completa</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Número de sincronizaciones</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Número de sincronizaciones</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarmas por tensión de la batería arranque baja</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarmas por tensión de la batería arranque baja</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Mínima tensión de la batería de arranque</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Mínima tensión de la batería de arranque</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Máxima tensión de la batería de arranque</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Máxima tensión de la batería de arranque</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Energía descargada</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Energía descargada</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Energía cargada</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Energía cargada</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Límite de tensión de carga (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Límite de tensión de carga (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Límite de corriente de carga (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Límite de corriente de carga (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Límite de corriente de descarga (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Límite de corriente de descarga (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Desconexión por tensión baja (siempre ignorada)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Desconexión por tensión baja (siempre ignorada)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Bancada de baterías</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Bancada de baterías</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relé (en monitor de batería)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relé (en monitor de batería)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Restablecer ajustes de fábrica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Restablecer ajustes de fábrica</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Presiona para restablecer</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Presiona para restablecer</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>¿Restablecer ajustes de fábrica?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>¿Restablecer ajustes de fábrica?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth activado</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth activado</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Tensión nominal</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Tensión nominal</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 voltios</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 voltios</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Voltios</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Voltios</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 voltios</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 voltios</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Capacidad</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Capacidad</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacidad</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Tensión de la batería cargada</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Tensión de la batería cargada</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Corriente de cola</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Corriente de cola</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Tiempo de detección de la batería cargada</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Tiempo de detección de la batería cargada</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Exponente de Peukert</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Exponente de Peukert</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Factor de eficiencia de la carga</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Factor de eficiencia de la carga</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Umbral de corriente</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Umbral de corriente</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Periodo promedio de la autonomía restante</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Periodo promedio de la autonomía restante</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Límite de descarga del tiempo restante</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Límite de descarga del tiempo restante</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Compensación de la corriente</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Compensación de la corriente</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Sincronizar estado de carga al 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Sincronizar estado de carga al 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Presiona para sincronizar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Presiona para sincronizar</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Calibrar corriente cero</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Calibrar corriente cero</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Pulsar para fijar en 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Pulsar para fijar en 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Distribuidor %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Distribuidor %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>No hay alimentación en el embarrado</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>No hay alimentación en el embarrado</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Conexión perdida</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n fusible(s) fundidos</numerusform>
-        <numerusform>%n fusible(s) fundidos</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n fusible(s) fundidos</numerusform>
+            <numerusform>%n fusible(s) fundidos</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>No hay información disponible, véase el estado del Distribuidor en la página anterior.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>No hay información disponible, véase el estado del Distribuidor en la página anterior.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Fusible %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Fusible %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>No utilizado</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>No utilizado</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Fundido</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Fundido</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Paradas debidas a un error</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Paradas debidas a un error</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Último error</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">2º ultimo error</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">3&lt;sup&gt;er&lt;/sup&gt; ultimo error</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">4º ultimo error</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Interruptor del sistema</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Interruptor del sistema</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Relé externo</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Relé externo</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Contacto programable</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Contacto programable</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Baterías</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Baterías</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacidad</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Baterías</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Paralelo</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Paralelo</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Series</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Series</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Tensión mín/máx de la celda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Tensión mín/máx de la celda</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Temperatura de celda mín/máx</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Temperatura de celda mín/máx</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Equilibrando</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Equilibrando</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Equilibrando</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconocido</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Salida</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Salida</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Control de campo</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Control de campo</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Velocidad del motor</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Velocidad del motor</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Tensión aux.</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Tensión aux.</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>sin alarmas</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>sin alarmas</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Tensión baja</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Tensión baja</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Tensión alta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Tensión alta</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Tensión aux. baja</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Tensión aux. baja</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Tensión aux. alta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Tensión aux. alta</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Alarmas por tensión aux. baja</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Alarmas por tensión aux. baja</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Alarmas por tensión aux. alta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Alarmas por tensión aux. alta</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Mínima tensión aux.</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Mínima tensión aux.</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Máxima tensión aux.</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Máxima tensión aux.</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Energía producida</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Energía producida</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Energía consumida</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Energía consumida</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Habilitar alarma</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Habilitar alarma</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Nivel activo</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Nivel activo</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Nivel de restauración</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Nivel de restauración</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Demora</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Demora</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Nivel</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Nivel</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Restante</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Restante</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Sensor batería</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Sensor batería</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Sensor batería</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Tipo de sensor</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Tipo de sensor</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Predeterminado</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Predeterminado</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Europeo (0 a 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Europeo (0 a 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>EE.UU (240 a 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>EE.UU (240 a 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Personalizado</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Personalizado</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Personalizado</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Valor del sensor cuando está vacío</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Valor del sensor cuando está vacío</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Tipo de líquido</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Tipo de líquido</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Ratio de butano</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Ratio de butano</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Forma personalizada</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Forma personalizada</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Tiempo de promedio</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Tiempo de promedio</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Valor del sensor</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Valor del sensor</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>No se ha definido una forma personalizada. Puede definir una con hasta diez puntos. Tenga en cuenta que 0 % y 100 % están implícitos.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>No se ha definido una forma personalizada. Puede definir una con hasta diez puntos. Tenga en cuenta que 0 % y 100&#xa0;% están implícitos.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punto %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punto %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Añadir punto</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Añadir punto</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Nivel del sensor</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Nivel del sensor</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Volumen</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>No se permiten valores duplicados del nivel del sensor.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>No se permiten valores duplicados del nivel del sensor.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Los valores de volumen deben ser crecientes.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Los valores de volumen deben ser crecientes.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Desbloqueado (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Desbloqueado (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Desbloqueado (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Desbloqueado (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Desbloqueado (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Desbloqueado (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Bloqueado</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Bloqueado</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Configuración de fase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Configuración de fase</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Posición del interruptor</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Posición del interruptor</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Monofase</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>Bifásica</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>Bifásica</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>Trifásica</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>Trifásica</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Dispositivos</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>CA</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>CA</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Velocidad</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Carga</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Temperatura refrigerante</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Temperatura refrigerante</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Temperatura del escape</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Temperatura del escape</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Temperatura devanado</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Temperatura devanado</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Tensión de la batería de arranque</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Tensión de la batería de arranque</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Número de arranques</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Número de arranques</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Control por BMS</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Selector frontal bloqueado (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Selector frontal bloqueado (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Ningún error (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Ningún error (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>Totales CA</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>Totales CA</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energía L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energía L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Secuencia de fase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Secuencia de fase</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Versión del gestor de datos</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Versión del gestor de datos</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Ninguno</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>El LED parpadeante indica este CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>El LED parpadeante indica este CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Dispositivos bus Smappee</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Dispositivos bus Smappee</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>Cargador FV</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>Cargador FV</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Este ajuste se deshabilita cuando se conecta un Digital Multi Control.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Este ajuste se deshabilita cuando se conecta un Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Este ajuste se deshabilita cuando se conecta un VE.Bus BMS.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Este ajuste se deshabilita cuando se conecta un VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>CA In %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>CA In %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>CC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>CC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Invertido</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Invertido</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Habilitar alarma</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Invertido</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Invertir lógica de alarma</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Invertir lógica de alarma</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Irradiancia</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Irradiancia</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Temperatura de la celda</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Temperatura de la celda</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Temperatura externa (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Temperatura externa (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Temperatura externa</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Temperatura externa</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Temperatura externa (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Temperatura externa (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Velocidad del viento</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Velocidad del viento</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Detección automática</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Detección automática</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Sensor de velocidad del viento</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Sensor de velocidad del viento</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Sensor de temperatura externa</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Sensor de temperatura externa</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Agregado</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Agregado</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Multiplicar</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Multiplicar</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Restablecer contador</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Restablecer contador</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Cortocircuito</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Polaridad inversa</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Sensor de batería bajo</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Sensor de batería bajo</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Humedad</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Humedad</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Presión</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Presión</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Baja</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Compensación</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Compensación</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Escala</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Escala</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Tensión del sensor</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Tensión del sensor</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Potencia FV total</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Potencia FV total</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Página del producto</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Página del producto</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Sensor CA %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Sensor CA %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Hay una nueva versión de MK3 disponible.
+        <translation>Hay una nueva versión de MK3 disponible.
 NOTE: La actualización podría interrumpir temporalmente el sistema.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Actualizar el MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Actualizar el MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Pulsar para actualizar</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Pulsar para actualizar</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Actualizando el MK3, los valores volverán a aparecer una vez terminada la actualización</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Actualizando el MK3, los valores volverán a aparecer una vez terminada la actualización</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Cargando la batería hasta el 100&#xa0;%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Cargando la batería hasta el 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Cargando la batería hasta el 100&#xa0;%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Avanzado</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>En curso</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>En curso</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Pulse para detener</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Pulse para detener</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Pulsar para iniciar</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Pulsar para iniciar</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Cargar la batería hasta el 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Cargar la batería hasta el 100&#xa0;%</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>El sistema retomará el funcionamiento normal, dando prioridad a la energía renovable.
+        <translation>El sistema retomará el funcionamiento normal, dando prioridad a la energía renovable.
 ¿Quiere continuar?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Se usará energía de la red cuando esté disponible y se ignorará la opción "Solar &amp; wind priority" (dar prioridad a la energía solar y eólica). ¿Quiere continuar?</translation>
+        <translation>Se usará energía de la red cuando esté disponible y se ignorará la opción &quot;Solar &amp; wind priority&quot; (dar prioridad a la energía solar y eólica). ¿Quiere continuar?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Se usará la energía de la red para completar una carga completa de la batería una vez.
+        <translation>Se usará la energía de la red para completar una carga completa de la batería una vez.
 Cuando se complete el proceso de carga, el sistema volverá al funcionamiento normal, dando prioridad a la energía solar y eólica.
 ¿Quiere continuar?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Tensión CC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Tensión CC</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>Corriente CC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>Corriente CC</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Avanzado</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Avanzado</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Configuración de la alarma</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Configuración de la alarma</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>Un VE.Bus BMS automáticamente apaga el sistema cuando necesita proteger la batería. Entonces, controlar el sistema desde el Color Control no es posible.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>Un VE.Bus BMS automáticamente apaga el sistema cuando necesita proteger la batería. Entonces, controlar el sistema desde el Color Control no es posible.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Asistente BMS instalado configurado para VE.Bus BMS pero el VE.Bus BMS no ha sido encontrado!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Asistente BMS instalado configurado para VE.Bus BMS pero el VE.Bus BMS no ha sido encontrado!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Advertencia: Activar la ecualización en un sistema ESS con cargadores solares puede hacer que la batería se cargue a una alta tensión con una corriente demasiado elevada.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Advertencia: Activar la ecualización en un sistema ESS con cargadores solares puede hacer que la batería se cargue a una alta tensión con una corriente demasiado elevada.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>El sistema se pondrá automáticamente en flotación una vez finalizada la carga de Ecualización.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>El sistema se pondrá automáticamente en flotación una vez finalizada la carga de Ecualización.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Interrumpir ecualización</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Interrumpir ecualización</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Ecualización</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Ecualización</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Interrumpiendo...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Interrumpiendo...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Iniciando...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Iniciando...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Iniciando...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Pulsar para interrumpir</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Pulsar para interrumpir</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Interrumpir y reiniciar la absorción</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Interrumpir y reiniciar la absorción</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Interrumpir e ir a flotación</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Interrumpir e ir a flotación</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Interrumpir</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Interrumpir</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>No interrumpir</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>No interrumpir</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Volver a detectar el sistema VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Volver a detectar el sistema VE.Bus</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Detectando...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Detectando...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Reiniciar el sistema VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Reiniciar el sistema VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Reiniciando...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Reiniciando...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Pulse para reiniciar</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Pulse para reiniciar</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>Entrada de CA 1 ignorada</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>Entrada de CA 1 ignorada</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>Entrada de CA 2 ignorada</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>Entrada de CA 2 ignorada</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Prueba del relé ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Prueba del relé ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Completado</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Pendiente...</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Completado</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Completado</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Pendiente...</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Pendiente...</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Diagnósticos VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Diagnósticos VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Contador de calidad de la red Fase L%1, dispositivo %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Contador de calidad de la red Fase L%1, dispositivo %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>Error VE.Bus 8 / informe 11</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>Error VE.Bus 8 / informe 11</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Solo alarma</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Solo alarma</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarmas &amp; avisos</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarmas &amp; avisos</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Error BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Error BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Números de serie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Números de serie</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Último error VE.Bus informe 11 #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Último error VE.Bus informe 11 #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Prueba de seguridad BF en curso</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Prueba de seguridad BF en curso</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Prueba de seguridad BF correcta</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Prueba de seguridad BF correcta</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Desajuste CA0 /CA1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Desajuste CA0 /CA1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Error de comunicación</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Error de comunicación</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>Error del relé GND</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>Error del relé GND</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Desajuste de la red</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Desajuste de la red</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Desajuste del periodo de tiempo</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Desajuste del periodo de tiempo</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Desajuste del relé del impulsor de BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Desajuste del relé del impulsor de BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Error: PE2 abierto</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Error: PE2 abierto</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Error: PE2 cerrado</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Error: PE2 cerrado</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Paso que falla: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Paso que falla: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Fase L%1, dispositivo %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Fase L%1, dispositivo %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Error 11 de VE.Bus indica que se requiere como mínimo la versión de firmware 454 para el VE.Bus.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Error 11 de VE.Bus indica que se requiere como mínimo la versión de firmware 454 para el VE.Bus.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>Caprichos del VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>Caprichos del VE.Bus</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energía</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energía</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Potencia</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Potencia</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Tensión</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Tensión</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Corriente</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Corriente</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Ubicación</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Ubicación</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Fase</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Entrada CA activa</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Entrada CA activa</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Tensión de ondulación CC alta</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Tensión de ondulación CC alta</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Alta tensión CC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Alta tensión CC</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Alta corriente CC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Alta corriente CC</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Error sensor temperatura</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Error sensor temperatura</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Error sensor voltaje</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Error sensor voltaje</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Sobrecarga</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Sobrecarga</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>Tensión de ondulación CC</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>Tensión de ondulación CC</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Sensor tensión</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Sensor tensión</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Rotación de fase</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Rotación de fase</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Rotación de fase</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Versión de VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Versión de VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>Dispositivo MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>Dispositivo MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Versión de MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Versión de MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Versión Multi Control</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Versión Multi Control</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Versión VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Versión VE.Bus BMS</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Salvo fallo de la red</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Salvo fallo de la red</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>Entrada CA</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>Entrada CA</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>Entrada CA</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>Entrada CA</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>Entrada CA 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>Entrada CA 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>Entrada CA 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>Entrada CA 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Rol</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>Carga CA</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>Carga CA</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>SALIDA CA</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>SALIDA CA</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>Salida CA</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>Salida CA</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>CA Fase L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>CA Fase L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Sensor CA %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Sensor CA %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Sensores CA</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Sensores CA</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Activo</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Activo</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarma</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Sobrecarga</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Estado de la alarma</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Estado de la alarma</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarmas</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarmas</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Permitir cargar</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Permitir cargar</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Permitir descargar</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Permitir descargar</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Escaneado automático</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Escaneado automático</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Batería</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Batería</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Corriente de la batería</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Corriente de la batería</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Tensión de la batería</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Tensión de la batería</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Corriente de carga</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Corriente de carga</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Cargando</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Cargando</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Borrar error</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Borrar error</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Cerrado</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Cerrado</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Conectado</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Conectado</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Corriente</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Corriente</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Transformadores de corriente</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Transformadores de corriente</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Nombre personalizado</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Nombre personalizado</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Solucionar errores</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Solucionar errores</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Dispositivo</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Dispositivo</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Deshabilitado</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Descargando</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Descargando</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Desconectado</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Desconectado</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Habilitar</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Habilitar</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Habilitado</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Habilitado</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energía</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energía</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Error</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Error</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Error:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Error:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Código de error</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Código de error</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Versión de firmware</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Versión de firmware</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generador</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generador</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Alta temperatura de la batería</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Alta temperatura de la batería</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Alarma de nivel alto</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Alarma de nivel alto</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Alta tensión de la batería de arranque</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Alta tensión de la batería de arranque</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Temperatura alta</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Temperatura alta</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Alarmas por tensión alta</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Alarmas por tensión alta</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Historial</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Historial</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Hora(s)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Hora(s)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>En reposo</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>En reposo</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inactivo</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inactivo</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Inversor / cargador</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>Dirección IP</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>Dirección IP</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Baja temperatura de la batería</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Baja temperatura de la batería</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Alarma de nivel bajo</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Alarma de nivel bajo</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Tensión de batería de arranque baja</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Tensión de batería de arranque baja</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Estado de carga bajo</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Estado de carga bajo</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Temperatura baja</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Temperatura baja</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Alarmas por tensión baja</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Alarmas por tensión baja</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Fabricante</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Fabricante</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Temperatura máxima</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Temperatura máxima</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Tensión máxima</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Tensión máxima</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Temperatura mínima</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Temperatura mínima</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Tensión mínima</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Tensión mínima</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Modo</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Modo</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Nombre del modelo</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Nombre del modelo</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>No</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>No</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Ningún error</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Ningún error</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>No disponible</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>No disponible</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>No conectado</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>No conectado</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Fuera de línea</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Fuera de línea</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>OK</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>OK</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Encendido</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Encendido</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>En línea</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>En línea</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Abierto</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Abierto</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Contraseña</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Contraseña</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Fase</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Pulsar para borrar</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Pulsar para borrar</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Pulsar para reiniciar</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Pulsar para reiniciar</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Pulsar para escanear</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Pulsar para escanear</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>Inversor FV</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>Inversor FV</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>Potencia FV</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>Potencia FV</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Horario silencioso</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Horario silencioso</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relé</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relé</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Reiniciar</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Reiniciar</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Eliminar</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Eliminar</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>En marcha</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>En marcha</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Escaneando %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Escaneando %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Número de serie</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Número de serie</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Ajustes</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Ajustes</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Configuración</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Configuración</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Intensidad señal</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Intensidad señal</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>En espera</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>En espera</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Arrancar cuando la condición esté activa durante</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Arrancar cuando la condición esté activa durante</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Hora de inicio</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Hora de inicio</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Valor de arranque durante horario silencioso</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Valor de arranque durante horario silencioso</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Arrancar cuando aviso activo durante</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Arrancar cuando aviso activo durante</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Estado de carga</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Estado de carga</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Estado</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Estado</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Arranque (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Arranque (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Valor de parada durante horario silencioso</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Valor de parada durante horario silencioso</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Parar cuando la condición esté activa durante</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Parar cuando la condición esté activa durante</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Parado</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Parado</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatura</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Sensor de temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Sensor de temperatura</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Hoy</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Hoy</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Total</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Total</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Rastreador</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Rastreador</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Tipo</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Número de identidad único</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Número de identidad único</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Desconocido</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Desconocido</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Error VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Error VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Tensión</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Tensión</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Instancia VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Instancia VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Al desaparecer aviso parar después de</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Al desaparecer aviso parar después de</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Sí</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Sí</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Ayer</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Ayer</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Rendimiento</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Rendimiento</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Límite de potencia sin inyección a la red</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Límite de potencia sin inyección a la red</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Fecha establecida</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Fecha establecida</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Iniciar ahora</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Iniciar ahora</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Funcionamiento programado</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Funcionamiento programado</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Detener ahora</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Detener ahora</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Tiempo de funcionamiento total</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Tiempo de funcionamiento total</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Hora establecida %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Hora establecida %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>El generador seguirá funcionando si se cumple una condición de arranque automático.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>El generador seguirá funcionando si se cumple una condición de arranque automático.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Modo Inversor / Cargador</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Modo Inversor / Cargador</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Sep</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Sep</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Cerrar</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Cerrar</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Tiempo establecido</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Tiempo establecido</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Ya está en uso</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Ya está en uso</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Error en el intercambio</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Error en el intercambio</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Intercambio completado</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Intercambio completado</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Intercambiando instancias de dispositivo...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Intercambiando instancias de dispositivo...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>La instancia de dispositivo %1 ya está en uso por '%3'. ¿Intercambiar instancias de dispositivo y asignarla a %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>La instancia de dispositivo %1 ya está en uso por &apos;%3&apos;. ¿Intercambiar instancias de dispositivo y asignarla a %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>La instancia de dispositivo %1 ya está en uso por otro dispositivo del mismo tipo. ¿Intercambiar instancias de dispositivo y asignarla a %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>La instancia de dispositivo %1 ya está en uso por otro dispositivo del mismo tipo. ¿Intercambiar instancias de dispositivo y asignarla a %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>No se pueden intercambiar las instancias de dispositivo: se ha agotado el tiempo para realizar la operación.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>No se pueden intercambiar las instancias de dispositivo: se ha agotado el tiempo para realizar la operación.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Las nuevas instancias de dispositivo estarán activas en el reinicio.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Las nuevas instancias de dispositivo estarán activas en el reinicio.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Intercambiar</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Intercambiar</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Error al buscar actualizaciones de firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Error al buscar actualizaciones de firmware</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Descargando e instalado firmware %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Descargando e instalado firmware %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Instalando firmware...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Instalando firmware...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Error durante la instalación del firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Error durante la instalación del firmware</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Ninguna versión nueva disponible</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Ninguna versión nueva disponible</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Ningún firmware encontrado</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Ningún firmware encontrado</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Combustible</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Combustible</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Agua potable</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Agua potable</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Aguas grises</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Aguas grises</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Vivero</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Vivero</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Aceite</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Aceite</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>AGUAS NEGRAS</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>AGUAS NEGRAS</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Gasolina</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Gasolina</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diésel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diésel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>GLP</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>GLP</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>GNL</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>GNL</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Aceite hidráulico</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Aceite hidráulico</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Agua sin tratar</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Agua sin tratar</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Ajuste bloqueado para el nivel de acceso</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Ajuste bloqueado para el nivel de acceso</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Contraseña incorrecta</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Contraseña incorrecta</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Breve</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Breve</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Resumen</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Resumen</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Niveles</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Niveles</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Notificaciones</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Notificaciones</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Ahora</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Ahora</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>hace %1m </translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>hace %1m </translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>hace %1h %2m</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>hace %1h %2m</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Cada día</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Cada día</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Entre semana</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Entre semana</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Fines de semana</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Fines de semana</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Lunes</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Lunes</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Martes</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Martes</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Miércoles</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Miércoles</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Jueves</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Jueves</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Viernes</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Viernes</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Sábado</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Sábado</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Domingo</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Domingo</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 o %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 o %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Programa %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Programa %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Día</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Día</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Sin configurar</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Sin configurar</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Límite SOC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Límite SOC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Autoconsumo superior al límite</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Autoconsumo superior al límite</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">FV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>FV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>FV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>FV y batería</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>FV y batería</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Comprobando...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Comprobando...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Estado alarma</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Estado alarma</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarma</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Borrar historial</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Borrar historial</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Borrando</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Borrando</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Forzar encendido</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Forzar encendido</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Forzar apagado</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Forzar apagado</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Estado relé</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Estado relé</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Reiniciar historial en el propio monitor</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Reiniciar historial en el propio monitor</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Presiona para expulsar</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Presiona para expulsar</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Expulsando, espere por favor</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Expulsando, espere por favor</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Almacenamiento no encontrado</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Almacenamiento no encontrado</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>Sensor de temperatura %1</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>Sensor de temperatura %1</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 sensor de temperatura (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 sensor de temperatura (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Sensor de temperatura (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Sensor de temperatura (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Ninguna acción</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Ninguna acción</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Advertencia: Las temperaturas de activación y desactivación se han fijado en el mismo valor. Esto hará que la condición se ignore.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Advertencia: Las temperaturas de activación y desactivación se han fijado en el mismo valor. Esto hará que la condición se ignore.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Condición %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Condición %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Función deshabilitada</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Función deshabilitada</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Ninguna (deshabilitar)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Ninguna (deshabilitar)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relé 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relé 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relé 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relé 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Advertencia: El relé seleccionado anteriormente no está configurado para temperatura; esta condición se ignorará.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Advertencia: El relé seleccionado anteriormente no está configurado para temperatura; esta condición se ignorará.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Valor de activación</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Valor de activación</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Unidad de volumen</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Unidad de volumen</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Metros cúbicos</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Metros cúbicos</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Litros (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Litros (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Galones (EE. UU.)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Galones (EE. UU.)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Galones (imperiales)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Galones (imperiales)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Tensión min.</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Tensión min.</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Tensión max.</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Tensión max.</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Tensión max.</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Corriente máxima</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Corriente máxima</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Tiempo del proceso de carga</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Tiempo del proceso de carga</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Carga inicial</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Flotación</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">h</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Carga inicial</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Carga inicial</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Absorción</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Absorción</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Flotación</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Flotación</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>h</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>h</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>Se ha(n) producido %1 errore(s)</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>Se ha(n) producido %1 errore(s)</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Carga</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Carga</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2º último error</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2º último error</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3&lt;sup&gt;er&lt;/sup&gt; último error</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3&lt;sup&gt;er&lt;/sup&gt; último error</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4º último error</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4º último error</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Potencia máxima</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Potencia máxima</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Imposible conectarse</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Imposible conectarse</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Desconectado, intentando volver a conectar</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Desconectado, intentando volver a conectar</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Conectando</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Conectando</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Conectando</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Conectado, esperando mensajes del intermediario</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Conectado, esperando mensajes del intermediario</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Conectado, recibiendo mensajes del intermediario</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Conectado, recibiendo mensajes del intermediario</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Conectado, cargando interfaz de usuario</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Conectado, cargando interfaz de usuario</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Versión de protocolo no válida</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Versión de protocolo no válida</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Identificación del cliente rechazada</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Identificación del cliente rechazada</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>El servicio del intermediario no está disponible</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>El servicio del intermediario no está disponible</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Nombre de usuario o contraseña incorrectos</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Nombre de usuario o contraseña incorrectos</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Cliente no autorizado</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Cliente no autorizado</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Error de conexión de transporte</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Error de conexión de transporte</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Error de violación del protocolo</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Error de violación del protocolo</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Error de nivel 5 del protocolo MQTT </translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Error de nivel 5 del protocolo MQTT </translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Alarma de silencio</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Alarma de silencio</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Potencia total</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Potencia total</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>mín</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>mín</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1 d %2 h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1 d %2 h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1 h %2 m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1 h %2 m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1 m %2 s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1 m %2 s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1 m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1 m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1 s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1 s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0 m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0 m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Fallo</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Fallo</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Obteniendo dirección IP</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Obteniendo dirección IP</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectado</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Desconectar</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Desconectar</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Desconectado</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>Cargas CA</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>Cargas CA</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>Cargas CC</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>Cargas CC</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>Estación de carga de vehículos eléctricos</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>Estación de carga de vehículos eléctricos</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Viento</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Viento</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Toma de puerto</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Toma de puerto</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Límite de corriente de la red</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Límite de corriente de la red</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Límite de corriente del generador</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Límite de corriente del generador</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Límite de corriente del pantalán</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Límite de corriente del pantalán</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Parando</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Parando</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Parando</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 de autonomía</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 de autonomía</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 depósito (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 depósito (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>Cargador CA</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>Cargador CA</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Generador</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Generador</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>Cargador CC</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>Cargador CC</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Generador CC</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Generador CC</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>Sistema CC</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>Sistema CC</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Celda de combustible</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Celda de combustible</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Generador de eje</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Generador de eje</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Generador hidraulico</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Generador hidraulico</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Cargador eólico</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Cargador eólico</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Baja</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Baja</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Alto</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Alto</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Mantener baterías cargadas</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Mantener baterías cargadas</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimizado con BatteryLife</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimizado con BatteryLife</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimizado sin batterylife</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimizado sin batterylife</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Control externo</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Cargado</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Cargado</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Esperando al sol</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Esperando al sol</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Esperando a RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Esperando a RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Esperando el inicio.</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Esperando el inicio.</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Error de prueba de tierra</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Error de prueba de tierra</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Error de prueba de entrada de CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Error de prueba de entrada de CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Corriente residual detectada</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Corriente residual detectada</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Subtensión detectada</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Subtensión detectada</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Sobretensión detectada</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Sobretensión detectada</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Sobrecalentamiento detectado</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Sobrecalentamiento detectado</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Límite de carga</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Límite de carga</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Iniciar el proceso de carga</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Iniciar el proceso de carga</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Programado</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Programado</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Programado</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Calentamiento</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Calentamiento</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Enfriamiento</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Enfriamiento</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>TEST FUNC.</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>TEST FUNC.</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Arrancado manualmente</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Arrancado manualmente</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Cargando arranque</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Cargando arranque</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>En marcha (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>En marcha (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>En marcha (Acelerado)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>En marcha (Acelerado)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relé %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relé %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Fallo</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Fallo</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorción</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorción</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Almacenamiento</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Almacenamiento</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Ecualización</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Ecualización</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Control externo</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Baja potencia</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Baja potencia</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Condición de fallo</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Condición de fallo</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>En carga inicial</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>En carga inicial</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>En carga de absorción</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>En carga de absorción</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>En carga de flotación</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>En carga de flotación</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Modo de almacenamiento</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Modo de almacenamiento</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Realizando una carga de ecualización</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Realizando una carga de ecualización</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Pass-thru</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Pass-thru</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Invirtiendo</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Invirtiendo</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Asistiendo</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Asistiendo</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Modo fuente de alimentación</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Modo fuente de alimentación</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Sostener</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Activación</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Activación</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Absorción repetida</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Absorción repetida</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Ecualización automática</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Ecualización automática</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>BatterySafe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>BatterySafe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Detección de carga</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Detección de carga</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Bloqueado</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Bloqueado</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Prueba</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Prueba</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">ESS dinámico</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>ESS dinámico</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>ESS dinámico</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Maestro del grupo</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Maestro del grupo</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Maestro Instancia</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Maestro Instancia</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Maestro Grupo e Instancia</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Maestro Grupo e Instancia</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Autónomo y Maestro Grupo</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Autónomo y Maestro Grupo</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Solo cargador</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Solo cargador</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Solo inversor</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Solo inversor</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Alarma de tensión de batería baja</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Alarma de tensión de batería alta</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Alarma de cortocircuito</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Alarma de cortocircuito</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Deshabilitar punto de acceso</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Deshabilitar punto de acceso</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Entrada CC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Entrada CC</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Para las baterías de litio, no se recomienda una carga inferior al 10 %. Para otros tipos de baterías, consulte en la ficha técnica el nivel mínimo recomendado por el fabricante.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Para las baterías de litio, no se recomienda una carga inferior al 10 %. Para otros tipos de baterías, consulte en la ficha técnica el nivel mínimo recomendado por el fabricante.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>¿Deshabilitar Autostart?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>¿Deshabilitar Autostart?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Inversor / cargador (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Inversor / cargador (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Mostrar uso de la CPU</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Mostrar uso de la CPU</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Salir de la aplicación</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Salir de la aplicación</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Salir</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Salir</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Versión de la aplicación</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Versión de la aplicación</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Temperatura del aceite</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Temperatura del aceite</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Tenga en cuenta que cambiando el ajuste del Límite de descarga del tiempo restante también cambia el ajuste de Estado de carga bajo en el menú del relé.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Tenga en cuenta que cambiando el ajuste del Límite de descarga del tiempo restante también cambia el ajuste de Estado de carga bajo en el menú del relé.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Tiempo de funcionamiento</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Tiempo de funcionamiento</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Ah cargados</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Ah cargados</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Ciclos iniciados</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Ciclos iniciados</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Ciclos completados</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Ciclos completados</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Número de encendidos</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Número de encendidos</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Número de descargas profundas</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Número de descargas profundas</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Historial de ciclos de carga</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Historial de ciclos de carga</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Valor del sensor cuando está lleno</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Valor del sensor cuando está lleno</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Tiempo restante hasta mantenimiento</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Tiempo restante hasta mantenimiento</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Función de arranque automático</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Función de arranque automático</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Asegúrese de que el generador no está conectado a la entrada CA %1 cuando utilice esta opción</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Asegúrese de que el generador no está conectado a la entrada CA %1 cuando utilice esta opción</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>El temporizador de mantenimiento se ha reiniciado</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>El temporizador de mantenimiento se ha reiniciado</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>La detección continua puede interferir con el funcionamiento de la WiFi.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>La detección continua puede interferir con el funcionamiento de la WiFi.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Rangos mínimo y máximo de los indicadores</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Rangos mínimo y máximo de los indicadores</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Reiniciando aplicación...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Reiniciando aplicación...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>No se ha podido cambiar el idioma</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>No se ha podido cambiar el idioma</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Nunca</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Espere mientras se cambia el idioma.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Espere mientras se cambia el idioma.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Vista breve de la unidad</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Vista breve de la unidad</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Sin etiquetas</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Sin etiquetas</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Mostrar volúmenes de los depósitos</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Mostrar volúmenes de los depósitos</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Mostrar porcentajes</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Mostrar porcentajes</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Nota: Si no se puede mostrar la corriente (por ejemplo, cuando se muestra el total para las fuentes CA y CC combinadas) se mostrará la potencia.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Nota: Si no se puede mostrar la corriente (por ejemplo, cuando se muestra el total para las fuentes CA y CC combinadas) se mostrará la potencia.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Límites de corriente de carga</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Límites de corriente de carga</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Lanzamiento oficial</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Lanzamiento oficial</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Lanzamiento beta</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Lanzamiento beta</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Pruebas (interno de Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Pruebas (interno de Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Desarrollar (interno de Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Desarrollar (interno de Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Reiniciando...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Reiniciando...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Activar LEDs de estado</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Activar LEDs de estado</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Calentamiento y enfriamiento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Calentamiento y enfriamiento</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Hora de parada del generador</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Hora de parada del generador</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarma cuando el generador no esté en modo arranque automático</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarma cuando el generador no esté en modo arranque automático</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Saltará una alarma cuando la función de arranque automático permanezca deshabilitada durante más de 10 minutos</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Saltará una alarma cuando la función de arranque automático permanezca deshabilitada durante más de 10 minutos</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Autoconsumo de la batería</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Autoconsumo de la batería</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Todas las cargas del sistema</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Todas las cargas del sistema</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Solo las cargas críticas</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Solo las cargas críticas</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Estado de carga (SoC) mínimo (salvo fallo de red)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Estado de la vida de la batería</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Estado de la vida de la batería</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Puede acceder a Signal K en http://venus.local:3000 y a través de VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Puede acceder a Signal K en http://venus.local:3000 y a través de VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Puede acceder a Node-RED en https://venus.local:1881 y a través de VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Puede acceder a Node-RED en https://venus.local:1881 y a través de VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Mediciones de la batería</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Mediciones de la batería</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Estado del sistema</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Estado del sistema</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Lista de dispositivos</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Lista de dispositivos</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Instancias de dispositivo VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Instancias de dispositivo VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Alarma de temperatura alta</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Alarma de temperatura alta</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Controlado por BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Controlado por BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarmas y errores</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarmas y errores</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Para esta función se necesita la versión de firmware 400 o superior. Póngase en contacto con su instalador para actualizar su Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Para esta función se necesita la versión de firmware 400 o superior. Póngase en contacto con su instalador para actualizar su Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>El cargador no está listo, no se puede iniciar la ecualización</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>El cargador no está listo, no se puede iniciar la ecualización</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>La ecualización no puede activarse durante la carga inicial</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>La ecualización no puede activarse durante la carga inicial</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Corriente máxima</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Corriente máxima</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Potencia máxima</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Potencia máxima</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Corriente mínima</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Corriente mínima</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Ninguno</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">No disponible</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Apagado</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Historial general</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Historial general</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Ajustes</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Desconocido</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Producción hoy</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Producción hoy</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware instalado, reiniciando dispositivo</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware instalado, reiniciando dispositivo</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Control de entrada Touch</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Control de entrada Touch</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Error de prueba de contactos soldados (cortocircuitado)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Error de prueba de contactos soldados (cortocircuitado)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Pasando a trifásica</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Pasando a trifásica</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Pasando a monofásica</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Pasando a monofásica</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Detener la carga</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Detener la carga</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Reservado</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Reservado</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Modo inversor</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Modo inversor</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Out L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Out L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Entrada</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Entrada</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Passthrough (paso libre)</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Passthrough (paso libre)</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>La página se volverá a cargar automáticamente en diez segundos para cargar la última versión.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>La página se volverá a cargar automáticamente en diez segundos para cargar la última versión.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Inversor (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Inversor (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Inversores/cargadores</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Inversores/cargadores</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>No se ha encontrado ningún contador
+        <translation>No se ha encontrado ningún contador
 
 Tenga en cuenta que este menú solo muestra contadores de Carlo Gavazzi conectados por RS485. Para cualquier otro contador, incluidos los de Carlo Gavazzi conectados por Ethernet, véase el menú de dispositivos Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Autorregulado</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Autorregulado</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Si está habilitado, el mínimo y el máximo de los indicadores y los gráficos se ajustan automáticamente en función de valores anteriores.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Si está habilitado, el mínimo y el máximo de los indicadores y los gráficos se ajustan automáticamente en función de valores anteriores.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Restablecer todos los valores del rango a cero</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Restablecer todos los valores del rango a cero</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Restablecer valores del rango</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Restablecer valores del rango</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>¿Está seguro de que quiere volver a poner todos los valores a cero?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>¿Está seguro de que quiere volver a poner todos los valores a cero?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Corriente máxima: CA in 1 conectada</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Corriente máxima: CA in 1 conectada</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Corriente máxima: CA in 2 conectada</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Corriente máxima: CA in 2 conectada</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Corriente máxima: sin entradas CA</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Corriente máxima: sin entradas CA</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>Salida CC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>Salida CC</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solar</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solar</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>RPM motor</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>RPM motor</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Temperatura motor</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Temperatura motor</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Temperatura controlador</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Temperatura controlador</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Ciclo activo</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Ciclo activo</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Ciclo %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Ciclo %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>Desconectar CC</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>Desconectar CC</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Desconectado</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Desconectado</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Cambio de función</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Cambio de función</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Actualización de firmware</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Actualización de firmware</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Restablecimiento de software</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Restablecimiento de software</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Incompleto</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Incompleto</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Tiempo transcurrido</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Tiempo transcurrido</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Cargar / mantener (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Cargar / mantener (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Batería (V&lt;sub&gt;inicio&lt;/sub&gt;/V&lt;sub&gt;final&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Batería (V&lt;sub&gt;inicio&lt;/sub&gt;/V&lt;sub&gt;final&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Tensión salida CA baja</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Tensión salida CA baja</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Alta tensión CA de salida</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Alta tensión CA de salida</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Rendimiento total</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Rendimiento total</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Rendimiento del sistema</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Rendimiento del sistema</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Historial diario</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Historial diario</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Ninguna alarma para configurar</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Ninguna alarma para configurar</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Voltage FV máximo</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Voltage FV máximo</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Tensión máxima de la batería</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Tensión máxima de la batería</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Tensión mínima de la batería</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Tensión mínima de la batería</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Error de la bancada de baterías</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Error de la bancada de baterías</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Tensión de la batería no permitida</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Tensión de la batería no permitida</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Número incorrecto de baterías</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Número incorrecto de baterías</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Configuración de la batería no válida</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Configuración de la batería no válida</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Estado del equilibrador</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Estado del equilibrador</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Equilibrado</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Equilibrado</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Desequilibrio</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Desequilibrio</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Utilice esta opción en sistemas que no efectúen recorte de picos.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Utilice esta opción en sistemas que no efectúen recorte de picos.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Utilice esta opción para recorte de picos.</translation>
+        <translation>Utilice esta opción para recorte de picos.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>El umbral de recorte de picos se fija usando el ajuste del límite de corriente de entrada CA. Véase la documentación para más información.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>El umbral de recorte de picos se fija usando el ajuste del límite de corriente de entrada CA. Véase la documentación para más información.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Los umbrales de recorte de picos para importar y exportar se pueden modificar en esta pantalla. Véase la documentación para más información.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Los umbrales de recorte de picos para importar y exportar se pueden modificar en esta pantalla. Véase la documentación para más información.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Limitar corriente de importación CA del sistema</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Limitar corriente de importación CA del sistema</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Para usar esta función, el contador de red debe estar en Contador externo y debe instalarse un asistente ESS actualizado.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Para usar esta función, el contador de red debe estar en Contador externo y debe instalarse un asistente ESS actualizado.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Máxima corriente de importación del sistema (por fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Máxima corriente de importación del sistema (por fase)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>El contador de red debe estar en contador externo para usar esta función.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>El contador de red debe estar en contador externo para usar esta función.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Máxima corriente de exportación del sistema (por fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Máxima corriente de exportación del sistema (por fase)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Conectado por cable</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Conectado por cable</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Breve</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Carga del sistema elevada, cerrando el panel lateral para reducir la carga CPU</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Carga del sistema elevada, cerrando el panel lateral para reducir la carga CPU</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Límite de corriente de entrada</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Límite de corriente de entrada</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Cortocircuito</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Cortocircuito</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Comprando</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Comprando</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Vendiendo</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Vendiendo</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Estado de carga objetivo</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Estado de carga objetivo</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>CA out %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>CA out %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Rastreadores</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Rastreadores</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Dispositivos RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Dispositivos RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Pausar las animaciones de electrones</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Pausar las animaciones de electrones</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Capacidad total</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Capacidad total</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Número de BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Número de BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Limitar corriente de exportación CA del sistema</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Limitar corriente de exportación CA del sistema</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Dispositivos Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Dispositivos Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Añadir dispositivo</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Añadir dispositivo</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Detectar dispositivos</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Detectar dispositivos</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Dispositivos guardados</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Dispositivos guardados</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Dispositivos detectados</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Dispositivos detectados</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Añadir dispositivo Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Añadir dispositivo Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protocolo</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protocolo</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Puerto</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Puerto</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Unidad</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Unidad</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>No se ha guardado ningún dispositivo Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>No se ha guardado ningún dispositivo Modbus</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Dispositivo %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Dispositivo %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>¿Eliminar dispositivo Modbus?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>¿Eliminar dispositivo Modbus?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>No se ha encontrado ningún dispositivo Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>No se ha encontrado ningún dispositivo Modbus</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Batería %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Batería %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>Corriente CA</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>Corriente CA</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Arranque/parada del generador deshabilitado</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Arranque/parada del generador deshabilitado</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>La función de arranque a distancia está deshabilitada en el generador. Ahora, el GX no podrá arrancar ni parar el generador. Active esta función en el panel de control del generador.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>La función de arranque a distancia está deshabilitada en el generador. Ahora, el GX no podrá arrancar ni parar el generador. Active esta función en el panel de control del generador.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Función de arranque automático</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Función de arranque automático</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Tiempo de funcionamiento actual</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Estado del control</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Estado del control</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Estado del generador</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Estado del generador</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Modo de arranque a distancia</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Modo de arranque a distancia</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Presión del aceite</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Presión del aceite</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Niveles de carga programados</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Niveles de carga programados</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Activo (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Activo (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Parada manual</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Parada manual</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Circuito abierto</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Circuito abierto</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (no disponible)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (no disponible)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Entrada Touch on</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Entrada Touch on</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Entrada Touch off</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Entrada Touch off</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Entrada Touch deshabilitada</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Entrada Touch deshabilitada</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Confirmar alertas</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Confirmar alertas</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Código de error de control</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Código de error de control</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Utilice este menú para definir los datos de la batería que se muestran al hacer clic en el icono Batería de la página Vista general. Esto mismo también puede verse en el Portal VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Utilice este menú para definir los datos de la batería que se muestran al hacer clic en el icono Batería de la página Vista general. Esto mismo también puede verse en el Portal VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Tensión del sistema [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Tensión del sistema [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Información sobre la conexión</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Información sobre la conexión</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Por favor, seleccione...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Por favor, seleccione...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Asegurado</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Asegurado</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Protegido con contraseña y la comunicación de red está encriptada</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Protegido con contraseña y la comunicación de red está encriptada</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Débil</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Débil</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Protegido con contraseña, pero comunicación de red no está encriptada</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Protegido con contraseña, pero comunicación de red no está encriptada</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>No asegurado</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>No asegurado</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Sin contraseña y la comunicación de red no está encriptada</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Sin contraseña y la comunicación de red no está encriptada</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">La contraseña ha tener al menos ocho caracteres</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Introducir contraseña</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>La contraseña ha tener al menos ocho caracteres</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>La contraseña ha tener al menos ocho caracteres</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>¿Seleccionar el perfil «Seguro»?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>¿Seleccionar el perfil «Seguro»?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>¿Seleccionar el perfil « Débil»?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>¿Seleccionar el perfil « Débil»?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>¿Seleccionar el perfil « No seguro»?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>¿Seleccionar el perfil « No seguro»?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>• Los servicios de la red local están protegidos con contraseña
+        <translation>• Los servicios de la red local están protegidos con contraseña
 - La comunicación de red está encriptada
 - Hay habilitada una conexión segura con VRM
 - No se pueden habilitar configuraciones no seguras</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• Los servicios de la red local están protegidos por contraseña
+        <translation>• Los servicios de la red local están protegidos por contraseña
 • El acceso no cifrado a los sitios web locales también está habilitado (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• Los servicios de la red local no necesitan contraseña
+        <translation>• Los servicios de la red local no necesitan contraseña
 • El acceso no cifrado a los sitios web locales también está habilitado (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Contraseña raíz</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Contraseña raíz</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Cerrar sesión</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Cerrar sesión</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Cerrar sesión ahora</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Cerrar sesión ahora</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>¿Cerrar sesión?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>¿Cerrar sesión?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Esto desconectará todas las conexiones de red locales.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Esto desconectará todas las conexiones de red locales.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Cerrar sesión</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Cerrar sesión</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Sólo lectura</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Sólo lectura</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Completo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Completo</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>¿Está seguro?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>¿Está seguro?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Si cambia esta configuración a Sólo lectura u Off, usted quedará bloqueado.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Si cambia esta configuración a Sólo lectura u Off, usted quedará bloqueado.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Acceso MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Acceso MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' no es un número.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; no es un número.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Confirmar</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Confirmar</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Utilice un número con %1 dígitos o menos.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Utilice un número con %1 dígitos o menos.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' nó es una dirección IP válida.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; nó es una dirección IP válida.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' nó es un número de puerto válido. Utilice un número entre 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; nó es un número de puerto válido. Utilice un número entre 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 no es un número válido. Utilice un número entre 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 no es un número válido. Utilice un número entre 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Tiempo de funcionamiento actual</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Tiempo de funcionamiento actual</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Códigos de error del generador</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Códigos de error del generador</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Temperatura del disipador de calor</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Temperatura del disipador de calor</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Tensión de carga</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>La tensión de carga está controlada actualmente por el BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>La tensión de carga está controlada actualmente por el BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Límite de corriente de carga</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Límite de corriente de carga</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>Controlado por BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>Controlado por BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>El control por BMS se habilita automáticamente cuando hay un BMS. Resetear si la configuración del sistema ha cambiado o si no hay BMS disponible.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>El control por BMS se habilita automáticamente cuando hay un BMS. Resetear si la configuración del sistema ha cambiado o si no hay BMS disponible.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Temporizador de mantenimiento desactivado.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Temporizador de mantenimiento desactivado.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Portal VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Portal VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (acceso VPN remoto)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (acceso VPN remoto)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>Estado de carga %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>Estado de carga %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Debe configurarse un perfil de seguridad antes de habilitar los servicios de red, véase Ajustes - General</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Debe configurarse un perfil de seguridad antes de habilitar los servicios de red, véase Ajustes - General</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' fue sustituido por '%2' ya que contenía caracteres no válidos.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; fue sustituido por &apos;%2&apos; ya que contenía caracteres no válidos.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Inicializando...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Inicializando...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Iniciando Backend...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Iniciando Backend...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend detenido.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend detenido.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Fallo de conexión.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Fallo de conexión.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Este dispositivo GX está desconectado de Tailscale.
+        <translation>Este dispositivo GX está desconectado de Tailscale.
 
 Espere a su conexión a Internet o compruébela.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Esperando una respuesta de Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Esperando una respuesta de Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Conecte este dispositivo GX a su cuenta Tailscale abriendo este enlace:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Conecte este dispositivo GX a su cuenta Tailscale abriendo este enlace:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Espere a su conexión a Internet o compruébela.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Espere a su conexión a Internet o compruébela.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Estado desconocido: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Estado desconocido: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Error: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Error: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Desactive Tailscale para editar estos ajustes.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Desactive Tailscale para editar estos ajustes.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Active Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Active Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Nombre de la máquina</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Nombre de la máquina</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Salir de la cuenta de Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Salir de la cuenta de Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Acceso a la red local</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Acceso a la red local</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Acceso a la red local ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Acceso a la red local ethernet</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Acceda a la red WiFi local</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Acceda a la red WiFi local</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Red(es) personalizada(s)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Red(es) personalizada(s)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Ejemplo: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Ejemplo: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Explicación:
+        <translation>Explicación:
 
 Esta característica, llamada rutas de subred por Tailscale, permite el acceso remoto a otros dispositivos en la(s) red(es) local(es).
 
@@ -7384,2989 +8026,3057 @@ El campo de redes personalizadas acepta una lista separada por comas de subredes
 Después de añadir/habilitar una nueva red, deberá aprobarla en la consola de administración de Tailscale una vez.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Argumentos "tailscale up" personalizados</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Argumentos &quot;tailscale up&quot; personalizados</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>URL de servidor personalizada (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>URL de servidor personalizada (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>El controlador del generador necesita un relé de ayuda, pero no se ha configurado. Configure el Relé 1 en Ajustes → Relé en "Relé de ayuda del generador conectado".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>El controlador del generador necesita un relé de ayuda, pero no se ha configurado. Configure el Relé 1 en Ajustes → Relé en &quot;Relé de ayuda del generador conectado&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarmas por tensión de la batería arranque alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarmas por tensión de la batería arranque alta</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Omitir el calentamiento del generador</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Omitir el calentamiento del generador</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Activo, pero sin servicios (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Activo, pero sin servicios (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>La contraseña raíz ha cambiado a %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>La contraseña raíz ha cambiado a %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Relé de ayuda del generador conectado</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Relé de ayuda del generador conectado</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Posición de las cargas CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Posición de las cargas CA</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Entrada y salida de CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Entrada y salida de CA</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Use esta opción cuando haya cargas CA en la entrada del inversor/cargador. Use esta opción si no está seguro.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Use esta opción cuando haya cargas CA en la entrada del inversor/cargador. Use esta opción si no está seguro.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Salida de CA solamente</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Salida de CA solamente</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Use esta opción cunado el sistema use un contador de red pero todas las cargas CA estén en la salida del inversor/cargador.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Use esta opción cunado el sistema use un contador de red pero todas las cargas CA estén en la salida del inversor/cargador.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Mensual</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Mensual</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>Cargador de EV</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>Cargador de EV</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Bomba de calor</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Bomba de calor</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Cargas esenciales</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Cargas esenciales</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Arranque y parada del generador según las condiciones de arranque automático configuradas.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Arranque y parada del generador según las condiciones de arranque automático configuradas.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Ajustes del generador CC</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Ajustes del generador CC</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Temperatura del alternador</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Temperatura del alternador</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Temperatura del motor</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Temperatura del motor</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Tiempo de funcionamiento total</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Tiempo de funcionamiento total</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Perfil de seguridad de la red</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Perfil de seguridad de la red</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Últimos %1 días</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Últimos %1 días</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>El generador se detendrá en %1 a menos que se hayan habilitado condiciones de arranque automático que lo mantengan en funcionamiento.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>El generador se detendrá en %1 a menos que se hayan habilitado condiciones de arranque automático que lo mantengan en funcionamiento.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>El generador funcionará hasta que se detenga manualmente, a menos que se hayan habilitado condiciones de arranque automático que lo mantengan en funcionamiento.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>El generador funcionará hasta que se detenga manualmente, a menos que se hayan habilitado condiciones de arranque automático que lo mantengan en funcionamiento.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Interfaz de usuario clásica</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Interfaz de usuario clásica</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Interfaz de usuario nueva</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Interfaz de usuario nueva</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Se ha cambiado el idioma correctamente</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Limitación de potencia</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Se ha cambiado el idioma correctamente</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Para dispositivos Multi-RS y HS19, los ajustes de ESS están disponibles en la página de producto del sistema RS.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Para dispositivos Multi-RS y HS19, los ajustes de ESS están disponibles en la página de producto del sistema RS.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Arranque/parada del generador</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Arranque/parada del generador</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>No se puede cambiar la versión de firmware si no se selecciona "Perfil de seguridad de la red " en "Ajustes / General".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>No se puede cambiar la versión de firmware si no se selecciona &quot;Perfil de seguridad de la red &quot; en &quot;Ajustes / General&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Duración</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Duración</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Alarmas del sistema</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Alarmas del sistema</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Sin alarmas del sistema</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Sin alarmas del sistema</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Atrás</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Atrás</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Novedades</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Novedades</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>saltar</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>saltar</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Bienvenido</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Bienvenido</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Estamos encantados de presentarle una interfaz totalmente rediseñada que mejora la usabilidad y la estética de su GX.
+        <translation>Estamos encantados de presentarle una interfaz totalmente rediseñada que mejora la usabilidad y la estética de su GX.
 
  Con una navegación optimizada y una imagen renovada, todo lo que le gusta es ahora más accesible y más atractivo visualmente.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Modo oscuro - claro</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Modo oscuro - claro</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Se necesitan distintas configuraciones de pantalla para distintos entornos. Los modos oscuro y claro le aseguran la mejor visualización esté donde esté.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Se necesitan distintas configuraciones de pantalla para distintos entornos. Los modos oscuro y claro le aseguran la mejor visualización esté donde esté.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Toda la información esencial que necesita presentada de forma limpia y sencilla. La pieza central es un widget personalizable con anillos, que le permite acceder rápidamente a los detalles de su sistema de un solo vistazo.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Toda la información esencial que necesita presentada de forma limpia y sencilla. La pieza central es un widget personalizable con anillos, que le permite acceder rápidamente a los detalles de su sistema de un solo vistazo.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Obtenga un mejor control con nuestro panel de Resumen actualizado, que muestra información del sistema en tiempo real — todo en el mismo sitio para una monitorización más sencilla.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Obtenga un mejor control con nuestro panel de Resumen actualizado, que muestra información del sistema en tiempo real — todo en el mismo sitio para una monitorización más sencilla.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Controla</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Controla</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Todos los controles que se usan a diario están ahora juntos en el nuevo Panel de controles. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Todos los controles que se usan a diario están ahora juntos en el nuevo Panel de controles. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Vatios y amperios</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Vatios y amperios</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Ahora puede cambiar entre vatios y amperios. Elija la unidad que mejor se adapte a sus preferencias.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Ahora puede cambiar entre vatios y amperios. Elija la unidad que mejor se adapte a sus preferencias.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Más información</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Más información</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>En el siguiente enlace puede obtener más información acerca de la interfaz de usuario renovada.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>En el siguiente enlace puede obtener más información acerca de la interfaz de usuario renovada.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Escanee el código QR para obtener más información acerca de la interfaz de usuario renovada.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Escanee el código QR para obtener más información acerca de la interfaz de usuario renovada.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Hecho</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Hecho</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Siguiente</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Siguiente</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Error: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Error: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Error activo</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Error activo</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Tiempo de ejecución total (horas)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Tiempo de ejecución total (horas)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation></translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation></translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation></translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation></translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation></translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation></translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Restablecimiento de los valores de fábrica de Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Restablecimiento de los valores de fábrica de Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>¿Está seguro de que quiere restablecer los valores de fábrica de Node-RED? Se borrarán todos sus flujos.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>¿Está seguro de que quiere restablecer los valores de fábrica de Node-RED? Se borrarán todos sus flujos.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation></translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation></translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation></translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Valor de desactivación</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Valor de desactivación</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation></translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation></translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation></translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation></translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation></translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Breve</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Resumen</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation></translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation></translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation></translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>La funcion de arranque/parada de generador no esta habilitada, vaya a los ajustes de relé y seleccione la funcion "Arranque/parada generador"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Hora estándar Marruecos</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Hora estándar de África Central Occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Hora estándar de Sudáfrica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Hora estándar de Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Hora estándar de Egipto</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Hora estándar de África Oriental</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Hora estándar de Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Hora estándar de Sudamérica E.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Hora estándar de Groenlandia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Hora estándar de Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Hora estándar de Terranova y Labrador</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Hora estándar del este Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Hora estándar del Atlántico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Hora estándar de Brasil central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Hora estándar del Pacífico Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Hora estándar de Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Hora estándar occidental de Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Hora estándar de Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Hora estándar oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Hora estándar este de EE. UU.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Hora estándar de Canadá Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Hora estándar de América central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Hora estándar de México</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Hora estándar central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Hora estándar de México 2</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Hora estándar de la montaña</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Hora estándar de la montaña EE.UU</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Hora estándar del Pacífico (México)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Hora estándar de Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hora de Hawái-Aleutiano</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Hora estándar de Nueva Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Hora estándar Pacífico occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Hora estándar del Sudeste Asiático</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Hora estándar de Asia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Hora estándar Asia occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Hora estándar de África Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Hora estándar del Pacífico Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Hora estándar occidental de Sudamérica</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Hora estándar de Europa Occidental</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Hora estándar de Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Hora estándar Magadán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Hora estándar de Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Hora estándar de Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Hora estándar de Tokio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Hora estándar de Corea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Hora estándar de Singapur</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Hora estándar de Ulán Bator</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Hora estándar de Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Hora estándar este, Asia Norte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Hora estándar de China</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Hora estándar del Sudeste Asiático</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Hora estándar de Asia Norte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Hora estándar de Asia Central Norte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Hora estándar de Asia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Hora estándar de Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Hora estándar de Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Hora estándar de Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Hora estándar de India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Hora estándar Asia occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Hora estándar de Pakistán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Hora estándar de Ekaterimburgo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Hora estándar de Georgia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Hora estándar del Cáucaso</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Hora estándar de Azerbaiyán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Hora estándar árabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Hora estándar de Afganistán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Hora estándar de Irán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Hora estándar árabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Hora estándar árabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Hora estándar de Siria</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Hora estándar de Oriente medio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Hora estándar de Jordania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Hora estándar de Israel</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Hora estándar de Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Hora estándar de las Azores</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Hora estándar de Cabo Verde</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Hora estándar de Tasmania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Hora estándar de Australia Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Hora estándar de Australia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Occidental</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Hora estándar del Atlántico Medio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Línea de fecha internacional</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Hora estándar GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Hora estándar de Europa central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Hora estándar de Europa central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Hora estándar romance</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Hora estándar de Europa Occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Hora estándar de Europa Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Hora estándar FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Hora estándar GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Hora estándar de Bielorrusia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Hora estándar de Rusia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Hora estándar de Turquía</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Hora estándar de Mauricio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Hora estándar de Isla de Navidad</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Hora estándar de Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Hora estándar de las Islas Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Hora estándar de Nueva Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Hora estándar Pacífico occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Hora estándar de Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hora estándar de Hawái</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Hora estándar de Isla de Pascua</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>La funcion de arranque/parada de generador no esta habilitada, vaya a los ajustes de relé y seleccione la funcion &quot;Arranque/parada generador&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconocido</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Rendimiento solar</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Entrada CC</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">Cargas CA</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">Cargas CC</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Resumen</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Estado</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">FV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Rendimiento total</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Rendimiento del sistema</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Solo alarma</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarmas &amp; avisos</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Advertencia</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Ningún error</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Ningún error</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Error desconocido: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Error desconocido: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Ningún error</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Ningún error</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Error inicialización batería</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Error inicialización batería</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Ninguna batería conectada</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Ninguna batería conectada</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Batería desconocida</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Batería desconocida</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Diferentes tipos de batería</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Diferentes tipos de batería</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Número baterías incorrecto</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Número baterías incorrecto</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt no encontrado</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt no encontrado</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Error de medición de la batería</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Error de medición de la batería</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Error de cálculo interno</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Error de cálculo interno</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Número baterías en serie incorrecto</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Número baterías en serie incorrecto</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Error hardware</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Error hardware</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Error del perro guardián (watchdog)</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Error del perro guardián (watchdog)</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Sobrevoltaje</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Sobrevoltaje</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Subtensión</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Subtensión</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Exceso temperatura</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Exceso temperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Baja temperatura</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Baja temperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>En espera por baja carga</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>En espera por baja carga</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Error ADC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Error ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Error de comunicación con la batería</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Error de comunicación con la batería</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Error de pre-carga</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Error de pre-carga</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Error del contactor de seguridad</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Error del contactor de seguridad</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Error actualización de batería</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Error actualización de batería</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Error de cable BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Error de cable BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Fallo de la tensión de referencia</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Fallo de la tensión de referencia</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Tensión del sistema incorrecta</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Tensión del sistema incorrecta</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Tiempo de pre-carga agotado</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Tiempo de pre-carga agotado</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Fallo ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Fallo ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Datos de calibración perdidos</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Datos de calibración perdidos</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Ajustes no válidos</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Ajustes no válidos</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Enclavamiento</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Enclavamiento</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Parada de emergencia</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Parada de emergencia</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Tiempo de espera de comunicación agotado</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Tiempo de espera de comunicación agotado</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Bloqueo de seguridad</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Bloqueo de seguridad</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Exceso de temperatura en el terminal</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Exceso de temperatura en el terminal</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Ningún error</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Temperatura batería alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Tensión batería alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Error cableado Tsense de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Falta Tsense de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Error cableado Vsense de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Falta Vsense bateria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Pérdidas altas cable batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Tensión batería baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Tensión de ondulación CC alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Estado de carga baja de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Problema con la tensión de punto medio de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Temperatura de la batería demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Alta temperatura del cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Exceso de corriente del cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Corriente negativa del cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Tiempo de carga inicial agotado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problema del sensor de corriente del cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Error cableado Tsensor interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Falta Tsensor interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Ventilador del cargador no detectado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Sobrecorriente ventilador del cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Sobretemperatura terminal cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Cortocircuito del cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Problema con la etapa de potencia del cargador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Protección de sobrecarga</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Alta tensión de entrada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Excesiva corriente de entrada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Excesiva potencia de entrada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Fallo polaridad entrada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Tensión de entrada ausente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Desconexión entrada (sin reintentos)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Desconexión de la entrada (reintentos)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Fallo interno de entrada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Fallo de aislamiento FV</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Fallo de masa detectado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Sobrecarga del inversor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Temp. del inversor demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Corriente pico del inversor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Nivel CC interno del inversor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Nivel incorrecto CA de salida del inversor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Fallo de la etapa de potencia del inversor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Inversor conectado a CA</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Fallo de prueba del relé ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Fallo de prueba del relé ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Dispositivo desaparecido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Dispositivo incompatible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Conexión BMS perdida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Red mal configurada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Rotación de fase</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Varias entradas de CA</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Sobrecarga de fase</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Error escritura memoria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Temperatura CPU muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Comunicación perdida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Datos de calibración perdidos</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Firmware incompatible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Hardware incompatible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Ajustes no válidos</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Fallo de voltage de referencia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Fallo tester</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Historial no válido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Contadores de kWh no válidos</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Error de tensión CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Error del sensor de ID</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Error de alimentación de 3,3 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Error de alimentación de 5 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Error de alimentación 12 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Error de alimentación de 15 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Desconexión de la entrada FV</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Poner el interruptor en una posición desbloqueada para modificar los ajustes.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Usar fuente de datos D-Bus: conectar a la dirección D-Bus indicada.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>Dirección</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Usar fuente de datos D-Bus: conectar a la dirección D-Bus predeterminada.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Usar fuente de datos MQTT: conectar a la dirección del broker MQTT indicada.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>Dirección</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>Identificación del portal del dispositivo de la fuente de datos MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>ID portal</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Fragmento del hospedador web VRM MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>fragmento</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Nombre de usuario de la fuente de datos MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Usuario</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Contraseña de la fuente de datos MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>Pass</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Token de la fuente de datos MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Token</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Habilitar contador de FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Saltar pantalla de presentación</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Usar fuente de datos ficticia para pruebas.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Dispositivo apagado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>MK2 antiguo/nuevo mezclados</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Error dispositivos esperados</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>No se ha detectado ningún otro dispositivo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Sobrevoltage en salida CA</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Error programación DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS sin asistente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Ha fallado la prueba del relé de tierra</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Error de sincronización temporal del sistema</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Fallo de prueba del relé de red</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Desajuste de la configuración con 2º mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Error transmisión dispositivo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Esperando configuración o falta la mochila</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Falta la fase maestra</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Ha ocurrido sobrevoltaje</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Esclavo sin entrada CA!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>El dispositivo no puede ser esclavo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Se ha iniciado la protección del sistema</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Incompatibilidad de firmware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Error interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>La prueba fallida del relé impide la conexión</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Error VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Error desconocido:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Error interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Ningún error</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Temperatura batería alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Tensión batería alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Tensión batería baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>La tensión de la batería ha superado el máximo configurado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Alta temperatura del alternador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Altas RPM del alternador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Alta temperatura del FET del control de campo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Falta un sensor necesario</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Baja tensión del alternador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Compensación alta tensión del alternador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>La tensión del alternador ha superado el máximo configurado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Alta tensión del alternador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Batería desconectada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Desconexión por alta tensión de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Instancia de la batería fuera de rango</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Demasiados BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Batería a punto de desconectarse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Demasiados dispositivos para hacer un seguimiento</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Desconexión por baja tensión de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Desconexión por alta corriente de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Desconexión por alta temperatura de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Desconexión por baja temperatura de la batería</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Conexión BMS perdida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC (Permitir la carga) deshabilitado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>El convertidor CC/CC no está listo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>Tensión primaria alta CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>Tensión primaria baja CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>Tensión secundaria alta CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>Tensión secundaria baja CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>Temperatura alta CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>Configuración errónea CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Sensor de temperatura de la batería defectuoso</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Error desconocido:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Error desconocido:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Ningún error</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Temperatura batería alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Tensión batería alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Error cableado Tsense de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Falta Tsense de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Error cableado Vsense de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Falta Vsense bateria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Pérdidas altas cable batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Tensión batería baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Tensión de ondulación CC alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Estado de carga baja de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Problema con la tensión de punto medio de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Temperatura de la batería demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Alta temperatura del cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Exceso de corriente del cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Corriente negativa del cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Tiempo de carga inicial agotado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Problema del sensor de corriente del cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Error cableado Tsensor interno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Falta Tsensor interno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Ventilador del cargador no detectado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Sobrecorriente ventilador del cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Sobretemperatura terminal cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Cortocircuito del cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Problema con la etapa de potencia del cargador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Protección de sobrecarga</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Alta tensión de entrada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Excesiva corriente de entrada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Excesiva potencia de entrada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Fallo polaridad entrada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Tensión de entrada ausente</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Desconexión entrada (sin reintentos)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Desconexión de la entrada (reintentos)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Fallo interno de entrada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Fallo de aislamiento FV</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Fallo de masa detectado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Sobrecarga del inversor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Temp. del inversor demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Corriente pico del inversor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Nivel CC interno del inversor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Nivel incorrecto CA de salida del inversor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Fallo de la etapa de potencia del inversor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Inversor conectado a CA</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Fallo de prueba del relé ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Fallo de prueba del relé ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Dispositivo desaparecido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Dispositivo incompatible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Conexión BMS perdida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Red mal configurada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Rotación de fase</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Varias entradas de CA</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Sobrecarga de fase</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Error escritura memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Temperatura CPU muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Comunicación perdida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Datos de calibración perdidos</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Firmware incompatible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Hardware incompatible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Ajustes no válidos</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Fallo de voltage de referencia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Fallo tester</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Historial no válido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Contadores de kWh no válidos</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Error de tensión CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Error del sensor de ID</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>Error de alimentación de 3,3 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>Error de alimentación de 5 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>Error de alimentación 12&#xa0;V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>Error de alimentación de 15 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Desconexión de la entrada FV</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Error desconocido:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Error desconocido:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Error desconocido:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Error desconocido:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Ningún error</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>Voltage CA L1 muy bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>Voltage CA muy bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Voltage CA L1 muy alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Voltage CA muy bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Frecuencia CA L1 muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Frecuencia CA muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Frecuencia CA L1 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Frecuencia CA muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>Corriente CA L1 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>Corriente CA muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Potencia CA L1 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>Potencia CA muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Parada de emergencia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Corriente servo muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Presión de aceite muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Presión aceite muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Temperatura motor muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Temperature motor muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Temperatura devanado muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Temperatura devanado muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Temperatura escape muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Temperatura escape muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Temperatura electrónica baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Temperatura electrónica alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Tensión de arranque muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Corriente starter muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Tensión de calentador muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Corriente calentador muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Tensión de ayuda al arranque en frío demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Corriente de ayuda al arranque en frío demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Tensión del imán de retención de combustible muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Corriente del imán de retención de combustible muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Tensión de la bobina de retención de solenoide de parada muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Corriente de bobina de retención de solenoide de parada muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Tensión de la bobina tiradora de solenoide de parada muy baja </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Corriente de bobina tiradora de solenoide de parada muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Tensión del ventilador/bomba de agua demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Corriente del ventilador/bomba de agua demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Tensión baja del sensor de corriente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Corriente alta del sensor de corriente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Tensión de salida de refuerzo demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Corriente salida boost muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Tensión de alimentación del bus demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Corriente de alimentación del bus demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Tensión batería de arranque muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Voltaje bateria arranque muy alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Rotación muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Rotación muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Parad inesperada/problema con el suministro de combustible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Tensión del contactor de potencia demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Corriente del contactor de potencia muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>Tensión CA L2 muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Voltaje CA L2 muy alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>Frecuencia CA L2 muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Frecuencia CA L2 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>Corriente CA L2 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>Potencia CA L2 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Tensión CA L3 muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>Voltaje CA L3 muy alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Frecuencia CA L3 muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Frecuencia CA L3 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>Corriente CA L3 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>Potencia CA L3 muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Tensión del inversor de salida demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Corriente del inversor de salida demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Tensión de salida universal (1 A) demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Corriente de salida universal (1 A) demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Tensión de salida universal (5 A) demasiado baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Corriente de salida universal (5 A) demasiado alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Tensión CC AGT 1 baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Tensión CC AGT 1 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>Corriente CC AGT 1 baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>Corriente CC AGT 1 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Tensión CC AGT 2 baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Tensión CC AGT 2 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>Corriente CC AGT 2 baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>Corriente CC AGT 2 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Refrigerante B6 AGT bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>Refrigerante B6 AGT alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>Carril B6 AGT (-) bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>Carril B6 AGT (-) alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>Carril B6 AGT (+) bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>Carril B6 AGT (+) alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Temperatura combustible muy baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Temperatura combustible muy alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Nivel combustible muy bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Unidad de control perdida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Panel perdido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Mantenimiento necesario</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Modulo 3 fases perdido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Modulo AGT perdido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Fallo sincronización</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>ECU externa perdida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Filtro aire admisión</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Mensaje de diagnóstico (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Modulo sincronización perdido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Fallo balance carga</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Modo sincronización desactivado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Luz de parada roja (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Luz de advertencia ámbar (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Luz indicadora de funcionamiento incorrecto (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Luz de protección (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Campo rotación incorrecto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Sensor nivel combustible perdido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Arranque sin inversor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Bus #1 sin corriente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Petición de arranque denegada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Arranque a distancia denegado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Relé de apagado forzado de la carga</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>El módulo de sincronización está desconectado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>BMS perdido</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Tensión de enlace del convertidor CC baja/inversa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Corriente de enlace del convertidor CC baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Tensión de precarga del convertidor CC baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Tensión de precarga del convertidor CC alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Error del controlador IGBT/MOSFET del convertidor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Error del convertidor bucle del control de potencia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Detección de frecuencia del convertidor CA</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Fallo del valor de control del convertidor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Ajuste de fábrica modificado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parámetro modificado en modo administrador</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Intervención manual (sistema ext.)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Inicialización fallida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Temperatura del inversor alta L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Temperatura del inversor alta L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Temperatura del inversor alta L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Temperatura del inversor alta enlace CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Sobrecarga del inversor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Comunicacion perdida inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Sobreacarga CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Exceso voltaje CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Sin conexión</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Ningún error</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Error desconocido: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Error desconocido:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Presión del aceite</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Sobretemperatura de la cabeza del cilindro</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Control de carga</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Velocidad mayor de lo esperado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Exceso de velocidad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Temperatura del aceite mayor de lo esperado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Circuito abierto/cortocircuito a la alimentación de la temperatura del aceite</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Cortocircuito a la alimentación de la temperatura del aceite</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Punto de referencia analógico alto/cortocircuito a la alimentación</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Punto de referencia analógico bajo/cortocircuito a tierra</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Tiempo de espera de recepción del mensaje TSC1 agotado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Tiempo de espera de recepción del mensaje CM1 agotado</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Tensión de batería alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Tensión de batería baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Señal de velocidad distorsionada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Suministro del sensor de 5 V interno alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Suministro del sensor de 5 V interno bajo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Presión barométrica alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Presión barométrica baja</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Cortocircuito a la alimentación de la bomba de combustible de salida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Cortocircuito a tierra de la bomba de combustible de salida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Cortocircuito a la alimentación de la bujía de precalentamiento de salida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Cortocircuito a tierra de la bujía de precalentamiento de salida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Circuito abierto/cortocircuito a tierra de la parte baja del inyector</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Cortocircuito interno de la bobina del inyector</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Cortocircuito a la alimentación en la parte baja del inyector</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Se han agotado las horas de servicio</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Fallo del procesador</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Error desconocido:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Batería</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Batería</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Refrigerador</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Refrigerador</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Genérico</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Genérico</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Sala</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Sala</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Exterior</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Exterior</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Calentador de agua</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Calentador de agua</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Congelador</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Congelador</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Error desconocido:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Ningún error</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>Voltage CA L1 muy bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>Voltage CA muy bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>Voltage CA L1 muy alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>Voltage CA muy bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>Frecuencia CA L1 muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>Frecuencia CA muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>Frecuencia CA L1 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>Frecuencia CA muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>Corriente CA L1 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>Corriente CA muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>Potencia CA L1 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>Potencia CA muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Parada de emergencia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Corriente servo muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Presión de aceite muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Presión aceite muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Temperatura motor muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Temperature motor muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Temperatura devanado muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Temperatura devanado muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Temperatura escape muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Temperatura escape muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Temperatura electrónica baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Temperatura electrónica alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Tensión de arranque muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Corriente starter muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Tensión de calentador muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Corriente calentador muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Tensión de ayuda al arranque en frío demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Corriente de ayuda al arranque en frío demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Tensión del imán de retención de combustible muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Corriente del imán de retención de combustible muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Tensión de la bobina de retención de solenoide de parada muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Corriente de bobina de retención de solenoide de parada muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Tensión de la bobina tiradora de solenoide de parada muy baja </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Corriente de bobina tiradora de solenoide de parada muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Tensión del ventilador/bomba de agua demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Corriente del ventilador/bomba de agua demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Tensión baja del sensor de corriente</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Corriente alta del sensor de corriente</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Tensión de salida de refuerzo demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Corriente salida boost muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Tensión de alimentación del bus demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Corriente de alimentación del bus demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Tensión batería de arranque muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Voltaje bateria arranque muy alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Rotación muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Rotación muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Parad inesperada/problema con el suministro de combustible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Tensión del contactor de potencia demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Corriente del contactor de potencia muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>Tensión CA L2 muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>Voltaje CA L2 muy alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>Frecuencia CA L2 muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>Frecuencia CA L2 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>Corriente CA L2 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>Potencia CA L2 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>Tensión CA L3 muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>Voltaje CA L3 muy alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>Frecuencia CA L3 muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>Frecuencia CA L3 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>Corriente CA L3 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>Potencia CA L3 muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Tensión del inversor de salida demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Corriente del inversor de salida demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Tensión de salida universal (1&#xa0;A) demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Corriente de salida universal (1&#xa0;A) demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Tensión de salida universal (5&#xa0;A) demasiado baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Corriente de salida universal (5&#xa0;A) demasiado alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>Tensión CC AGT 1 baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>Tensión CC AGT 1 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>Corriente CC AGT 1 baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>Corriente CC AGT 1 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Tensión CC AGT 2 baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Tensión CC AGT 2 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>Corriente CC AGT 2 baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>Corriente CC AGT 2 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>Refrigerante B6 AGT bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>Refrigerante B6 AGT alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>Carril B6 AGT (-) bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>Carril B6 AGT (-) alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>Carril B6 AGT (+) bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>Carril B6 AGT (+) alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Temperatura combustible muy baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Temperatura combustible muy alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Nivel combustible muy bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Unidad de control perdida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Panel perdido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Mantenimiento necesario</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Modulo 3 fases perdido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Modulo AGT perdido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Fallo sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>ECU externa perdida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Filtro aire admisión</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Mensaje de diagnóstico (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Modulo sincronización perdido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Fallo balance carga</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Modo sincronización desactivado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Luz de parada roja (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Luz de advertencia ámbar (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Luz indicadora de funcionamiento incorrecto (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Luz de protección (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Campo rotación incorrecto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Sensor nivel combustible perdido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Arranque sin inversor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Bus #1 sin corriente</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Petición de arranque denegada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Arranque a distancia denegado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Relé de apagado forzado de la carga</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>El módulo de sincronización está desconectado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>BMS perdido</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Tensión de enlace del convertidor CC baja/inversa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Corriente de enlace del convertidor CC baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Tensión de precarga del convertidor CC baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Tensión de precarga del convertidor CC alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Error del controlador IGBT/MOSFET del convertidor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Error del convertidor bucle del control de potencia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Detección de frecuencia del convertidor CA</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Fallo del valor de control del convertidor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Ajuste de fábrica modificado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parámetro modificado en modo administrador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Intervención manual (sistema ext.)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Inicialización fallida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Temperatura del inversor alta L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Temperatura del inversor alta L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Temperatura del inversor alta L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Temperatura del inversor alta enlace CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Sobrecarga del inversor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Comunicacion perdida inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>Sobreacarga CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>Exceso voltaje CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Sin conexión</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Ningún error</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Error desconocido: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Error desconocido:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Presión del aceite</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Sobretemperatura de la cabeza del cilindro</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Control de carga</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Velocidad mayor de lo esperado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Exceso de velocidad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Temperatura del aceite mayor de lo esperado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Circuito abierto/cortocircuito a la alimentación de la temperatura del aceite</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Cortocircuito a la alimentación de la temperatura del aceite</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Punto de referencia analógico alto/cortocircuito a la alimentación</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Punto de referencia analógico bajo/cortocircuito a tierra</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Tiempo de espera de recepción del mensaje TSC1 agotado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Tiempo de espera de recepción del mensaje CM1 agotado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Tensión de batería alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Tensión de batería baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Señal de velocidad distorsionada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Suministro del sensor de 5&#xa0;V interno alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Suministro del sensor de 5&#xa0;V interno bajo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Presión barométrica alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Presión barométrica baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Cortocircuito a la alimentación de la bomba de combustible de salida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Cortocircuito a tierra de la bomba de combustible de salida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Cortocircuito a la alimentación de la bujía de precalentamiento de salida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Cortocircuito a tierra de la bujía de precalentamiento de salida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Circuito abierto/cortocircuito a tierra de la parte baja del inyector</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Cortocircuito interno de la bobina del inyector</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Cortocircuito a la alimentación en la parte baja del inyector</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Se han agotado las horas de servicio</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Fallo del procesador</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Poner el interruptor en una posición desbloqueada para modificar los ajustes.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Usar fuente de datos D-Bus: conectar a la dirección D-Bus indicada.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>Dirección</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Usar fuente de datos D-Bus: conectar a la dirección D-Bus predeterminada.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Usar fuente de datos MQTT: conectar a la dirección del broker MQTT indicada.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>Dirección</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>Identificación del portal del dispositivo de la fuente de datos MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>ID portal</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Fragmento del hospedador web VRM MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>fragmento</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Nombre de usuario de la fuente de datos MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Usuario</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Contraseña de la fuente de datos MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>Pass</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Token de la fuente de datos MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Token</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Habilitar contador de FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Saltar pantalla de presentación</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Usar fuente de datos ficticia para pruebas.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Hora estándar Marruecos</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Hora estándar de África Central Occidental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Hora estándar de Sudáfrica</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Hora estándar de Namibia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Hora estándar de Egipto</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Hora estándar de África Oriental</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Hora estándar de Argentina</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Hora estándar de Sudamérica E.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Hora estándar de Groenlandia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Hora estándar de Montevideo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Hora estándar de Terranova y Labrador</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Hora estándar del este Sudamérica</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Hora estándar del Atlántico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Hora estándar de Brasil central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Hora estándar del Pacífico Sudamérica</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Hora estándar de Paraguay</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Hora estándar occidental de Sudamérica</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Hora estándar de Venezuela</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Hora estándar oriental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Hora estándar del Pacífico Sudamérica</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Hora estándar este de EE. UU.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Hora estándar de Canadá Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Hora estándar de América central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Hora estándar de México</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Hora estándar central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Hora estándar de México 2</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Hora estándar de la montaña</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Hora estándar de la montaña EE.UU</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Hora estándar del Pacífico (México)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Hora estándar del Pacífico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Hora estándar de Alaska</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hora de Hawái-Aleutiano</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Hora estándar de Nueva Zelanda</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Hora estándar del Pacífico central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Hora estándar Pacífico occidental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Hora estándar de Australia Occidental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Hora estándar del Sudeste Asiático</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Hora estándar de Asia Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Hora estándar Asia occidental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Hora estándar de África Oriental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Hora estándar del Pacífico Sudamérica</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Hora estándar occidental de Sudamérica</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Hora estándar de Europa Occidental</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Hora estándar de Kamchatka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Hora estándar Magadán</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Hora estándar de Vladivostok</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Hora estándar de Yakutsk</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Hora estándar de Tokio</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Hora estándar de Corea</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Hora estándar de Singapur</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Hora estándar de Ulán Bator</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Hora estándar de Taipei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Hora estándar este, Asia Norte</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Hora estándar de China</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Hora estándar del Sudeste Asiático</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Hora estándar de Asia Norte</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Myanmar Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Hora estándar de Asia Central Norte</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Hora estándar de Asia Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Hora estándar de Bangladesh</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Hora estándar de Nepal</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Hora estándar de Sri Lanka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Hora estándar de India</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Hora estándar Asia occidental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Hora estándar de Pakistán</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Hora estándar de Ekaterimburgo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Hora estándar de Georgia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Hora estándar del Cáucaso</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Hora estándar de Azerbaiyán</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Hora estándar árabe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Hora estándar de Afganistán</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Hora estándar de Irán</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Hora estándar árabe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Hora estándar árabe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Hora estándar de Siria</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Hora estándar de Oriente medio</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Hora estándar de Jordania</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Hora estándar de Israel</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Hora estándar de Greenwich</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Hora estándar de las Azores</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Hora estándar de Cabo Verde</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Hora estándar de Tasmania</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Hora estándar de Australia Oriental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Hora estándar de Australia Oriental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Hora estándar de Australia Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Hora estándar de Australia Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Hora estándar de Australia Occidental</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Hora estándar del Atlántico Medio</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Línea de fecha internacional</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>Hora estándar GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Hora estándar de Europa central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Hora estándar de Europa central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Hora estándar romance</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Hora estándar de Europa Occidental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Hora estándar de Europa Oriental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Hora estándar FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Hora estándar GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Hora estándar de Bielorrusia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Hora estándar de Rusia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Hora estándar de Turquía</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Hora estándar de Mauricio</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Hora estándar de Isla de Navidad</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Hora estándar de Tonga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Hora estándar de las Islas Fiji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Hora estándar de Nueva Zelanda</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Hora estándar del Pacífico central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Hora estándar Pacífico occidental</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Hora estándar de Samoa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Hora estándar de Hawái</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Hora estándar de Isla de Pascua</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Error interno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Error desconocido:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Error interno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Ningún error</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Temperatura batería alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Tensión batería alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Tensión batería baja</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>La tensión de la batería ha superado el máximo configurado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Alta temperatura del alternador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Altas RPM del alternador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Alta temperatura del FET del control de campo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Falta un sensor necesario</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Baja tensión del alternador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Compensación alta tensión del alternador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>La tensión del alternador ha superado el máximo configurado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Alta tensión del alternador</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Batería desconectada</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Desconexión por alta tensión de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Instancia de la batería fuera de rango</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Demasiados BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Batería a punto de desconectarse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Demasiados dispositivos para hacer un seguimiento</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Desconexión por baja tensión de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Desconexión por alta corriente de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Desconexión por alta temperatura de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Desconexión por baja temperatura de la batería</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Conexión BMS perdida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC (Permitir la carga) deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>El convertidor CC/CC no está listo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>Tensión primaria alta CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>Tensión primaria baja CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>Tensión secundaria alta CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>Tensión secundaria baja CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>Temperatura alta CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>Configuración errónea CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Sensor de temperatura de la batería defectuoso</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_fr.ts
+++ b/i18n/venus-gui-v2_fr.ts
@@ -1,10376 +1,11083 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="fr">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Désactivé</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Surcharge convertisseur</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Surcharge convertisseur</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Puissance</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Puissance</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Off</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Off</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Auto</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Batterie</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connecté</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Déconnecté</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Générateur</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Tension de batterie élevée</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Tension de batterie élevée</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Onduleur / Chargeur</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Onduleur / Chargeur</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Tension de batterie basse</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Tension de batterie basse</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manuel</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manuel</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Aucune</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Aucune</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Position</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Position</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Vitesse</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Vitesse</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>État</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>État</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installation en cours %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installation en cours %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Erreur inconnue</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Erreur inconnue</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>SOC minimum</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>SOC minimum</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Inconnu</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Saisir mot de passe</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Saisir mot de passe</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Cliquer pour vérifier</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Cliquer pour vérifier</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Réseau</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Réseau</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Production solaire</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Production solaire</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Contrôle externe</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Contrôle externe</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Réservoirs</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Réservoirs</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Environnement</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Environnement</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Pas d'alertes en cours</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Pas d&apos;alertes en cours</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Général</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Général</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Micrologiciel</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Micrologiciel</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Date &amp; Heure</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Date &amp; Heure</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Configuration Système</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Configuration Système</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Affichage &amp; Langue</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Affichage &amp; Langue</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>Portail en ligne VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>Portail en ligne VRM</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Compteurs d'énergie</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Compteurs d&apos;énergie</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>Convertisseurs PV</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>Convertisseurs PV</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>Modem GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>Modem GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Arrêter/Démarrer Générateur</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Arrêter/Démarrer Générateur</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Pompe du réservoir</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Pompe du réservoir</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Services</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Services</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Fonctionnalités Venus OS Large</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Fonctionnalités Venus OS Large</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Limite Battery life : %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Limite Battery life : %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Démarrage auto</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Le démarrage automatique sera désactivé et le générateur ne démarrera pas automatiquement en fonction des conditions configurées.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Le démarrage automatique sera désactivé et le générateur ne démarrera pas automatiquement en fonction des conditions configurées.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Arrêt Manuel</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Arrêt Manuel</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Démarrage Manuel</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Démarrage Manuel</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Position</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Démarrage auto</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Démarrage auto</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Interrupteurs</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Interrupteurs</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Niveau d'accès</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Niveau d&apos;accès</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Utilisateur</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Utilisateur</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Utilisateur &amp; Installateur</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Utilisateur &amp; Installateur</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superutilisateur</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superutilisateur</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Service</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Service</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Veillez également à réinitialiser le système VE.Bus après avoir désactivé le DVCC.</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Veillez également à réinitialiser le système VE.Bus après avoir désactivé le DVCC.</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Limiter courant de charge</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Limiter courant de charge</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Courant de charge maximal</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Courant de charge maximal</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Util. %1 pour démarrer/arrêter</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Util. %1 pour démarrer/arrêter</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Démarrage lorsque %1 est supérieur à</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Démarrage lorsque %1 est supérieur à</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Démarrage lorsque %1 est inférieur à</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Démarrage lorsque %1 est inférieur à</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Arrêt lorsque %1 est supérieur à</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Arrêt lorsque %1 est supérieur à</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Arrêt lorsque %1 est inférieur à</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Arrêt lorsque %1 est inférieur à</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Supprimer l'adresse IP ?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Supprimer l&apos;adresse IP ?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max : %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max : %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Connexion</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Connexion</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Produit</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Produit</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Nom</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Nom</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Nom</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>ID produit</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>ID produit</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Version matérielle</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Version matérielle</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Nom de l'appareil</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Nom de l&apos;appareil</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Contrôle de l'interrupteur à distance désactivé</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Contrôle de l&apos;interrupteur à distance désactivé</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Générateur défaillant</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Générateur défaillant</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Générateur non détecté sur l'entrée CA</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Générateur non détecté sur l&apos;entrée CA</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Durée de fonctionnement cumulée depuis dernier test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Durée de fonctionnement cumulée depuis dernier test</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Temps manquant avant prochain test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Temps manquant avant prochain test</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Fonctionnement en cours</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Fonctionnement en cours</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Démarrage manuel</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Démarrage manuel</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Démarrer générateur</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Démarrer générateur</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Durée de fonctionnement quotidien</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Durée de fonctionnement quotidien</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>La valeur doit être supérieure à la valeur d'arrêt</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>La valeur doit être supérieure à la valeur d&apos;arrêt</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>La valeur doit être &lt; à la valeur de démarrage</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>La valeur doit être &lt; à la valeur de démarrage</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>Sortie CA</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>Sortie CA</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">Sortie CA</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Utiliser la charge CA pour démarrer/arrêter</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Utiliser la charge CA pour démarrer/arrêter</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Mesure</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Mesure</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Consommation totale</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Consommation totale</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Sortie CA totale du convertisseur</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Sortie CA totale du convertisseur</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Phase plus élevée de sortie CA du convertisseur</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Phase plus élevée de sortie CA du convertisseur</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Démarrer si la puissance est supérieure à</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Démarrer si la puissance est supérieure à</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Arrêter si la puissance est inférieure à</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Arrêter si la puissance est inférieure à</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Contrôleur de batterie</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Contrôleur de batterie</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Indisponible, en sélectionner un autre</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Indisponible, en sélectionner un autre</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Contrôleur de batterie</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Indisponible, en sélectionner un autre</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>En cas de perte de communication</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>En cas de perte de communication</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Arrêter générateur</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Arrêter générateur</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Laisser le générateur fonctionner</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Laisser le générateur fonctionner</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Arrêt du générateur lorsque l'alimentation en courant alternatif est disponible</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Arrêt du générateur lorsque l&apos;alimentation en courant alternatif est disponible</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>SOC de batterie</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>SOC de batterie</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Température élevée convertisseur</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Température élevée convertisseur</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Température élevée convertisseur</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Démarrer si avertissement de température élevée</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Démarrer si avertissement de température élevée</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Démarrer si avertissement de surcharge</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Démarrer si avertissement de surcharge</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Exécution régulière</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Exécution régulière</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Intervalle d'exécution</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Intervalle d&apos;exécution</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 jour(s)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 jour(s)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Sauter l'exécution si en marche depuis</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Sauter l&apos;exécution si en marche depuis</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Toujours démarrer</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Toujours démarrer</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Date de démarrage de l'intervalle d'exécution</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Date de démarrage de l&apos;intervalle d&apos;exécution</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Durée d'exécution (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Durée d&apos;exécution (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Fonctionner jusqu'à charge totale de la batterie</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Fonctionner jusqu&apos;à charge totale de la batterie</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (fixe)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (fixe)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS connecté, mais pas de GPS fixe</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS connecté, mais pas de GPS fixe</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Pas de GPS connecté</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Pas de GPS connecté</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Latitude</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Latitude</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Longitude</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Longitude</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Cap</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Cap</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Altitude</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Altitude</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Nombre de satellites</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Nombre de satellites</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Point de consigne du réseau</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Point de consigne du réseau</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Point de consigne AC-IN</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Point de consigne AC-IN</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Courant : %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Courant : %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Tension : %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Tension : %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Limites (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Limites (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Charge : %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Charge : %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Décharge : %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Décharge : %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Limites (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Limites (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Visible</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Visible</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Caché(e)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Caché(e)</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (mesure supplémentaire)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (mesure supplémentaire)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Sortie %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Sortie %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Contrôleur de batterie actif</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Contrôleur de batterie actif</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Nom</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Saisir le nom</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Saisir le nom</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Saisir le nom</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Scan en continu</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Scan en continu</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Adaptateurs Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Adaptateurs Bluetooth</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Code pin</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Code pin</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Il peut être nécessaire de supprimer les informations d'accouplement existantes avant la connexion.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Il peut être nécessaire de supprimer les informations d&apos;accouplement existantes avant la connexion.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Type de phase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Type de phase</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Monophasé</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Monophasé</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Multiphasé</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Multiphasé</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>Convertisseur PV sur phase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>Convertisseur PV sur phase 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>Position convertisseur PV sur phase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>Position convertisseur PV sur phase 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>Profil Bus CAN</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>Profil Bus CAN</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Désactivé</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can et Lynx Ion pour BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can et Lynx Ion pour BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can et CAN-bus pour BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can et CAN-bus pour BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Up, mais pas de services (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Up, mais pas de services (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Appareils</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Appareils</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>Sortie NMEA 2000</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>Sortie NMEA 2000</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Sélecteur de numéro d'identité unique</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Sélecteur de numéro d&apos;identité unique</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Veuillez patienter, changer et vérifier le numéro unique prend du temps</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Veuillez patienter, changer et vérifier le numéro unique prend du temps</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Le sélecteur ci-dessus définit le bloc de numéros d'identité uniques à utiliser pour les numéros d'identité uniques NAME dans le champ PGN 60928 NAME. A modifier uniquement en cas d'utilisation de plusieurs équipements GX dans un réseau VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Le sélecteur ci-dessus définit le bloc de numéros d&apos;identité uniques à utiliser pour les numéros d&apos;identité uniques NAME dans le champ PGN 60928 NAME. A modifier uniquement en cas d&apos;utilisation de plusieurs équipements GX dans un réseau VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Le sélecteur ci-dessus définit le bloc de numéros d'identité uniques à utiliser pour le numéro de série dans le champ DGN 60928 ADDRESS_CLAIM. Modifier uniquement en cas d'utilisation de plusieurs dispositifs GX dans un réseau RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Le sélecteur ci-dessus définit le bloc de numéros d&apos;identité uniques à utiliser pour le numéro de série dans le champ DGN 60928 ADDRESS_CLAIM. Modifier uniquement en cas d&apos;utilisation de plusieurs dispositifs GX dans un réseau RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Vérifier les numéros  uniques d'identification</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Vérifier les numéros  uniques d&apos;identification</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Cliquer pour vérifier</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Un autre appareil est connecté avec ce numéro unique, veuillez sélectionner un nouveau numéro.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Un autre appareil est connecté avec ce numéro unique, veuillez sélectionner un nouveau numéro.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK : aucun autre appareil n'est connecté avec ce numéro unique.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK : aucun autre appareil n&apos;est connecté avec ce numéro unique.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>État réseau</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>État réseau</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Luminosité adaptative</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Luminosité adaptative</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Luminosité</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Luminosité</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Durée avant extinction de l'affichage</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Durée avant extinction de l&apos;affichage</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 s</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 s</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Jamais</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Jamais</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Mode d'affichage</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Mode d&apos;affichage</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Sombre</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Sombre</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Clair</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Clair</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Niveaux de vue succincts</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Niveaux de vue succincts</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Langue</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Langue</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Changement de langue</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Changement de langue</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Affichage de la puissance électrique</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Affichage de la puissance électrique</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Puissance (Watts)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Puissance (Watts)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Courant (Ampères)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Courant (Ampères)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Unités</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Unités</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Niveau %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Niveau %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;ATTENTION:&lt;/b&gt; Lire le manuel avant de procéder au réglage.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;ATTENTION:&lt;/b&gt; Lire le manuel avant de procéder au réglage.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Limiter la tension de charge de la batterie gérée</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Limiter la tension de charge de la batterie gérée</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Tension de charge maximale</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Tension de charge maximale</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Sonde de tension partagée</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Sonde de tension partagée</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Sonde de température partagée</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Sonde de température partagée</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Sonde indisponible. Configurez-en une autre</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Sonde indisponible. Configurez-en une autre</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Sonde indisponible. Configurez-en une autre</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Capteur utilisé</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Capteur utilisé</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Sonde de courant partagée</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Sonde de courant partagée</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Statut SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Statut SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Désactivée (contrôle externe)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Désactivée (contrôle externe)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Désactivée (pas de chargeurs)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Désactivée (pas de chargeurs)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Désactivée (pas de contrôleur de batterie)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Désactivée (pas de contrôleur de batterie)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Sélection automatique</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Sélection automatique</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Pas de contrôle par BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Pas de contrôle par BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Contrôle du BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Contrôle du BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Indisponible, en paramètrer un autre</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Indisponible, en paramètrer un autre</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Auto sélectionné</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Auto sélectionné</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Aucune</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Date/Heure de fabrication</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Date/Heure de fabrication</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Mises à jour en ligne</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Mises à jour en ligne</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Installer micrologiciel depuis SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Installer micrologiciel depuis SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Micrologiciel de secours stocké</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Micrologiciel de secours stocké</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Vérifier les mises à jour sur SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Vérifier les mises à jour sur SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Micrologiciel trouvé</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Micrologiciel trouvé</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installation de %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installation de %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Cliquer pour mettre à jour vers %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Cliquer pour mettre à jour vers %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Cliquer pour mettre à jour vers %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Date/Heure de compilation du micrologiciel</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Date/Heure de compilation du micrologiciel</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Mise à jour automatique</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Mise à jour automatique</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Vérifier uniquement</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Vérifier uniquement</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Vérifier et télécharger</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Vérifier et télécharger</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Vérifier et télécharger</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Vérifier et télécharger</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Mettre à jour le flux</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Mettre à jour le flux</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Type d'image</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Type d&apos;image</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normal</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normal</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Large</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Large</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Vérifier mises à jour</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Vérifier mises à jour</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Mise à jour disponible</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Mise à jour disponible</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Installation en cours %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Installation en cours %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Installation en cours %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Date/Heure construction de la mise à jour</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Date/Heure construction de la mise à jour</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Convertisseurs</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Convertisseurs</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Trouver convertisseurs PV</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Trouver convertisseurs PV</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Adresses IP détectées</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Adresses IP détectées</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Ajouter adresse IP manuellement</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Ajouter adresse IP manuellement</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>Port TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>Port TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Multiphase</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Multiphase</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Phase auxiliaire (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Phase auxiliaire (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Montrer</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Montrer</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Rescanner les adresses IP ?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Rescanner les adresses IP ?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Scanner à nouveau</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Scanner à nouveau</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH sur LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH sur LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Assistance à distance</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Assistance à distance</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Tunnel de support à distance</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Tunnel de support à distance</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>IP et port de support à distance</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>IP et port de support à distance</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Se déconnecter</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Redémarrer maintenant</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Redémarrer maintenant</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">L&apos;appareil a été redémarré.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Alarme sonore</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Alarme sonore</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Mode démo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Mode démo</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>Démo ESS</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>Démo ESS</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Bateau/Camping-car démo 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Bateau/Camping-car démo 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Bateau/Camping-car démo 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Bateau/Camping-car démo 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>En lançant le mode Démo, certains paramètres seront modifiés et l'interface utilisateur restera bloquée un instant.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>En lançant le mode Démo, certains paramètres seront modifiés et l&apos;interface utilisateur restera bloquée un instant.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Conditions</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Conditions</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Temps minimal de fonctionnement</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Temps minimal de fonctionnement</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Temps d'échauffement</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Temps d&apos;échauffement</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Temps de refroidissement</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Temps de refroidissement</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Détecter générateur sur entrée CA</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Détecter générateur sur entrée CA</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Aucune entrée CA n'est paramétrée sur le générateur. Rendez-vous sur la page de configuration du système et paramétrez l'entrée CA correcte au générateur afin d'activer cette fonctionnalité.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Aucune entrée CA n&apos;est paramétrée sur le générateur. Rendez-vous sur la page de configuration du système et paramétrez l&apos;entrée CA correcte au générateur afin d&apos;activer cette fonctionnalité.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Une alarme se déclenchera si aucune puissance provenant du générateur n'est détectée sur l'entrée CA du convertisseur. Assurez-vous que l'entrée CA correcte est paramétrée sur le générateur sur la page de configuration du système.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Une alarme se déclenchera si aucune puissance provenant du générateur n&apos;est détectée sur l&apos;entrée CA du convertisseur. Assurez-vous que l&apos;entrée CA correcte est paramétrée sur le générateur sur la page de configuration du système.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Début  Heures calmes</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Début  Heures calmes</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Fin Heures calmes</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Fin Heures calmes</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Durée d'exécution et service</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Durée d&apos;exécution et service</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Réinitialiser compteurs d'exécution quotidienne</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Réinitialiser compteurs d&apos;exécution quotidienne</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Le compteur d'exécution quotidienne a été réinitialisé</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Le compteur d&apos;exécution quotidienne a été réinitialisé</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Il n'est pas possible de modifier les compteurs tant que le générateur est en marche</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Il n&apos;est pas possible de modifier les compteurs tant que le générateur est en marche</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Intervalle d'entretien du générateur (heures)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Intervalle d&apos;entretien du générateur (heures)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>L'intervalle de temps de service est réglé sur %1h. Utilisez le bouton "Réinitialiser le minuteur de service" pour réinitialiser le minuteur de service.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>L&apos;intervalle de temps de service est réglé sur %1h. Utilisez le bouton &quot;Réinitialiser le minuteur de service&quot; pour réinitialiser le minuteur de service.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Réinitialisation de la minuterie de service</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Réinitialisation de la minuterie de service</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Paramètres GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Paramètres GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Format</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Format</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Unité de vitesse</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Unité de vitesse</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilomètres par heure</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilomètres par heure</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Mètres par seconde</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Mètres par seconde</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Miles par heure</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Miles par heure</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Nœuds</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Nœuds</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Aucun modem GSM connecté</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Aucun modem GSM connecté</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Opérateur</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Opérateur</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Il vous faudra peut-être configurer sur cette page les paramètres APN ci-dessous : veuillez contacter votre opérateur pour davantage de détails.
-Si cela ne marche pas, vérifiez la carte SIM dans un téléphone pour vous assurer qu'elle a du crédit et/ou qu'elle est enregistrée afin d'être utilisée pour les données.</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Il vous faudra peut-être configurer sur cette page les paramètres APN ci-dessous : veuillez contacter votre opérateur pour davantage de détails.
+Si cela ne marche pas, vérifiez la carte SIM dans un téléphone pour vous assurer qu&apos;elle a du crédit et/ou qu&apos;elle est enregistrée afin d&apos;être utilisée pour les données.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Autoriser l'itinérance</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Autoriser l&apos;itinérance</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Statut SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Statut SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM non insérée</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM non insérée</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>Code PIN requis</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>Code PIN requis</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>Code PUK requis</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>Code PUK requis</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Échec de la carte</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Échec de la carte</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM occupé</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM occupé</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Mauvaise carte SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Mauvaise carte SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Mauvais code PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Mauvais code PIN</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Prêt</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Prêt</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Erreur inconnue</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Par défaut</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Par défaut</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Utiliser APN par défaut</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Utiliser APN par défaut</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Nom APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Nom APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Utiliser l'authentification</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Utiliser l&apos;authentification</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Nom d'utilisateur</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Nom d&apos;utilisateur</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Autoconsommation</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Autoconsommation</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Aucun assistant ESS trouvé</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Aucun assistant ESS trouvé</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Comptage réseau</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Comptage réseau</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Compteur externe</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Compteur externe</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Onduleur/chargeur</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Onduleur/chargeur</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Sortie CA du convertisseur utilisée</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Sortie CA du convertisseur utilisée</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Régulation multiphase</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Régulation multiphase</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Total de toutes les phases</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Total de toutes les phases</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Phase individuelle</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Phase individuelle</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Chaque phase est régulée pour atteindre individuellement le point de consigne du réseau (l'efficacité du système est réduite).
+        <translation>Chaque phase est régulée pour atteindre individuellement le point de consigne du réseau (l&apos;efficacité du système est réduite).
 
-ATTENTION : A n'utiliser que si le fournisseur d'électricité l'exige.</translation>
+ATTENTION : A n&apos;utiliser que si le fournisseur d&apos;électricité l&apos;exige.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Le total de toutes les phases est régulé intelligemment pour atteindre le point de consigne du réseau (l'efficacité du système est optimisée).
+        <translation>Le total de toutes les phases est régulé intelligemment pour atteindre le point de consigne du réseau (l&apos;efficacité du système est optimisée).
 
-A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
+A utiliser sauf si le fournisseur d&apos;électricité l&apos;interdit.</translation>
+    </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inactif</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamic ESS</translation>
     </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>SOC minimum (Sauf défaillance réseau)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>SOC minimum (Sauf défaillance réseau)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Limite actuelle d'état de charge</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Limite actuelle d&apos;état de charge</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Maintenir</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Recharge</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Ecrêtage</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Ecrêtage</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Au dessus du SOC minimum seulement</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Au dessus du SOC minimum seulement</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Toujours</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Toujours</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Décharge désactivée</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Décharge désactivée</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Ralentir charge</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Ralentir charge</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Maintenir</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Maintenir</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Recharge</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Recharge</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Limiter puissance de charge</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Limiter puissance de charge</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Puissance de charge maximale</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Puissance de charge maximale</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Limiter puissance convertisseur</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Limiter puissance convertisseur</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Puissance maximale convertisseur</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Puissance maximale convertisseur</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Point de consigne du réseau</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Point de consigne du réseau</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Injection dans le réseau</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Injection dans le réseau</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>Réinjecter l'excédent puissance PV en couplage AC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>Réinjecter l&apos;excédent puissance PV en couplage AC</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>Réinjecter l'excédent puissance PV couplé CC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>Réinjecter l&apos;excédent puissance PV couplé CC</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Limiter l'injection du système</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Limiter l&apos;injection du système</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Injection maximale</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Injection maximale</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Limitation de l'injection active</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Limitation de l&apos;injection active</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Entrées analogiques</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Entrées analogiques</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Entrées numériques</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Entrées numériques</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Entrée numérique %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Entrée numérique %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Compteur d'impulsions</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Compteur d&apos;impulsions</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Alarme porte</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Alarme porte</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Pompe de cale</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Pompe de cale</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Alarme de fond de cale</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Alarme de fond de cale</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Alarme anti-intrusion</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Alarme anti-intrusion</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Alarme fumée</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Alarme fumée</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Alarme incendie</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Alarme incendie</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>Alarme C02</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>Alarme C02</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Capteurs Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Capteurs Bluetooth</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Notez que ces fonctionnalités ne sont pas officiellement prises en charge par Victron. Veuillez visiter community.victronenergy.com pour toute question.
+        <translation>Notez que ces fonctionnalités ne sont pas officiellement prises en charge par Victron. Veuillez visiter community.victronenergy.com pour toute question.
 
 Documentation sur https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Activé (mode sécurisé)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Activé (mode sécurisé)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Différé par %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Différé par %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID Portail VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID Portail VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Intervalle entre enregistrements</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Intervalle entre enregistrements</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 Heure</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 Heure</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 Heures</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 Heures</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 Heures</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 Heures</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 heures</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 heures</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 jour</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 jour</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Utiliser connexion sécurisée (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Utiliser connexion sécurisée (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Dernier contact</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Dernier contact</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Texte de réponse inattendu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Texte de réponse inattendu</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Réponse HTTP inattendue</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Réponse HTTP inattendue</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Délai de connexion</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Délai de connexion</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Erreur de connexion</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Erreur de connexion</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Échec du DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Échec du DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Erreur de routage</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Erreur de routage</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM indisponible</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM indisponible</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Erreur inconnue</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Erreur inconnue</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Message d'erreur :
+        <translation>Message d&apos;erreur :
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Redémarrer appareil si aucun contact</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Redémarrer appareil si aucun contact</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Retard de réinitialisation si aucun contact (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Retard de réinitialisation si aucun contact (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Emplacement stockage</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Emplacement stockage</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Aucune mémoire tampon active</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Aucune mémoire tampon active</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Stockage interne</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Stockage interne</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Transfert en cours</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Transfert en cours</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Stockage externe</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Stockage externe</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Erreur inconnue</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Aucune erreur</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Aucune erreur</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Plus d'espace de stockage</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Plus d&apos;espace de stockage</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Erreur ES</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Erreur ES</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Erreur montage</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Erreur montage</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Contient le micrologiciel. Pas utilisée.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Contient le micrologiciel. Pas utilisée.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>Carte SD/clé USB sans zone d'écriture</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>Carte SD/clé USB sans zone d&apos;écriture</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Espace libre du disque</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Espace libre du disque</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>octet</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>octet</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>octets</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>octets</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Enregistrements stockés</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Enregistrements stockés</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 enregistrements</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 enregistrements</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Enregistrement le plus ancien</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Enregistrement le plus ancien</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Activer Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Activer Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Aucune erreur signalée</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Aucune erreur signalée</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>heure de la dernière erreur</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>heure de la dernière erreur</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Services disponibles</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Services disponibles</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>ID de l'unité : %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>ID de l&apos;unité : %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Fonction (Relais 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Fonction (Relais 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Fonction</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Fonction</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Relais d'alarme</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Relais d&apos;alarme</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Pompe du réservoir</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuel</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polarité du relais d'alarme</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polarité du relais d&apos;alarme</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normalement ouvert</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normalement ouvert</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normalement fermé</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normalement fermé</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relais 1 Activé</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relais 1 Activé</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relais activé</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relais activé</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Fonction (Relai 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Fonction (Relai 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relais 2 Activé</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relais 2 Activé</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Règles de contrôle de température</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Règles de contrôle de température</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Activation du relai par la température</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Activation du relai par la température</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Aucun relais n'est configuré pour être activé par la température. Allez à la page des réglages du relais située dans le menu principal des réglages et réglez la fonction du relais sur "Température".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Aucun relais n&apos;est configuré pour être activé par la température. Allez à la page des réglages du relais située dans le menu principal des réglages et réglez la fonction du relais sur &quot;Température&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Cette option vous permet d'alterner entre les versions de micrologiciel actuelle et antérieure. Internet ou carte SD ne sont pas necessaires.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Cette option vous permet d&apos;alterner entre les versions de micrologiciel actuelle et antérieure. Internet ou carte SD ne sont pas necessaires.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Micrologiciel %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Micrologiciel %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Appuyer pour démarrer</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Appuyer pour démarrer</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Micrologiciel %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Redémarrage en %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Redémarrage en %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Le changement de version du micrologiciel n'est pas possible lorsque la mise à jour automatique est définie sur "Vérifier et mettre à jour". Réglez la mise à jour automatique sur "Désactivé" ou "Vérifier uniquement" pour activer cette option.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Le changement de version du micrologiciel n&apos;est pas possible lorsque la mise à jour automatique est définie sur &quot;Vérifier et mettre à jour&quot;. Réglez la mise à jour automatique sur &quot;Désactivé&quot; ou &quot;Vérifier uniquement&quot; pour activer cette option.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Micrologiciel de secours indisponible</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Micrologiciel de secours indisponible</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Console sur VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-bus sur TCP/IP (Débogage)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-bus sur TCP/IP (Débogage)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Puissance de quai</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Puissance de quai</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Véhicule</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Véhicule</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Bateau</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Bateau</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Nom du système</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Nom du système</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatique</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatique</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Réseau</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatique</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Défini par utilisateur</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Défini par utilisateur</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Nom défini par l'utilisateur</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Nom défini par l&apos;utilisateur</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>Entrée CA 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>Entrée CA 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>Entrée CA 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>Entrée CA 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Contrôle pour défaillance réseau</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Contrôle pour défaillance réseau</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Contrôle pour déconnexion de quai</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Contrôle pour déconnexion de quai</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Sélection automatique</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Sélection automatique</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>A un système CC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>A un système CC</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Synchroniser SOC de VE.Bus avec batterie</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Synchroniser SOC de VE.Bus avec batterie</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Utiliser courant de charge solaire pour améliorer SOC VE.Bus</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Utiliser courant de charge solaire pour améliorer SOC VE.Bus</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Contrôle de tension du chargeur solaire</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Contrôle de tension du chargeur solaire</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Contrôle de courant du chargeur solaire</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Contrôle de courant du chargeur solaire</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Contrôle BMS</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>Contrôle BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>Contrôle BMS</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>La fonction de démarrage/arrêt de la pompe du réservoir n'est pas activée. Allez dans les réglages du relais et réglez la fonction sur "Pompe du réservoir".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>La fonction de démarrage/arrêt de la pompe du réservoir n&apos;est pas activée. Allez dans les réglages du relais et réglez la fonction sur &quot;Pompe du réservoir&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>État de la pompe</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>État de la pompe</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Sonde de réservoir</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Sonde de réservoir</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Niveau de démarrage</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Niveau de démarrage</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Niveau d'arrêt</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Niveau d&apos;arrêt</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Connexion perdue</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Connexion perdue</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Débranché</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Débranché</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Caché]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Caché]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Connecter au réseau ?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Connecter au réseau ?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Connecter</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Connecter</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Oublier réseau ?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Oublier réseau ?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Oublier</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Oublier</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Etes vous sur que vous voulez oublié ce réseau ?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Etes vous sur que vous voulez oublié ce réseau ?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>Adresse MAC</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>Adresse MAC</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>Configuration IP</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>Configuration IP</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuel</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Off</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Fixe</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Fixe</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Masque de réseau</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Masque de réseau</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Passerelle</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Passerelle</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>Serveur DNS</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>Serveur DNS</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Lier l'adresse IP locale</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Lier l&apos;adresse IP locale</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Attention, pour les systèmes ESS, ainsi que pour les systèmes avec une batterie gérée, l'instance d'appareil CAN-bus doit restée configurée sur 0. Voir le manuel des appareils GX pour plus d'informations.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Attention, pour les systèmes ESS, ainsi que pour les systèmes avec une batterie gérée, l&apos;instance d&apos;appareil CAN-bus doit restée configurée sur 0. Voir le manuel des appareils GX pour plus d&apos;informations.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Instance du dispositif</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Instance du dispositif</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Adresse du réseau</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Adresse du réseau</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Appareils VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Appareils VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Dispositif# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Dispositif# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Aucun point d'accès</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Aucun point d&apos;accès</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Aucun adaptateur Wi-Fi connecté</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Aucun adaptateur Wi-Fi connecté</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Créer point d'accès</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Créer point d&apos;accès</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Réseaux Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Réseaux Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Etes vous sur que vous voulez désactivé le point d'accès ?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Etes vous sur que vous voulez désactivé le point d&apos;accès ?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Date/Heure UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Date/Heure UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Date/Heure locale</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Date/Heure locale</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Fuseau  horaire</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Fuseau  horaire</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afrique</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afrique</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Amérique</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Amérique</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antarctique</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antarctique</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Artique</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Artique</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asie</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asie</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantique</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantique</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australie</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australie</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europe</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europe</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indien</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pacifique</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pacifique</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Non connecté %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Non connecté %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Redémarrer maintenant ?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Redémarrer maintenant ?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Les modifications de l'instance VRM ne seront pas appliquées tant que l'appareil n'aura pas été redémarré.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Les modifications de l&apos;instance VRM ne seront pas appliquées tant que l&apos;appareil n&apos;aura pas été redémarré.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>L'appareil redémarre...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>L&apos;appareil redémarre...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>L'appareil a été redémarré.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>L&apos;appareil a été redémarré.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Alarme de tension de batterie faible</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Alarme de tension de batterie faible</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Alarme de tension de batterie élevée</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Alarme de tension de batterie élevée</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Dernière erreur</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Dernière erreur</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2e dernière erreur</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2e dernière erreur</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3e dernière erreur</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3e dernière erreur</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4e dernière erreur</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4e dernière erreur</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Mis en réseau</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Mis en réseau</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Configuration Mode</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Configuration Mode</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Indépendant</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Indépendant</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Indépendant</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Charge</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Charge</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Contrôle externe</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Charge et HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Charge et HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Charge et BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Charge et BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Contrôle ext. et BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Contrôle ext. et BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Charge, Hub-1 et BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Charge, Hub-1 et BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Configuration Maître</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Configuration Maître</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Esclave</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Esclave</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Esclave</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Maître du groupe</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Maître du groupe</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Maître de la charge</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Maître de la charge</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Maître du groupe et de la charge</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Maître du groupe et de la charge</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Tension de charge</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Tension de charge</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Réinitialiser</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Réinitialiser</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Le contrôle du BMS est activé automatiquement lorsque le BMS est présent. Réinitialiser si la configuration du système a changé ou si aucun BMS n'est présent.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Le contrôle du BMS est activé automatiquement lorsque le BMS est présent. Réinitialiser si la configuration du système a changé ou si aucun BMS n&apos;est présent.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Puissance PV totale</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Charge</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Charge</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 trouvé</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 trouvé</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Histoire</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Histoire</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Histoire</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Fonctionnement en réseau</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Fonctionnement en réseau</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Vue du tableau</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Vue du tableau</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Graphique</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Graphique</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Avertissement</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Avertissement</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarme</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarme</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarme</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Volume</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Volume</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Court-circuité</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Court-circuité</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Polarité inversée</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Polarité inversée</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Chargeurs VE</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Chargeurs VE</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Session</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Session</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Temps</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Temps</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Mode charge</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Mode charge</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Démarrez et arrêtez vous-même le processus. Utilisez cette fonction pour des charges rapides et une surveillance étroite.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Démarrez et arrêtez vous-même le processus. Utilisez cette fonction pour des charges rapides et une surveillance étroite.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Démarre et s'arrête en fonction du niveau de charge de la batterie. Optimal pour les charges de nuit et les charges prolongées afin d'éviter les surcharges.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Démarre et s&apos;arrête en fonction du niveau de charge de la batterie. Optimal pour les charges de nuit et les charges prolongées afin d&apos;éviter les surcharges.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Des tarifs d'électricité plus bas pendant les heures creuses ou si vous voulez vous assurer que votre VE est complètement chargé et prêt à partir à une heure précise.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Des tarifs d&apos;électricité plus bas pendant les heures creuses ou si vous voulez vous assurer que votre VE est complètement chargé et prêt à partir à une heure précise.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Autoriser la charge</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Autoriser la charge</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Verrouiller affichage chargeur</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Verrouiller affichage chargeur</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Adresse source</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Adresse source</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Configuration</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Configuration</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Instance de ligne #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Instance de ligne #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Instance ligne</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Instance ligne</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Instance chargeur</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Instance chargeur</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Instance convertisseur</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Instance convertisseur</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Source DC #%1 instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Source DC #%1 instance</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Instance source DC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Instance source DC</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Source DC #%1 priorité</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Source DC #%1 priorité</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Priorité source DC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Priorité source DC</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Instance de réservoir</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Instance de réservoir</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Dispositifs RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Dispositifs RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Activer l'affichage de la fréquence des images</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Activer l&apos;affichage de la fréquence des images</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Incompatible</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Incompatible</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Supprimer les appareils déconnectés</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Supprimer les appareils déconnectés</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Appareil incompatible trouvé</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Appareil incompatible trouvé</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Fonction relais</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Fonction relais</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarme</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Démarrer/Arrêter Chargeur ou générateur</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Démarrer/Arrêter Chargeur ou générateur</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Contrôle manuel</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Fusible grillé</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Contrôle manuel</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Contrôle manuel</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Toujours ouvert (ne pas utiliser le relais)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Toujours ouvert (ne pas utiliser le relais)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Notez que la modification du réglage de l'état de charge bas modifie également le réglage de l'étage de décharge Time-to-go dans le menu de la batterie.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Notez que la modification du réglage de l&apos;état de charge bas modifie également le réglage de l&apos;étage de décharge Time-to-go dans le menu de la batterie.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Fusible grillé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Fusible grillé</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>LED de statut</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>LED de statut</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Aucune</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Interrupteur principal</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Interrupteur principal</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Radiateur</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Radiateur</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Ventilateur interne</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Ventilateur interne</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Drapeaux d'avertissement</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Drapeaux d&apos;avertissement</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Drapeaux d'alarme</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Drapeaux d&apos;alarme</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Interrupteur</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Interrupteur</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Initialisation en cours</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Initialisation en cours</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Arrêt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Arrêt</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Mise à jour en cours</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Mise à jour en cours</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Prêt à fonctionner</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Prêt à fonctionner</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>En pré-charge</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>En pré-charge</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Vérifier contacteur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Vérifier contacteur</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>État de santé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>État de santé</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Température de batterie</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Température de batterie</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Température de l'air</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Température de l&apos;air</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Tension de batt. de démarrage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Tension de batt. de démarrage</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Tension Bus</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Tension Bus</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Tension de section supérieure</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Tension de section supérieure</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Erreur de communication</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">État de santé</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Tension Bus</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Tension de section inférieure</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Tension de section inférieure</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Écart de point médian</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Écart de point médian</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Ampères-Heures consommés</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Ampères-Heures consommés</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Autonomie restante</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Autonomie restante</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Détails</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Détails</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarmes au niveau du module</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarmes au niveau du module</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnostics</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostics</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Fusibles</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Fusibles</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>Système</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>Système</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Paramètres</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Paramètres</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Détecter à nouveau la batterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Détecter à nouveau la batterie</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Appuyer pour scanner</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Appuyer pour scanner</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Appuyer pour scanner</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Détecter à nouveau la batterie peut prendre jusqu'à 30 secondes. Entre-temps, le nom de la batterie peut-être incorrect.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Détecter à nouveau la batterie peut prendre jusqu&apos;à 30 secondes. Entre-temps, le nom de la batterie peut-être incorrect.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Courant de charge élevé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Courant de charge élevé</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Courant de décharge élevé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Courant de décharge élevé</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>SOC bas</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>SOC bas</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Tension de batterie élevée</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">SOC bas</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Tension batt.de démarrage basse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Tension batt.de démarrage basse</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Tension batt. de démarrage élevée</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Tension batt. de démarrage élevée</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Sonde de température de batterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Sonde de température de batterie</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Tension médiane</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Tension médiane</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Fusible grillé</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Température interne élevée</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Température interne élevée</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Température de charge basse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Température de charge basse</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Température de charge élevée</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Température de charge élevée</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Défaillance interne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Défaillance interne</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Disjoncteur déclenché</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Disjoncteur déclenché</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Déséquilibre de cellule</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Déséquilibre de cellule</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Tension de cellule basse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Tension de cellule basse</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Tension de cellule la plus basse</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Tension de cellule la plus basse</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Tension de cellule la plus haute</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Tension de cellule la plus haute</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Température min. cellule</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Température min. cellule</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Température max. cellule</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Température max. cellule</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Modules de batterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Modules de batterie</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 en ligne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 en ligne</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 hors ligne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 hors ligne</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Nombre de modules bloquant la charge / décharge</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Nombre de modules bloquant la charge / décharge</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Capacité installée/disponible</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Capacité installée/disponible</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Décharge la plus profonde</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Décharge la plus profonde</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Dernière décharge</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Dernière décharge</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Décharge moyenne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Décharge moyenne</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Total cycles de charge</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Total cycles de charge</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Nombre de décharges complètes</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Nombre de décharges complètes</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Cumul des Ah consommés</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Cumul des Ah consommés</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Tension minimale de cellule</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Tension minimale de cellule</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Tension maximale de cellule</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Tension maximale de cellule</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Temps depuis dernière charge complète</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Temps depuis dernière charge complète</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Compte de synchronisation</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Compte de synchronisation</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarmes de faible tension de la batterie de démarrage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarmes de faible tension de la batterie de démarrage</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Tension minimale de la batterie de démarrage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Tension minimale de la batterie de démarrage</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Tension maximale de la batterie de démarrage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Tension maximale de la batterie de démarrage</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Énergie déchargée</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Énergie déchargée</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Énergie chargée</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Énergie chargée</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Limite de tension de charge (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Limite de tension de charge (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Limite de courant de charge (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Limite de courant de charge (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Limite de courant de décharge (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Limite de courant de décharge (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Déconnexion à tension basse (toujours ignorée)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Déconnexion à tension basse (toujours ignorée)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Banc de batteries</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Banc de batteries</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relais (sur contrôleur de batterie)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relais (sur contrôleur de batterie)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Restaurer paramètres d'usine</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Restaurer paramètres d&apos;usine</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Appuyer pour restaurer</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Appuyer pour restaurer</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Rétablir les paramètres d'usine ?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Rétablir les paramètres d&apos;usine ?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth activé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth activé</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Tension nominale</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Tension nominale</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Capacité</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Capacité</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacité</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Tension chargée</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Tension chargée</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Courant de queue</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Courant de queue</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Temps de détection de batterie chargée</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Temps de détection de batterie chargée</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Indice Peukert</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Indice Peukert</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Facteur d'efficacité de charge</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Facteur d&apos;efficacité de charge</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Seuil de courant</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Seuil de courant</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Période moyenne d'autonomie restante</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Période moyenne d&apos;autonomie restante</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Plancher de décharge d'autonomie restante</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Plancher de décharge d&apos;autonomie restante</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Décalage de courant</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Décalage de courant</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Synchroniser l'état de charge à 100 %</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Synchroniser l&apos;état de charge à 100 %</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Appuyer pour synchroniser</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Appuyer pour synchroniser</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Étalonner courant sur zéro</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Étalonner courant sur zéro</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Appuyer pour configurer sur 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Appuyer pour configurer sur 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Distributeur %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Distributeur %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Jeu de barres non alimenté</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Jeu de barres non alimenté</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Connexion perdue</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n fusible grillé</numerusform>
-        <numerusform>%n fusibles grillés</numerusform>
-        <numerusform>%n fusibles grillés</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n fusible grillé</numerusform>
+            <numerusform>%n fusibles grillés</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Pas d'informations disponibles, voir la page précédente pour le statut du distributeur.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Pas d&apos;informations disponibles, voir la page précédente pour le statut du distributeur.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Fusible %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Fusible %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Pas utilisé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Pas utilisé</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Grillé</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Grillé</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Arrêt dû à une erreur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Arrêt dû à une erreur</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Dernière erreur</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">2e dernière erreur</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">3e dernière erreur</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">4e dernière erreur</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Interrupteur Système</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Interrupteur Système</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Relais externe</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Relais externe</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Contact programmable</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Contact programmable</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Batteries</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Batteries</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacité</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Batteries</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Parallèle</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Parallèle</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>En serie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>En serie</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Tension de cell. min/max</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Tension de cell. min/max</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Température de cellule min/max</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Température de cellule min/max</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Équilibrage</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Équilibrage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Équilibrage</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Inconnu</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Sortie</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Sortie</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Contrôle du champ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Contrôle du champ</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Vitesse moteur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Vitesse moteur</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Tension Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Tension Aux</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Aucune alarme</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Aucune alarme</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Tension faible</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Tension faible</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Tension élevée</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Tension élevée</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Tension Aux basse</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Tension Aux basse</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Tension Aux élevée</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Tension Aux élevée</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Alarme Tension Aux basse</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Alarme Tension Aux basse</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Alarme Tension Aux élevée</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Alarme Tension Aux élevée</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Tension Aux minimum</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Tension Aux minimum</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Tension Aux maximum</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Tension Aux maximum</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Énergie produite</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Énergie produite</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Energie consomée</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Energie consomée</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Activer alarme</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Activer alarme</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Niveau actif</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Niveau actif</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Rétablir niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Rétablir niveau</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Délai</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Délai</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Niveau</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Restant</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Restant</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Capteur Batterie</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Capteur Batterie</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Capteur Batterie</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Type de capteur</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Type de capteur</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Par défaut</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Par défaut</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Européen (0 à 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Européen (0 à 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>US (240 à 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>US (240 à 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Personnaliser</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Personnaliser</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Personnaliser</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Valeur du capteur quand vide</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Valeur du capteur quand vide</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Type de liquide</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Type de liquide</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Ratio butane</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Ratio butane</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Forme personnalisée</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Forme personnalisée</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Temps de moyennage</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Temps de moyennage</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Valeur du capteur</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Valeur du capteur</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Aucune forme personnalisée n'a été définie. Vous pouvez en définir une avec un maximum de dix points. Notez que 0 % et 100 % sont implicites.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Aucune forme personnalisée n&apos;a été définie. Vous pouvez en définir une avec un maximum de dix points. Notez que 0 % et 100 % sont implicites.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Point %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Point %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Ajouter un point</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Ajouter un point</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Niveau du capteur</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Niveau du capteur</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Volume</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Les valeurs de niveau de capteur en double ne sont pas autorisées.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Les valeurs de niveau de capteur en double ne sont pas autorisées.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Les valeurs de volume doivent augmenter.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Les valeurs de volume doivent augmenter.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Chien de garde</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Chien de garde</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Débloqué (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Débloqué (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Débloqué (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Débloqué (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Débloqué (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Débloqué (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Verrouillé</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Verrouillé</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Configuration de phase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Configuration de phase</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Position de l'interrupteur</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Position de l&apos;interrupteur</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Monophasé</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>Biphasé</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>Biphasé</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>Triphasé</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>Triphasé</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Appareils</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>CA</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>CA</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Moteur</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Moteur</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Vitesse</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Charge</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Température de refroidissement</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Température de refroidissement</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Température d'échappement</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Température d&apos;échappement</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Température d'enroulement</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Température d&apos;enroulement</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Tension de batterie de démarrage</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Tension de batterie de démarrage</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Nombre de départs</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Nombre de départs</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Contrôle BMS</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Sélecteur avant verrouillé (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Sélecteur avant verrouillé (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Pas d'erreur (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Pas d&apos;erreur (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>Totaux CA</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>Totaux CA</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Énergie L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Énergie L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Séquence de phase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Séquence de phase</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Version Data Manager</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Version Data Manager</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1 : %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1 : %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Aucune</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Un voyant clignotant indique ce CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Un voyant clignotant indique ce CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Appareils bus Smappee</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Appareils bus Smappee</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>Chargeur PV</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>Chargeur PV</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Ce réglage est désactivé lorsqu'un multicontrôleur numérique est connecté.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Ce réglage est désactivé lorsqu&apos;un multicontrôleur numérique est connecté.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Ce paramètre est désactivé lorsqu'un BMS VE.Bus est raccordé.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Ce paramètre est désactivé lorsqu&apos;un BMS VE.Bus est raccordé.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC in %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC in %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>CC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>CC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Inversé</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Inversé</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Activer alarme</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Inversé</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Inverser la logique d'alarme</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Inverser la logique d&apos;alarme</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Irradiance</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Irradiance</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Température de cellule</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Température de cellule</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Température extérieure (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Température extérieure (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Température externe</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Température externe</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Température externe (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Température externe (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Vitesse du vent</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Vitesse du vent</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Détection automatique</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Détection automatique</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Sonde de vitesse du vent</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Sonde de vitesse du vent</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Sonde de température externe</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Sonde de température externe</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Regrouper</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Regrouper</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Multiplier</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Multiplier</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Réinitialiser compteur</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Réinitialiser compteur</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Court-circuité</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Polarité inversée</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Batterie capteur faible</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Batterie capteur faible</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Humidité</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Humidité</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Pression</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Pression</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Basse</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Offset</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Échelle</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Échelle</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Tension du capteur</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Tension du capteur</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Puissance PV totale</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Puissance PV totale</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Page produit</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Page produit</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Sonde CA %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Sonde CA %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Une nouvelle version MK3 est disponible.
+        <translation>Une nouvelle version MK3 est disponible.
 NOTE : La mise à jour peut arrêter temporairement le système.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Mise à jour de la MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Mise à jour de la MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Appuyer pour mettre à jour</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Appuyer pour mettre à jour</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>En mettant à jour le MK3, les valeurs réapparaîtront une fois la mise à jour terminée</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>En mettant à jour le MK3, les valeurs réapparaîtront une fois la mise à jour terminée</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Chargement de la batterie à 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Chargement de la batterie à 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Chargement de la batterie à 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Avancé</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>En cours</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>En cours</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Appuyer pour arrêter</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Appuyer pour arrêter</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Appuyer pour démarrer</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Appuyer pour démarrer</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Chargez la batterie à 100 %.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Chargez la batterie à 100 %.</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Le système reviendra à un fonctionnement normal, en donnant la priorité aux énergies renouvelables.
+        <translation>Le système reviendra à un fonctionnement normal, en donnant la priorité aux énergies renouvelables.
 Voulez-vous continuer ?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>L'alimentation à quai sera utilisée lorsqu'elle est disponible et l'option "Priorité au solaire et à l'éolien" sera ignorée.
+        <translation>L&apos;alimentation à quai sera utilisée lorsqu&apos;elle est disponible et l&apos;option &quot;Priorité au solaire et à l&apos;éolien&quot; sera ignorée.
 Voulez-vous continuer ?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>L'alimentation de quai sera utilisée pour charger complètement la batterie pendant une fois.
-Une fois le processus de charge terminé, le système reviendra à un fonctionnement normal, en donnant la priorité à l'énergie solaire et éolienne.
+        <translation>L&apos;alimentation de quai sera utilisée pour charger complètement la batterie pendant une fois.
+Une fois le processus de charge terminé, le système reviendra à un fonctionnement normal, en donnant la priorité à l&apos;énergie solaire et éolienne.
 Voulez-vous continuer ?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Tension CC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Tension CC</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>Courant CC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>Courant CC</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Avancé</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Avancé</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Configuration de l'alarme</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Configuration de l&apos;alarme</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>Un BMS de VE.Bus éteindra automatiquement le système s'il faut protéger la batterie. Le contrôle du système depuis le Color Control sera donc impossible.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>Un BMS de VE.Bus éteindra automatiquement le système s&apos;il faut protéger la batterie. Le contrôle du système depuis le Color Control sera donc impossible.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Un assistant BMS est installé, configuré pour un BMS de VE.Bus, mais ce dernier est introuvable!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Un assistant BMS est installé, configuré pour un BMS de VE.Bus, mais ce dernier est introuvable!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>BMS du VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>BMS du VE.Bus</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Avertissement : L'activation de l'égalisation dans un système ESS avec des chargeurs solaires peut entraîner la charge de la batterie à haute tension avec un courant trop élevé.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Avertissement&#xa0;: L&apos;activation de l&apos;égalisation dans un système ESS avec des chargeurs solaires peut entraîner la charge de la batterie à haute tension avec un courant trop élevé.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Le système commutera automatiquement en mode Float dès que la charge d'égalisation aura pris fin.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Le système commutera automatiquement en mode Float dès que la charge d&apos;égalisation aura pris fin.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Interrompre l'égalisation</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Interrompre l&apos;égalisation</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Égalisation</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Égalisation</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Interruption en cours...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Interruption en cours...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Démarrage en cours...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Démarrage en cours...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Démarrage en cours...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Appuyer pour interrompre</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Appuyer pour interrompre</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Interrompre et redémarrer l'absorption</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Interrompre et redémarrer l&apos;absorption</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Interrompre et passer à Float</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Interrompre et passer à Float</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Interrompre</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Interrompre</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Ne pas interrompre</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Ne pas interrompre</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Re-détecter le système VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Re-détecter le système VE.Bus</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Nouvelle détection en cours...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Nouvelle détection en cours...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Redémarrer le système VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Redémarrer le système VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Redémarrage en cours...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Redémarrage en cours...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Appuyer pour redémarrer</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Appuyer pour redémarrer</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>Entrée CA1 ignorée</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>Entrée CA1 ignorée</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>Entrée CA2 ignorée</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>Entrée CA2 ignorée</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Test du relais ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Test du relais ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Terminé</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">En attente</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Terminé</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Terminé</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>En attente</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>En attente</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Diagnostics VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Diagnostics VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Compteur de qualité du réseau Phase L%1, dispositif %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Compteur de qualité du réseau Phase L%1, dispositif %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>Rapport d'erreur VE.bus 8 / 11</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>Rapport d&apos;erreur VE.bus 8 / 11</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Alarme uniquement</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Alarme uniquement</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarmes &amp; Avertissements</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarmes &amp; Avertissements</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Erreur BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Erreur BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Numéro(s) de série</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Numéro(s) de série</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Dernier rapport VE.Bus Error 11 #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Dernier rapport VE.Bus Error 11 #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Test de sécurité BF en cours</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Test de sécurité BF en cours</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Test de sécurité BF OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Test de sécurité BF OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Inadéquation AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Inadéquation AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Erreur de communication</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Erreur de communication</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>GND Erreur de relais</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>GND Erreur de relais</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Inadéquation des UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Inadéquation des UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Période Inadéquation temporelle</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Période Inadéquation temporelle</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Inadéquation entre l'entraînement et le relais BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Inadéquation entre l&apos;entraînement et le relais BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Erreur : PE2 ouvert</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Erreur : PE2 ouvert</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Erreur : PE2 fermé</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Erreur : PE2 fermé</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Échec de l'étape : %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Échec de l&apos;étape : %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Phase L%1, dispositif %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Phase L%1, dispositif %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Pour obtenir le rapport d'erreur 11 du VE.Bus, le micrologiciel 454 ou supérieure est nécessaire.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Pour obtenir le rapport d&apos;erreur 11 du VE.Bus, le micrologiciel 454 ou supérieure est nécessaire.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>Quirks de VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>Quirks de VE.Bus</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Énergie</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Énergie</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Puissance</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Puissance</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Tension</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Tension</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Courant</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Courant</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Localisation</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Localisation</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Phase</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Phase</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Entrée CA active</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Entrée CA active</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Ondulation CC élevée</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Ondulation CC élevée</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Tension DC élevée</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Tension DC élevée</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Courant DC élevé</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Courant DC élevé</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Erreur sonde de température</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Erreur sonde de température</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Erreur sonde de tension</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Erreur sonde de tension</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Surcharge</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Surcharge</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>Ondulation CC</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>Ondulation CC</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Sonde de tension</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Sonde de tension</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Rotation de phase</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Rotation de phase</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Rotation de phase</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Version du VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Version du VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>Appareil MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>Appareil MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Version du MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Version du MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Version du Multi Control</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Version du Multi Control</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Version  BMS du VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Version  BMS du VE.Bus</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Sauf coupure réseau</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Sauf coupure réseau</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>Entrée CA</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>Entrée CA</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>Entrée CA</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>Entrée CA</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>Entrée CA 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>Entrée CA 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>Entrée CA 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>Entrée CA 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Rôle</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Rôle</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>Charge CA</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>Charge CA</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>Sortie CA</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>Sortie CA</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>Sortie CA</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>Sortie CA</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Phase CA L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Phase CA L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Sonde CA %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Sonde CA %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Sonde CA</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Sonde CA</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Actif</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Actif</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarme</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Surcharge</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>État de l'alarme</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>État de l&apos;alarme</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarmes</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarmes</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Autorisation de charger</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Autorisation de charger</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Autorisation de décharger</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Autorisation de décharger</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Scan automatique</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Scan automatique</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Batterie</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Batterie</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Courant batterie</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Courant batterie</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Tension batterie</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Tension batterie</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Courant de charge</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Courant de charge</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Charge en cours</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Charge en cours</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Suprrimer erreur</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Suprrimer erreur</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Fermé</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Fermé</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Connecté</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Connecté</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Courant</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Courant</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Transformateurs de courant</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Transformateurs de courant</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Nom personnalisé</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Nom personnalisé</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Débogage</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Débogage</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Appareil</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Appareil</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Désactivé</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Déchargement en cours</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Déchargement en cours</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Déconnecté</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Déconnecté</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Activer</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Activer</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Activé</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Activé</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Énergie</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Énergie</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Erreur</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Erreur :</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Erreur :</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Code d'erreur</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Code d&apos;erreur</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Version micrologicielle</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Version micrologicielle</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Générateur</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Générateur</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Température de batterie élevée</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Température de batterie élevée</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Alarme niveau haut</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Alarme niveau haut</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Tension de batterie de démarrage élevée</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Tension de batterie de démarrage élevée</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Température élevée</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Température élevée</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Alarmes de tension élevée</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Alarmes de tension élevée</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Historique</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Historique</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Heure(s)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Heure(s)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>En attente</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>En attente</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inactif</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inactif</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Onduleur / Chargeur</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>Adresse IP</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>Adresse IP</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Température de batterie basse</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Température de batterie basse</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Alarme niveau bas</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Alarme niveau bas</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Tension de batterie de démarrage basse</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Tension de batterie de démarrage basse</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>État de charge bas</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>État de charge bas</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Température basse</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Température basse</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Alarmes de tension faible</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Alarmes de tension faible</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Fabricant</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Fabricant</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Température maximum</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Température maximum</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Tension maximum</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Tension maximum</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Température minimum</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Température minimum</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Tension minimum</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Tension minimum</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Mode</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Mode</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Nom du modèle</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Nom du modèle</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Non</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Non</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Aucune erreur</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Indisponible</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Indisponible</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Non connecté</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Non connecté</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Hors ligne</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Hors ligne</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>OK</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>OK</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>On</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>On</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>En ligne</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>En ligne</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Ouvert</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Ouvert</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Mot de passe</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Mot de passe</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Phase</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Phase</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Appuyer pour effacer</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Appuyer pour effacer</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Appuyez pour réinitialiser</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Appuyez pour réinitialiser</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Appuyer pour scanner</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Appuyer pour scanner</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>Convertisseur PV</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>Convertisseur PV</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>Puissance PV</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>Puissance PV</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Heures calmes</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Heures calmes</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relais</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relais</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Redémarrer</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Redémarrer</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Supprimer</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Supprimer</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>En marche</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>En marche</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Scan en cours %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Scan en cours %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>N° de série</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>N° de série</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Paramètres</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Paramètres</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Configuration</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Configuration</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Force du signal</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Force du signal</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Standby</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Standby</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Démarrer si la condition est atteinte pendant</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Démarrer si la condition est atteinte pendant</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Heure de démarrage</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Heure de démarrage</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Valeur de démarrage pendant Heures calmes</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Valeur de démarrage pendant Heures calmes</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Démarrer si avertissement actif pendant</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Démarrer si avertissement actif pendant</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>État de charge</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>État de charge</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>État</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>État</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Démarrer (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Démarrer (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Valeur d'arrêt durant les heures calmes</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Valeur d&apos;arrêt durant les heures calmes</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Arrêter si la condition est atteinte pendant</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Arrêter si la condition est atteinte pendant</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Arrêté</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Arrêté</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Température</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Température</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Sonde de température</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Sonde de température</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Aujourd'hui</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Aujourd&apos;hui</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Total</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Total</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Tracker</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Tracker</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Type</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Type</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Numéro unique d'identité</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Numéro unique d&apos;identité</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Inconnu</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Inconnu</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Erreur VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Erreur VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Tension</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Tension</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Instance VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Instance VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Si avertissement supprimé, arrêter au bout de</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Si avertissement supprimé, arrêter au bout de</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Oui</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Oui</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Hier</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Hier</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Production</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Production</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Limite de puissance zéro injection</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Limite de puissance zéro injection</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Définir date</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Définir date</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Démarrer maintenant</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Démarrer maintenant</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Cycle chronométré</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Cycle chronométré</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Arrêter maintenant</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Arrêter maintenant</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Durée de fonctionnement totale</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Durée de fonctionnement totale</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Définir durée %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Définir durée %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Le générateur continuera à fonctionner si une condition de démarrage automatique est remplie.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Le générateur continuera à fonctionner si une condition de démarrage automatique est remplie.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Mode Onduleur / Chargeur</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Mode Onduleur / Chargeur</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Régler</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Régler</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Annuler</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Fermer</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Fermer</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Définir une durée</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Définir une durée</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Déjà en utilisation</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Déjà en utilisation</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Echanger erreur</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Echanger erreur</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Echange terminé</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Echange terminé</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Echange des instances appareils...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Echange des instances appareils...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>L'instance d'appareil %1 est déjà utilisée par '%3'. Échanger les instances d'appareil et les attribuer à %2 ?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>L&apos;instance d&apos;appareil %1 est déjà utilisée par &apos;%3&apos;. Échanger les instances d&apos;appareil et les attribuer à %2&#xa0;?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>L'instance d'appareil %1 est déjà utilisée par un autre appareil du même type. Échanger les instances d'appareil et les attribuer à %2 ?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>L&apos;instance d&apos;appareil %1 est déjà utilisée par un autre appareil du même type. Échanger les instances d&apos;appareil et les attribuer à %2&#xa0;?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Impossible d'échanger les instances d'appareil : l'opération a expiré.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Impossible d&apos;échanger les instances d&apos;appareil&#xa0;: l&apos;opération a expiré.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Les nouvelles instances appareils seront actives au redémarrage.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Les nouvelles instances appareils seront actives au redémarrage.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Echange</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Echange</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Erreur lors de la recherche de mises à jour micrologiciel</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Erreur lors de la recherche de mises à jour micrologiciel</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Téléchargement et installation en cours micrologiciel %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Téléchargement et installation en cours micrologiciel %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Installation en cours micrologiciel...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Installation en cours micrologiciel...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Erreur lors de l’installation du micrologiciel</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Erreur lors de l’installation du micrologiciel</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Aucune version plus récente disponible</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Aucune version plus récente disponible</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Aucun micrologiciel trouvé</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Aucun micrologiciel trouvé</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Carburant</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Carburant</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Eau douce</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Eau douce</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Eaux usées</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Eaux usées</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Vivier</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Vivier</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Huile</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Huile</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Eaux Noires</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Eaux Noires</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Essence</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Essence</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diesel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diesel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>GPL</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>GPL</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>GNL</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>GNL</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Huile hydraulique</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Huile hydraulique</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Eau non traitée</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Eau non traitée</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Paramétrage bloqué pour niveau d'accès</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Paramétrage bloqué pour niveau d&apos;accès</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Mot de passe incorrect</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Mot de passe incorrect</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>En bref</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>En bref</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Vue d'ensemble</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Vue d&apos;ensemble</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Niveaux</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Niveaux</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Notifications</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Notifications</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>maintenant</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>maintenant</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>Il y a %1m</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>Il y a %1m</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>Il y a %1h %2m</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>Il y a %1h %2m</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Chaque jour</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Chaque jour</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Jours de semaine</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Jours de semaine</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Weekends</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Weekends</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Lundi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Lundi</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Mardi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Mardi</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Mercredi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Mercredi</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Jeudi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Jeudi</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Vendredi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Vendredi</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Samedi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Samedi</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Dimanche</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Dimanche</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 ou %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 ou %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Programme %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Programme %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Jour</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Jour</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Non reglé</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Non reglé</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Limite SOC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Limite SOC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Autoconsommation supérieure à la limite</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Autoconsommation supérieure à la limite</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>PV &amp; Batterie</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>PV &amp; Batterie</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Vérification en cours...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Vérification en cours...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>État alarme</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>État alarme</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarme</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Effacer l'historique</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Effacer l&apos;historique</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Effacement en cours</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Effacement en cours</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Mode forcé activé</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Mode forcé activé</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Mode forcé désactivé</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Mode forcé désactivé</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>État relais</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>État relais</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Réinitialiser l'historique sur le moniteur lui même</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Réinitialiser l&apos;historique sur le moniteur lui même</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Appuyer pour éjecter</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Appuyer pour éjecter</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Éjection en cours, patientez</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Éjection en cours, patientez</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Aucun stockage trouvé</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Aucun stockage trouvé</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 sonde de température</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 sonde de température</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 sonde de température (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 sonde de température (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Sonde de température (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Sonde de température (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Pas d'actions</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Pas d&apos;actions</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Attention : Les températures d'activation et de désactivation sont réglées à la même valeur. Cela conduira à ignorer la condition.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Attention : Les températures d&apos;activation et de désactivation sont réglées à la même valeur. Cela conduira à ignorer la condition.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Condition %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Condition %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Fonction désactivée</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Fonction désactivée</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Aucun (désactiver)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Aucun (désactiver)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relai 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relai 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relai 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relai 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Avertissement : Le relai sélectionné ci-dessus n'est pas configuré pour la température, cette condition sera ignorée.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Avertissement : Le relai sélectionné ci-dessus n&apos;est pas configuré pour la température, cette condition sera ignorée.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Valeur d'activation</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Valeur d&apos;activation</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Unité de volume</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Unité de volume</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Mètres cubes</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Mètres cubes</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Litres (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Litres (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Gallons (US)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Gallons (US)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Gallons (Impériaux)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Gallons (Impériaux)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Tension Min</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Tension Min</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Tension Max</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Tension Max</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Tension Max</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Courant Max</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Courant Max</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Temps de charge</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Temps de charge</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Float</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Float</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Float</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>hr</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>hr</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 erreur(s) produite(s)</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 erreur(s) produite(s)</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Dernier</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Dernier</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2ème dernier</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2ème dernier</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3ème dernier</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3ème dernier</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4ème dernier</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4ème dernier</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Puissance Max</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Puissance Max</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Connexion impossible</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Connexion impossible</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Déconnecté, tentative de reconnexion</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Déconnecté, tentative de reconnexion</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Connexion en cours</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Connexion en cours</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Connexion en cours</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Connecté, en attente des messages du broker</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Connecté, en attente des messages du broker</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Connecté, réception des messages du broker</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Connecté, réception des messages du broker</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Connecté, charge en cours interface utilisateur</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Connecté, charge en cours interface utilisateur</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Version de protocol invalide</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Version de protocol invalide</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>ID client rejeté</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>ID client rejeté</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Broker service indisponible</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Broker service indisponible</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Mauvais nom d'utilisateur ou mot de passe</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Mauvais nom d&apos;utilisateur ou mot de passe</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Client non autorisé</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Client non autorisé</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Erreur connexion transport</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Erreur connexion transport</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Erreur violation protocol</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Erreur violation protocol</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Erreur protocol MQTT niveau 5</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Erreur protocol MQTT niveau 5</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Alarme en silencieux</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Alarme en silencieux</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Puissance totale</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Puissance totale</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1h %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1h %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Défaillance</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Défaillance</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Extraction en cours adresse IP</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Extraction en cours adresse IP</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connecté</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Déconnecter</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Déconnecter</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Déconnecté</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>Charges CA</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>Charges CA</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>Charges DC</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>Charges DC</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>Chargeur VE</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>Chargeur VE</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Eolien</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Eolien</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Quai</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Quai</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Limite de courant réseau</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Limite de courant réseau</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Limite de courant générateur</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Limite de courant générateur</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Limite de courant de quai</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Limite de courant de quai</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Arrêt en cours</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Arrêt en cours</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Arrêt en cours</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 restant</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 restant</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 réservoir (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 réservoir (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>Chargeur CA</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>Chargeur CA</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Alternateur</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Alternateur</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>Chargeur DC</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>Chargeur DC</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Générateur DC</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Générateur DC</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>Système DC</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>Système DC</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Pile à combustible</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Pile à combustible</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Générateur sur l'arbre</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Générateur sur l&apos;arbre</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Turbine à eau</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Turbine à eau</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Eolienne</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Eolienne</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Basse</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Basse</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Élevé(e)</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Élevé(e)</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Maintenir les batteries chargées</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Maintenir les batteries chargées</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimisé avec batterylife</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimisé avec batterylife</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimisé sans batterylife</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimisé sans batterylife</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Contrôle externe</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Chargé</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Chargé</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>En attente d'ensoleillement</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>En attente d&apos;ensoleillement</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>En attente de RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>En attente de RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>En attente de démarrage</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>En attente de démarrage</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Erreur test mise à la terre</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Erreur test mise à la terre</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Erreur test entrée CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Erreur test entrée CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Courant résiduel détecté</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Courant résiduel détecté</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Sous-tension détectée</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Sous-tension détectée</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Surtension détectée</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Surtension détectée</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Surchauffe détectée</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Surchauffe détectée</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Limite de charge</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Limite de charge</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Début de la charge</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Début de la charge</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Plannifié</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Plannifié</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Plannifié</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Préchauffage</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Préchauffage</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Refroidissement</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Refroidissement</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Test de fonctionnement</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Test de fonctionnement</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Démarré manuellement</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Démarré manuellement</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Démarrage en cours</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Démarrage en cours</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>En marche (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>En marche (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>En marche (accéléré)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>En marche (accéléré)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relai %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relai %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Défaillance</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Défaillance</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorption</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorption</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Stockage</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Stockage</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Égalisation</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Égalisation</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Contrôle externe</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Mode AES</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Mode AES</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Condition défaut</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Condition défaut</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Charge Bulk</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Charge Bulk</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Charge Absorption</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Charge Absorption</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Charge Float</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Charge Float</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Mode stockage</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Mode stockage</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Charge d'égalisation</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Charge d&apos;égalisation</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Passant</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Passant</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Conversion</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Conversion</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Assistance</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Assistance</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Mode Alimentation</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Mode Alimentation</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Maintenir</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Réveil</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Réveil</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Absorption répétée</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Absorption répétée</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Égalisation auto</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Égalisation auto</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <extracomment>is it the same than BatterySafe ?</extracomment>
-      <translation>BatterySafe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>BatterySafe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Détection de charge</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Détection de charge</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Bloqué</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Bloqué</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamic ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dynamic ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dynamic ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Maître Groupe</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Maître Groupe</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Maître Instance</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Maître Instance</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Maître Groupe &amp; Instance</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Maître Groupe &amp; Instance</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Autonome &amp; Maitre Groupe</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Autonome &amp; Maitre Groupe</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Chargeur uniquement</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Chargeur uniquement</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Onduleur uniquement</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Onduleur uniquement</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Alarme de tension de batterie faible</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Alarme de tension de batterie élevée</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Alarme de court-circuit</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Alarme de court-circuit</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Désactiver le point d'accès</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Désactiver le point d&apos;accès</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Entrée DC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Entrée DC</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Pour les piles au lithium, une charge inférieure à 10 % n'est pas recommandée. Pour les autres types de piles, vérifiez la fiche technique pour connaître le niveau minimum recommandé par le fabricant.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Pour les piles au lithium, une charge inférieure à 10 % n&apos;est pas recommandée. Pour les autres types de piles, vérifiez la fiche technique pour connaître le niveau minimum recommandé par le fabricant.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Désactiver le démarrage automatique ?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Désactiver le démarrage automatique ?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Onduleur/Chargeur (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Onduleur/Chargeur (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Affichage de l'utilisation de l'unité centrale</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Affichage de l&apos;utilisation de l&apos;unité centrale</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Quitter l'application</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Quitter l&apos;application</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Démissionner</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Démissionner</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Version de l'application</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Version de l&apos;application</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Température de l'huile</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Température de l&apos;huile</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Notez que la modification du réglage de l'étage de décharge Time-to-go modifie également le réglage de l'état de charge bas dans le menu des relais.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Notez que la modification du réglage de l&apos;étage de décharge Time-to-go modifie également le réglage de l&apos;état de charge bas dans le menu des relais.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Durée de fonctionnement</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Durée de fonctionnement</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Ah chargés</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Ah chargés</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Cycles démarrés</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Cycles démarrés</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Cycles terminés</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Cycles terminés</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Nombre d'allumages</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Nombre d&apos;allumages</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Nombre de décharges profondes</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Nombre de décharges profondes</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Historique du cycle de charge</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Historique du cycle de charge</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Valeur du capteur quand plein</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Valeur du capteur quand plein</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Délai de mise en service</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Délai de mise en service</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Fonctionnalité de démarrage automatique</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Fonctionnalité de démarrage automatique</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Assurez-vous que le générateur n'est pas connecté à l'entrée AC %1 lorsque vous utilisez cette option.</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Assurez-vous que le générateur n&apos;est pas connecté à l&apos;entrée AC %1 lorsque vous utilisez cette option.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>La minuterie de service a été réinitialisée</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>La minuterie de service a été réinitialisée</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Le balayage continu peut interférer avec le fonctionnement du Wi-Fi.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Le balayage continu peut interférer avec le fonctionnement du Wi-Fi.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Plages minimales et maximales de la jauge</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Plages minimales et maximales de la jauge</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Page d&apos;accueil</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Redémarrage de l'application...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Redémarrage de l&apos;application...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Le changement de langue a échoué !</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Le changement de langue a échoué !</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Jamais</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Veuillez patienter pendant le changement de langue.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Veuillez patienter pendant le changement de langue.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Vue d'ensemble de l'unité</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Vue d&apos;ensemble de l&apos;unité</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Pas d'étiquettes</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Pas d&apos;étiquettes</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Afficher les volumes des réservoirs</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Afficher les volumes des réservoirs</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Afficher les pourcentages</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Afficher les pourcentages</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Remarque : Si le courant ne peut pas être affiché (par exemple, lors de l'affichage d'un total pour les sources combinées CA et CC), la puissance sera affichée à la place.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Remarque : Si le courant ne peut pas être affiché (par exemple, lors de l&apos;affichage d&apos;un total pour les sources combinées CA et CC), la puissance sera affichée à la place.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Charge Limites de courant</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Charge Limites de courant</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Communiqué officiel</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Communiqué officiel</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Version Beta</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Version Beta</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Essais (internes à Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Essais (internes à Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Développer (Victron interne)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Développer (Victron interne)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Redémarrage en cours...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Redémarrage en cours...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Activer les LED d'état</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Activer les LED d&apos;état</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Échauffement et récupération</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Échauffement et récupération</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Temps d'arrêt du générateur</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Temps d&apos;arrêt du générateur</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarme lorsque le générateur n'est pas en mode de démarrage automatique</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarme lorsque le générateur n&apos;est pas en mode de démarrage automatique</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Une alarme se déclenche lorsque la fonction de démarrage automatique est désactivée pendant plus de 10 minutes.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Une alarme se déclenche lorsque la fonction de démarrage automatique est désactivée pendant plus de 10 minutes.</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Autoconsommation de la batterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Autoconsommation de la batterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Toutes les charges du système</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Toutes les charges du système</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Seulement les charges critiques</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Seulement les charges critiques</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">SOC minimum (Sauf défaillance réseau)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>État de l'autonomie de la batterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>État de l&apos;autonomie de la batterie</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Accédez au signal K sur http://venus.local:3000 et via VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Accédez au signal K sur http://venus.local:3000 et via VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Accédez à Node-RED sur https://venus.local:1881 et via VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Accédez à Node-RED sur https://venus.local:1881 et via VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Mesures de la batterie</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Mesures de la batterie</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>État du système</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>État du système</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Liste Appareils</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Liste Appareils</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Instances du dispositif VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Instances du dispositif VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Alarme de température élevée</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Alarme de température élevée</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Contrôlé par BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Contrôlé par BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarmes et erreurs</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarmes et erreurs</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Cette fonction nécessite la version 400 ou supérieure du micrologiciel. Contactez votre installateur pour mettre à jour votre Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Cette fonction nécessite la version 400 ou supérieure du micrologiciel. Contactez votre installateur pour mettre à jour votre Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Le chargeur n'est pas prêt, l'égalisation ne peut pas être lancée</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Le chargeur n&apos;est pas prêt, l&apos;égalisation ne peut pas être lancée</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>L'égalisation ne peut pas être déclenchée pendant l'étape de bluk</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>L&apos;égalisation ne peut pas être déclenchée pendant l&apos;étape de bluk</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Éco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Éco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Courant maximal</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Courant maximal</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Puissance maximale</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Puissance maximale</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Courant minimum</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Courant minimum</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Aucune</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Indisponible</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Off</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Historique général</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Historique général</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Paramètres</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Inconnu</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Production aujourd'hui</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Production aujourd&apos;hui</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware installé, appareil redémarré</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware installé, appareil redémarré</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Contrôle de l'entrée tactile</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Contrôle de l&apos;entrée tactile</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Erreur de test des contacts soudés (court-circuit)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Erreur de test des contacts soudés (court-circuit)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Passage au triphasé</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Passage au triphasé</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Passage à une phase</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Passage à une phase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Arrêter le chargement</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Arrêter le chargement</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Réservé</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Réservé</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Mode onduleur</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Mode onduleur</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Sortie CA L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Sortie CA L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Entrée</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Entrée</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Passthrough</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Passthrough</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>La page sera automatiquement rechargée dans dix secondes pour afficher la dernière version.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>La page sera automatiquement rechargée dans dix secondes pour afficher la dernière version.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Onduleur (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Onduleur (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Convertisseurs/Chargeurs</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Convertisseurs/Chargeurs</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Aucun compteur d'énergie trouvé
+        <translation>Aucun compteur d&apos;énergie trouvé
 
-Notez que ce menu n'affiche que les compteurs Carlo Gavazzi connectés par RS485. Pour tout autre compteur, y compris les compteurs Carlo Gavazzi connectés par Ethernet, consultez plutôt le menu des appareils Modbus TCP/UDP.</translation>
+Notez que ce menu n&apos;affiche que les compteurs Carlo Gavazzi connectés par RS485. Pour tout autre compteur, y compris les compteurs Carlo Gavazzi connectés par Ethernet, consultez plutôt le menu des appareils Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Auto-rangement</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Auto-rangement</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Lorsque cette option est activée, les minima et maxima des jauges et des graphiques sont automatiquement ajustés en fonction des valeurs passées.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Lorsque cette option est activée, les minima et maxima des jauges et des graphiques sont automatiquement ajustés en fonction des valeurs passées.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Remise à zéro de toutes les valeurs de la plage</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Remise à zéro de toutes les valeurs de la plage</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Remise à zéro des valeurs de la plage</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Remise à zéro des valeurs de la plage</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Êtes-vous sûr de vouloir remettre toutes les valeurs à zéro ?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Êtes-vous sûr de vouloir remettre toutes les valeurs à zéro ?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Courant maximum : AC en 1 connecté</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Courant maximum : AC en 1 connecté</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Courant maximum : AC en 2 connecté</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Courant maximum : AC en 2 connecté</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Courant maximal : pas d'entrées AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Courant maximal : pas d&apos;entrées AC</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>Sortie DC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>Sortie DC</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solaire</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solaire</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Tr/min Moteur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Tr/min Moteur</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Température moteur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Température moteur</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Contrôleur température</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Contrôleur température</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Cycle actif</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Cycle actif</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Cycle %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Cycle %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>Déconnexion DC</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>Déconnexion DC</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Éteint</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Éteint</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Changement de fonction</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Changement de fonction</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Mise à jour du micrologiciel</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Mise à jour du micrologiciel</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Réinitialisation du logiciel</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Réinitialisation du logiciel</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Incomplet</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Incomplet</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Temps écoulé</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Temps écoulé</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Charge / maintien (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Charge / maintien (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Batterie (V&lt;sub&gt;début&lt;/sub&gt;/V&lt;sub&gt;fin&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Batterie (V&lt;sub&gt;début&lt;/sub&gt;/V&lt;sub&gt;fin&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Tension de sortie CA faible</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Tension de sortie CA faible</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Tension de sortie CA élevée</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Tension de sortie CA élevée</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Production totale</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Production totale</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Champ système</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Champ système</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Historique quotidien</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Historique quotidien</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Pas d'alarmes devant être configurées</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Pas d&apos;alarmes devant être configurées</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Tension PV maximale</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Tension PV maximale</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Tension maximale de la batterie</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Tension maximale de la batterie</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Tension minimale de la batterie</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Tension minimale de la batterie</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Erreur du banc de batteries</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Erreur du banc de batteries</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>La tension de la batterie n'est pas prise en charge</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>La tension de la batterie n&apos;est pas prise en charge</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Nombre incorrect de piles</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Nombre incorrect de piles</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Configuration invalide de la batterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Configuration invalide de la batterie</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Etat de l'équilibreur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Etat de l&apos;équilibreur</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Equilibré</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Equilibré</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Déséquilibre</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Déséquilibre</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Utiliser cette option dans les systèmes qui ne font pas d'écrêtage.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Utiliser cette option dans les systèmes qui ne font pas d&apos;écrêtage.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Utilisez cette option pour l'écrêtement des pointes.</translation>
+        <translation>Utilisez cette option pour l&apos;écrêtement des pointes.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Le seuil d'écrêtage est défini à l'aide du réglage de la limite du courant d'entrée CA. Voir la documentation pour plus d'informations.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Le seuil d&apos;écrêtage est défini à l&apos;aide du réglage de la limite du courant d&apos;entrée CA. Voir la documentation pour plus d&apos;informations.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Les seuils d'écrêtement des pointes pour l'importation et l'exportation peuvent être modifiés sur cet écran. Voir la documentation pour plus d'informations.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Les seuils d&apos;écrêtement des pointes pour l&apos;importation et l&apos;exportation peuvent être modifiés sur cet écran. Voir la documentation pour plus d&apos;informations.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Limiter le courant d'importation AC du système</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Limiter le courant d&apos;importation AC du système</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Pour utiliser cette fonction, le compteur de réseau doit être réglé sur Compteur externe et un assistant ESS à jour doit être installé.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Pour utiliser cette fonction, le compteur de réseau doit être réglé sur Compteur externe et un assistant ESS à jour doit être installé.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Courant d'importation maximal du système (par phase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Courant d&apos;importation maximal du système (par phase)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Pour utiliser cette fonction, le compteur de réseau doit être réglé sur Compteur externe.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Pour utiliser cette fonction, le compteur de réseau doit être réglé sur Compteur externe.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Courant d'exportation maximal du système (par phase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Courant d&apos;exportation maximal du système (par phase)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Câblés</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Câblés</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">En bref</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Charge du système élevée, fermeture du panneau latéral pour réduire la charge du CPU</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Charge du système élevée, fermeture du panneau latéral pour réduire la charge du CPU</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Limite de courant d'entrée</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Limite de courant d&apos;entrée</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Court-circuit</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Court-circuit</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Achat</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Achat</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Vente</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Vente</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Cible SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Cible SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>Sortie AC %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>Sortie AC %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Traceurs</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Traceurs</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Dispositifs RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Dispositifs RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Mettre en pause les animations des électrons</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Mettre en pause les animations des électrons</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Capacité totale</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Capacité totale</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Nombre de BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Nombre de BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Limiter le courant d'exportation CA du système</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Limiter le courant d&apos;exportation CA du système</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Appareils Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Appareils Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Ajouter un appareil</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Ajouter un appareil</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Rechercher des appareils</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Rechercher des appareils</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Dispositifs enregistrés</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Dispositifs enregistrés</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Dispositifs découverts</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Dispositifs découverts</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Ajouter un dispositif Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Ajouter un dispositif Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protocole</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protocole</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Port</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Port</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Unité</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Unité</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Aucun dispositif Modbus n'est sauvegardé</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Aucun dispositif Modbus n&apos;est sauvegardé</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Dispositif %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Dispositif %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Supprimer le dispositif Modbus ?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Supprimer le dispositif Modbus ?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Aucun dispositif Modbus n'a été découvert</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Aucun dispositif Modbus n&apos;a été découvert</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Batterie %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Batterie %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>Courant CA</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>Courant CA</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Démarrage/arrêt groupe électrogène désactivé</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Démarrage/arrêt groupe électrogène désactivé</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>La fonctionnalité de démarrage à distance est désactivée sur le groupe électrogène. Le GX ne pourra pas démarrer ou arrêter le groupe électrogène pour le moment. Activez-le sur le panneau de commande du groupe électrogène.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>La fonctionnalité de démarrage à distance est désactivée sur le groupe électrogène. Le GX ne pourra pas démarrer ou arrêter le groupe électrogène pour le moment. Activez-le sur le panneau de commande du groupe électrogène.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Fonction de démarrage auto</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Fonction de démarrage auto</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Durée d&apos;exécution actuelle</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>État du contrôle</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>État du contrôle</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>État du groupe électrogène</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>État du groupe électrogène</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Mode démarrage à distance</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Mode démarrage à distance</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Pression d'huile</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Pression d&apos;huile</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Niveaux de charge plannifiés</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Niveaux de charge plannifiés</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Actif (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Actif (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Arrêt manuel</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Arrêt manuel</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Circuit ouvert</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Circuit ouvert</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (non disponible)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (non disponible)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Entrée tactile on</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Entrée tactile on</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Entrée tactile off</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Entrée tactile off</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Entrée tactile désactivée</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Entrée tactile désactivée</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Accuser réception des alertes</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Accuser réception des alertes</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Code d'erreur de contrôle</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Code d&apos;erreur de contrôle</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Ce menu permet de définir les données relatives à la batterie qui s'affichent lorsque l'on clique sur l'icône Batterie de la page Vue d'ensemble. La même sélection est également visible sur le portail VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Ce menu permet de définir les données relatives à la batterie qui s&apos;affichent lorsque l&apos;on clique sur l&apos;icône Batterie de la page Vue d&apos;ensemble. La même sélection est également visible sur le portail VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Tension du système [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Tension du système [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Information de connexion</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Information de connexion</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Veuillez sélectionner...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Veuillez sélectionner...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Sécurisé</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Sécurisé</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Protection par mot de passe et cryptage de la communication réseau</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Protection par mot de passe et cryptage de la communication réseau</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Faible</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Faible</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Protégé par un mot de passe, mais la communication réseau n'est pas cryptée</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Protégé par un mot de passe, mais la communication réseau n&apos;est pas cryptée</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Non garanti</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Non garanti</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Pas de mot de passe et la communication réseau n'est pas cryptée</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Pas de mot de passe et la communication réseau n&apos;est pas cryptée</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Le mot de passe doit comporter au moins 8 caractères</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Saisir mot de passe</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Le mot de passe doit comporter au moins 8 caractères</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Le mot de passe doit comporter au moins 8 caractères</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Sélectionner le profil "sécurisé" ?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Sélectionner le profil &quot;sécurisé&quot; ?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Sélectionner le profil "faible" ?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Sélectionner le profil &quot;faible&quot; ?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Sélectionner le profil "non sécurisé" ?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Sélectionner le profil &quot;non sécurisé&quot; ?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Les services du réseau local sont protégés par un mot de passe
+        <translation>- Les services du réseau local sont protégés par un mot de passe
 - La communication réseau est cryptée
 - Une connexion sécurisée avec le VRM est activée
 - Les paramètres non sécurisés ne peuvent pas être activés</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Les services du réseau local sont protégés par un mot de passe
-- L'accès non crypté aux sites web locaux est également activé (HTTP/HTTPS).</translation>
+        <translation>- Les services du réseau local sont protégés par un mot de passe
+- L&apos;accès non crypté aux sites web locaux est également activé (HTTP/HTTPS).</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Les services du réseau local ne nécessitent pas de mot de passe
-- L'accès non crypté aux sites web locaux est également autorisé (HTTP/HTTPS).</translation>
+        <translation>- Les services du réseau local ne nécessitent pas de mot de passe
+- L&apos;accès non crypté aux sites web locaux est également autorisé (HTTP/HTTPS).</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Mot de passe racine</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Mot de passe racine</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Déconnexion</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Déconnexion</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Se déconnecter</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Se déconnecter</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Déconnexion ?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Déconnexion ?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Cette opération déconnecte toutes les connexions du réseau local.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Cette opération déconnecte toutes les connexions du réseau local.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Déconnexion</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Déconnexion</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Lecture seule</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Lecture seule</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Complet</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Complet</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Êtes-vous sûr ?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Êtes-vous sûr ?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>La modification de ce paramètre en lecture seule ou en désactivation vous bloquera.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>La modification de ce paramètre en lecture seule ou en désactivation vous bloquera.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Accès MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Accès MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' n'est pas un nombre.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; n&apos;est pas un nombre.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Confirmer</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Confirmer</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Utilisez un nombre avec %1 chiffres ou moins.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Utilisez un nombre avec %1 chiffres ou moins.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' n'est pas une adresse IP valide.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; n&apos;est pas une adresse IP valide.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' n'est pas un numéro de port valide. Utilisez un numéro compris entre 0 et 65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; n&apos;est pas un numéro de port valide. Utilisez un numéro compris entre 0 et 65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 n'est pas un numéro d'unité valide. Utilisez un nombre compris entre 1 et 247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 n&apos;est pas un numéro d&apos;unité valide. Utilisez un nombre compris entre 1 et 247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Durée d'exécution actuelle</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Durée d&apos;exécution actuelle</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Codes d'erreur du groupe électrogène</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Codes d&apos;erreur du groupe électrogène</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Température du radiateur</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Température du radiateur</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Tension de charge</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>La tension de charge est actuellement contrôlée par le BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>La tension de charge est actuellement contrôlée par le BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Limite de courant de charge</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Limite de courant de charge</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>Contrôlé par BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>Contrôlé par BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Le contrôle du BMS est activé automatiquement si un BMS est présent. Réinitialisez-le si la configuration du système a été modifiée ou s'il n'y a pas de BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Le contrôle du BMS est activé automatiquement si un BMS est présent. Réinitialisez-le si la configuration du système a été modifiée ou s&apos;il n&apos;y a pas de BMS.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Minuterie de service désactivée.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Minuterie de service désactivée.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Portail VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Portail VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (accès VPN à distance)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (accès VPN à distance)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Un profil de sécurité doit être configuré avant que les services réseau puissent être activés, voir Paramètres - Général</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Un profil de sécurité doit être configuré avant que les services réseau puissent être activés, voir Paramètres - Général</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' a été remplacé par '%2' car il contenait des caractères non valides.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; a été remplacé par &apos;%2&apos; car il contenait des caractères non valides.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Initialisation...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Initialisation...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Backend débutant...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Backend débutant...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend arrêté.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend arrêté.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>La connexion a échoué.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>La connexion a échoué.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Cet appareil GX est déconnecté de Tailscale.
+        <translation>Cet appareil GX est déconnecté de Tailscale.
 
 Veuillez patienter ou vérifier votre connexion internet.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>En attente d'une réponse de Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>En attente d&apos;une réponse de Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Connectez cet appareil GX à votre compte Tailscale en ouvrant ce lien :</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Connectez cet appareil GX à votre compte Tailscale en ouvrant ce lien :</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Veuillez patienter ou vérifier votre connexion internet.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Veuillez patienter ou vérifier votre connexion internet.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>État inconnu : #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>État inconnu : #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Erreur : %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Erreur : %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Désactiver Tailscale pour modifier ces paramètres.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Désactiver Tailscale pour modifier ces paramètres.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Activer Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Activer Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Nom de la machine</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Nom de la machine</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Déconnexion du compte Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Déconnexion du compte Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Accès au réseau local</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Accès au réseau local</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Accès au réseau local ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Accès au réseau local ethernet</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Accéder au réseau WiFi local</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Accéder au réseau WiFi local</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Réseau(x) personnalisé(s)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Réseau(x) personnalisé(s)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Exemple : 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Exemple : 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Explication :
+        <translation>Explication :
 
-Cette fonction, appelée routes de sous-réseau par Tailscale, permet d'accéder à distance à d'autres appareils sur le(s) réseau(x) local(aux).
+Cette fonction, appelée routes de sous-réseau par Tailscale, permet d&apos;accéder à distance à d&apos;autres appareils sur le(s) réseau(x) local(aux).
 
 Le champ réseaux personnalisés accepte une liste de sous-réseaux en notation CIDR séparée par des virgules.
 
-Après avoir ajouté/activé un nouveau réseau, vous devez l'approuver une fois dans la console d'administration de Tailscale.</translation>
+Après avoir ajouté/activé un nouveau réseau, vous devez l&apos;approuver une fois dans la console d&apos;administration de Tailscale.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Arguments personnalisés "tailscale up</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Arguments personnalisés &quot;tailscale up</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>URL du serveur personnalisé (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>URL du serveur personnalisé (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Ce contrôleur de groupe électrogène nécessite un relais d'assistance pour être contrôlé, mais le relais d'assistance n'est pas configuré. Veuillez configurer le relais 1 sous Paramètres → Relais sur "Relais d'assistance du groupe électrogène connecté".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Ce contrôleur de groupe électrogène nécessite un relais d&apos;assistance pour être contrôlé, mais le relais d&apos;assistance n&apos;est pas configuré. Veuillez configurer le relais 1 sous Paramètres → Relais sur &quot;Relais d&apos;assistance du groupe électrogène connecté&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarmes de tension élevée de la batterie de démarrage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarmes de tension élevée de la batterie de démarrage</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Sauter l'échauffement du générateur</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Sauter l&apos;échauffement du générateur</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Up, mais pas de services (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Up, mais pas de services (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Le mot de passe racine a été changé en %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Le mot de passe racine a été changé en %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Relais d'aide du groupe électrogène connecté</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Relais d&apos;aide du groupe électrogène connecté</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Position des charges CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Position des charges CA</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Entrée et sortie AC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Entrée et sortie AC</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Utilisez cette option lorsque des charges CA sont présentes sur l'entrée de l'onduleur/du chargeur. Utiliser cette option en cas de doute.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Utilisez cette option lorsque des charges CA sont présentes sur l&apos;entrée de l&apos;onduleur/du chargeur. Utiliser cette option en cas de doute.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Sortie AC uniquement</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Sortie AC uniquement</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Utilisez cette option lorsque le système utilise un compteur de réseau, mais que toutes les charges CA sont sur la sortie de l'onduleur/chargeur.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Utilisez cette option lorsque le système utilise un compteur de réseau, mais que toutes les charges CA sont sur la sortie de l&apos;onduleur/chargeur.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Mensuel</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Mensuel</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>EVCS</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>EVCS</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Pompe à chaleur</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Pompe à chaleur</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Charges essentielles</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Charges essentielles</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Démarrer et arrêter le générateur en fonction des conditions de démarrage automatique configurées.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Démarrer et arrêter le générateur en fonction des conditions de démarrage automatique configurées.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Paramètres du groupe électrogène CC</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Paramètres du groupe électrogène CC</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Température de l'alternateur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Température de l&apos;alternateur</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Température du moteur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Température du moteur</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Durée de fonctionnement totale</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Durée de fonctionnement totale</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Profil de sécurité du réseau</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Profil de sécurité du réseau</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Derniers %1 jours</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Derniers %1 jours</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Le générateur s'arrêtera dans %1 à moins que des conditions de démarrage automatique ne soient activées pour le maintenir en marche.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Le générateur s&apos;arrêtera dans %1 à moins que des conditions de démarrage automatique ne soient activées pour le maintenir en marche.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Le générateur fonctionnera jusqu'à ce qu'il soit arrêté manuellement, à moins que des conditions de démarrage automatique soient activées pour le maintenir en marche.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Le générateur fonctionnera jusqu&apos;à ce qu&apos;il soit arrêté manuellement, à moins que des conditions de démarrage automatique soient activées pour le maintenir en marche.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Interface classique</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Interface classique</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Nouvelle interface</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Nouvelle interface</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Changement de langue réussi !</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Limitation de la puissance</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Changement de langue réussi !</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Pour les appareils Multi-RS et HS19, les paramètres ESS sont disponibles sur la page produit du système RS.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Pour les appareils Multi-RS et HS19, les paramètres ESS sont disponibles sur la page produit du système RS.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Démarrage/arrêt du groupe électrogène</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Démarrage/arrêt du groupe électrogène</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Le changement de version du micrologiciel n'est pas possible si le "Profil de sécurité du réseau" dans "Paramètres / Général" n'est pas sélectionné.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Le changement de version du micrologiciel n&apos;est pas possible si le &quot;Profil de sécurité du réseau&quot; dans &quot;Paramètres / Général&quot; n&apos;est pas sélectionné.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Durée</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Durée</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Alarmes du système</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Alarmes du système</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Pas d'alarmes système</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Pas d&apos;alarmes système</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Retour</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Retour</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>What's new</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>What&apos;s new</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>passer</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>passer</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Bienvenue !</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Bienvenue !</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Nous sommes heureux de vous présenter une interface entièrement repensée qui améliore à la fois la convivialité et l'esthétique de votre GX.
+        <translation>Nous sommes heureux de vous présenter une interface entièrement repensée qui améliore à la fois la convivialité et l&apos;esthétique de votre GX.
 
-Avec une navigation simplifiée et un nouveau look, tout ce que vous aimez est maintenant encore plus facile d'accès et plus attrayant visuellement.</translation>
+Avec une navigation simplifiée et un nouveau look, tout ce que vous aimez est maintenant encore plus facile d&apos;accès et plus attrayant visuellement.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Mode Sombre - Clair</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Mode Sombre - Clair</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Des environnements différents nécessitent des réglages d'affichage différents. Les modes sombre et clair garantissent une expérience visuelle optimale, quel que soit l'endroit où vous vous trouvez.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Des environnements différents nécessitent des réglages d&apos;affichage différents. Les modes sombre et clair garantissent une expérience visuelle optimale, quel que soit l&apos;endroit où vous vous trouvez.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Toutes les informations clés dont vous avez besoin sont présentées dans une mise en page simple et claire. La pièce maîtresse est un widget personnalisable représentant des anneaux, qui vous permet d'accéder rapidement à vos informations sur le système en un coup d'œil.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Toutes les informations clés dont vous avez besoin sont présentées dans une mise en page simple et claire. La pièce maîtresse est un widget personnalisable représentant des anneaux, qui vous permet d&apos;accéder rapidement à vos informations sur le système en un coup d&apos;œil.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Vous bénéficiez d'un meilleur contrôle grâce à notre nouveau tableau de bord, qui contient des données en temps réel sur le système, le tout regroupé en un seul endroit pour faciliter la surveillance.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Vous bénéficiez d&apos;un meilleur contrôle grâce à notre nouveau tableau de bord, qui contient des données en temps réel sur le système, le tout regroupé en un seul endroit pour faciliter la surveillance.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Contrôles</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Contrôles</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Tous les contrôles utiles sont désormais regroupés dans le nouveau volet Contrôles. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Tous les contrôles utiles sont désormais regroupés dans le nouveau volet Contrôles. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watts &amp; Ampères</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watts &amp; Ampères</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Vous pouvez désormais basculer entre les Watts et les Ampères. Choisissez l'unité qui correspond le mieux à vos préférences.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Vous pouvez désormais basculer entre les Watts et les Ampères. Choisissez l&apos;unité qui correspond le mieux à vos préférences.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>En savoir plus</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>En savoir plus</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Accédez au lien ci-dessous pour en savoir plus sur la nouvelle interface utilisateur.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Accédez au lien ci-dessous pour en savoir plus sur la nouvelle interface utilisateur.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Scannez le code QR pour en savoir plus sur la nouvelle interface utilisateur.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Scannez le code QR pour en savoir plus sur la nouvelle interface utilisateur.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Effectué</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Effectué</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Suivant</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Suivant</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Erreur : #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Erreur : #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Erreur active</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Erreur active</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Durée de fonctionnement totale du générateur (heures)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Durée de fonctionnement totale du générateur (heures)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Page d'accueil</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Page d&apos;accueil</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Interface utilisateur</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Interface utilisateur</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Interface utilisateur (console à distance)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Interface utilisateur (console à distance)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 mis à jour</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 mis à jour</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>L'interface utilisateur passe à %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>L&apos;interface utilisateur passe à %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 est réglé sur %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Cet onduleur PV prend en charge la limitation de puissance. Désactivez ce paramètre s'il interfère avec le fonctionnement normal.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 est réglé sur %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Appuyez sur "OK" pour redémarrer</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Appuyez sur &quot;OK&quot; pour redémarrer</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Remise à zéro de Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Remise à zéro de Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Êtes-vous sûr de vouloir réinitialiser Node-RED aux paramètres d'usine ? Cela supprimera tous vos flux.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Êtes-vous sûr de vouloir réinitialiser Node-RED aux paramètres d&apos;usine ? Cela supprimera tous vos flux.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>État de la connexion</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>État de la connexion</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>État de la connexion (canal HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>État de la connexion (canal HTTPS)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>État de la connexion (canal HTTP)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>État de la connexion (canal HTTP)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>État de la connexion (canal MQTT en temps réel)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>État de la connexion (canal MQTT en temps réel)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>État de la connexion (canal MQTT RPC)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>État de la connexion (canal MQTT RPC)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Démarrage automatique • %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Démarrage automatique • %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Valeur de désactivation</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Valeur de désactivation</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Pas démarré</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Pas démarré</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Perte de communication</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Perte de communication</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>Condition % Batterie</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>Condition % Batterie</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>Condition consommation CA</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>Condition consommation CA</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Condition courant batterie</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Condition courant batterie</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Condition tension batterie</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Condition tension batterie</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Condition de surcharge de l'onduleur</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Condition de surcharge de l&apos;onduleur</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Charge/décharge désactivée</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Charge/décharge désactivée</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Charge désactivée</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Charge désactivée</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Décharge désactivée</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Décharge désactivée</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">En bref</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Slip (panneau latéral ouvert)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Slip (panneau latéral ouvert)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Vue d&apos;ensemble</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Niveaux (réservoirs)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Niveaux (réservoirs)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Niveaux (environnement)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Niveaux (environnement)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Liste des piles</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Liste des piles</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>Le dispositif GX a été mis à jour</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>Le dispositif GX a été mis à jour</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Après %n minute</numerusform>
-        <numerusform>Après %n minute</numerusform>
-        <numerusform>Après %n minute(s)</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Après %n minute</numerusform>
+            <numerusform>Après %n minute</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Rendez-vous sur cette page lorsque l'application démarre.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Rendez-vous sur cette page lorsque l&apos;application démarre.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Délai d'attente</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Délai d&apos;attente</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Revenir à la page d'accueil lorsque l'application est inactive.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Revenir à la page d&apos;accueil lorsque l&apos;application est inactive.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Après une minute d'inactivité, la page actuelle est sélectionnée comme page de démarrage, si elle figure dans cette liste.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Après une minute d&apos;inactivité, la page actuelle est sélectionnée comme page de démarrage, si elle figure dans cette liste.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Cette limite de courant est fixée dans la configuration du système. Elle ne peut pas être ajustée.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Cette limite de courant est fixée dans la configuration du système. Elle ne peut pas être ajustée.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Le mode est fixé dans la configuration du système. Il ne peut pas être ajusté.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Le mode est fixé dans la configuration du système. Il ne peut pas être ajusté.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>La fonction de démarrage/arrêt du générateur n'est pas activée, allez dans les réglages du relai et réglez la fonction sur "Arrêter/Démarrer Générateur".</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Heure standard Maroc</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Heure standard Afrique centrale ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Heure standard Afrique du sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Heure standard Namibie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Heure standard Égypte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Heure standard Afrique de l'est</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Heure standard Argentine</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Heure standard Est Amérique du  sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Heure standard Groenland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Heure standard Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Heure standard Terre-Neuve-et-Labrador</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Heure standard AS de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Heure standard Atlantique</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Heure standard Brésil centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Heure standard Pacifique Asie du sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Heure standard Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Heure standard AS de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Heure standard Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Heure standard de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Heure standard Pacifique AS</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Heure standard É-U de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Heure standard Canada centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Heure standard Amérique centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Heure standard du Centre (Mexique)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Heure standard du Centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Heure standard des Rocheuses (Mexique)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Heure standard des Rocheuses</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Heure standard montagne É-U</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Heure standard Pacifique (Mexique)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Heure standard Pacifique</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Heure standard Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aléoutien</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Heure standard Nouvelle Zélande</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Heure standard Pacifique centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Heure standard Pacifique de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Heure standard Australie de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Heure standard Asie S-E</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Heure standard Asie centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Heure standard Asie de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Heure standard Afrique de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Heure standard Pacifique Asie du sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Heure standard AS de l'ouest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Heure standard Europe de l'ouest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Heure standard Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Heure standard Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Heure standard Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Heure standaard Yakoutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Heure standard Tokyo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Heure standard Corée</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Heure standard Singapour</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Heure standard Oulanbator</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Heure standard Taïpei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Heure standard Nord Asie de l'Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Heure standard Chine</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Heure standard Asie S-E</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Heure standard Asie du nord</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Heure standard Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Heure standard Asie centrale du N</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Heure standard Asie centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Heure standard Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Heure standard Népal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Heure standard Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Heure standar Inde</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Heure standard Asie de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Heure standard Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Heure standard Ekaterinbourg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Heure standard Géorgie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Heure standard Caucase</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Heure standard Azerbaïdjan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Heure standard d'Arabie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Heure standard Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Heure standard Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Heure standard arabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Heure standard arabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Heure standard Syrie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Heure standard Moyen-Orient</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Heure standard Jordanie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Heure standard Israël</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Heure standard Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Heure standard Açores</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Heure standard Cap vert</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Heure standard Tasmanie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Heure standard Australie de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Heure standard AUS  de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Heure standard Australie centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Heure standard AUS  centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Heure standard Australie de l'ouest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Heure standard Mid-Atlantic</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Heure standard de la date</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Temps standard GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Temps standard Europe centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Temps standard européen central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Temps standard europe centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Heure standard Europe de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Temps standard europe de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Temps standard FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Temps standard GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Heure standard Biélorussie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Heure standard Russie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Heure standard Turquie</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Heure standard Ile Maurice</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Temps standard Ile Christmas</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Heure standard Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Heure standard Fidji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Heure standard Nouvelle Zélande</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Heure standard Pacifique centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Heure standard Pacifique de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Heure standard Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Heure standard Hawaï</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Temps standard Ile de Paques</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>La fonction de démarrage/arrêt du générateur n&apos;est pas activée, allez dans les réglages du relai et réglez la fonction sur &quot;Arrêter/Démarrer Générateur&quot;.</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Inconnu</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Production solaire</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Entrée DC</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">Charges CA</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">Charges DC</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Vue d&apos;ensemble</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">État</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Production totale</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Champ système</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Alarme uniquement</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarmes &amp; Avertissements</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Avertissement</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Aucune erreur</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Erreur inconnue : %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Erreur inconnue : %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Aucune erreur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Erreur d'initialisation de batterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Erreur d&apos;initialisation de batterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Aucune batterie connectée</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Aucune batterie connectée</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Batterie inconnue</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Batterie inconnue</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Types de batterie différents</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Types de batterie différents</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Nbr. de batterie incorrect</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Nbr. de batterie incorrect</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx shunt non trouvé</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx shunt non trouvé</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Erreur de mesure de batterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Erreur de mesure de batterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Erreur de calcul interne</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Erreur de calcul interne</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Nº de batteries en série incorrect</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Nº de batteries en série incorrect</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Erreur matérielle</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Erreur matérielle</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Erreur de surveillance</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Erreur de surveillance</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Surtension</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Surtension</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Sous-tension</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Sous-tension</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Surchauffe</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Surchauffe</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Température trop basse</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Température trop basse</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Pause due à une charge basse</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Pause due à une charge basse</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Erreur ACC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Erreur ACC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Erreur de batterie comm</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Erreur de batterie comm</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Erreur de pré-charge</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Erreur de pré-charge</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Erreur de contacteur de sécurité</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Erreur de contacteur de sécurité</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Erreur de mise à jour de batterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Erreur de mise à jour de batterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Erreur du câble BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Erreur du câble BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Défaut tension de référence</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Défaut tension de référence</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Tension de système erronée</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Tension de système erronée</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Temps de pré-charge dépassé</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Temps de pré-charge dépassé</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Défaillance ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Défaillance ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Données d'étalonnage perdues</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Données d&apos;étalonnage perdues</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Paramètres incorrects</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Paramètres incorrects</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Interlock</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Interlock</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Arrêt d'urgence</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Arrêt d&apos;urgence</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Délai de communication dépassé</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Délai de communication dépassé</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Verrouillage de sécurité</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Verrouillage de sécurité</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Surchauffe du terminal</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Surchauffe du terminal</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Aucune erreur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Température de batterie élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Tension de batterie élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Défaut de câblage sur Tsense de batterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Tsense de batterie manquante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Défaut de câblage Vsense de batterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Vsense de batterie manquante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Pertes élevées sur câble de batterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Tension de batterie basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Ondulation CC élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>État de charge faible de la batterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Problème de tension médiane de batterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Température de batterie trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Température de chargeur élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Courant excessif de chargeur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Courant de chargeur négatif</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Durée Bulk du chargeur expirée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problème sonde courant de chargeur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Défaut de câble Tsensor interne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Sonde tempér. interne manquante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Ventilateur du chargeur non détecté</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Surintensité ventilateur du chargeur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Surchauffe du terminal du chargeur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Court-circuit du chargeur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Problème d'étape de puissance sur le chargeur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Protection contre la surcharge</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Tension d'entrée élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Courant d'entrée excessif</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Puissance d'entrée excessive</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Problème de polarité sur entrée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Tension d'entrée absente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Arrêt d'entrée (pas d'autres tentatives)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Arrêt Entrée (essayer à nouveau)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Défaillance interne d'entrée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Erreur isolation PV</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Défaut de masse détecté</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Surcharge convertisseur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Temp. convertisseur trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Courant de crête de l'onduleur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Niveau CC interne de l'onduleur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Niveau de sortie CA de l'onduleur incorrect</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Défaut powerstage de l'onduleur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Onduleur connecté au secteur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Défaillance test relais ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Défaillante test relais ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Appareil disparu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Appareil incompatible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Connexion BLS perdue</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Réseau mal configuré</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Rotation de phase</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Entrées AC multiples</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Surcharge de phase</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Erreur d'écriture mémoire</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Température CPU trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Communication perdue</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Données d'étalonnage perdues</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Micrologiciel incompatible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Matériel incompatible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Paramètres incorrects</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Échec Tension de référence</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Échec testeur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Historique non valide</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Compteurs de kWh non valides</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Erreur de tension CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Erreur capteur GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>erreur alimentation 3V3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>erreur alimentation 5V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>erreur alimentation 12V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>erreur alimentation 15V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Déconnexion de l'entrée PV</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Placez l'interrupteur en position déverrouillée pour modifier les réglages.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Utiliser la source de données D-Bus : connectez-vous à l'adresse D-Bus spécifiée.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>Adresse</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Utiliser la source de données D-Bus : connectez-vous à l'adresse D-Bus par défaut</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Utiliser la source de données MQTT : connectez-vous à l'adresse du courtier MQTT spécifiée.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>Adresse</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>ID du portail du périphérique de source de données MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>IP Portail</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Fragment d'hébergement Web MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>fragment</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Nom d'utilisateur de la source de données MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Utilisateur</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Mot de passe de la source de données MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>Pass</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Jeton de source de données MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Jeton</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Activer le compteur FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Passer l'écran de démarrage</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Utilisez une source de données fictive pour les tests.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Appareil éteint</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Anciens/nouveaux MK2 mélangés</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Erreur d'appareils attendue</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Aucun autre appareil détecté</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Survoltage sur le CA de sortie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Erreur de programme DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>BMS du VE.Bus sans assistant</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Échec du test de relais de terre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Erreur synch.horaire système</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Défaut test du relais de réseau</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Différ. de config avec 2e mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Erreur de transmission appareil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Configuration en attente ou dongle manquant</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Maître de phase manquant</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Présence de survoltage</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>L'esclave n'e reçoit pas de CA !</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>L'appareil ne peut pas être esclave</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Protection du system démarrée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Incompatibilité du micrologiciel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Erreur interne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>L'échec du test de relais empêche la connexion</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Erreur VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Erreur inconnue :</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Erreur interne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Aucune erreur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Température de batterie élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Tension de batterie élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Tension de batterie basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Tenson de batterie dépassant le max configuré</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Température alternateur élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Vitesse alternateur élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Température élevée du FET de contrôle du champ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Capteur requis manquant</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Tension alternateur faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Décalage de tension alternateur élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Tension alternateur dépassant le max configuré</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Haute tension de l'alternateur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Batterie déconnectée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Déconnection tension batterie élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Instance batterie en dehors de la plage</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Trop de BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Batterie sur le point de se déconnecter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Trop d'appareils à suivre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Déconnection tension batterie faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Déconnection courant batterie élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Déconnection température batterie élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Déconnection température batterie faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Connexion BLS perdue</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC désactivé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>convertisseur DC/DC pas prêt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC tension primaire haute</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC tension primaire faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC tension secondaire haute</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC tension secondaire faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC température haute</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>mauvaise configuration DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Capteur de température de la batterie défectueux</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Erreur inconnue :</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Erreur inconnue :</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Température de batterie élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Tension de batterie élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Défaut de câblage sur Tsense de batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Tsense de batterie manquante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Défaut de câblage Vsense de batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Vsense de batterie manquante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Pertes élevées sur câble de batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Tension de batterie basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Ondulation CC élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>État de charge faible de la batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Problème de tension médiane de batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Température de batterie trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Température de chargeur élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Courant excessif de chargeur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Courant de chargeur négatif</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Durée Bulk du chargeur expirée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Problème sonde courant de chargeur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Défaut de câble Tsensor interne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Sonde tempér. interne manquante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Ventilateur du chargeur non détecté</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Surintensité ventilateur du chargeur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Surchauffe du terminal du chargeur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Court-circuit du chargeur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Problème d&apos;étape de puissance sur le chargeur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Protection contre la surcharge</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Tension d&apos;entrée élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Courant d&apos;entrée excessif</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Puissance d&apos;entrée excessive</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Problème de polarité sur entrée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Tension d&apos;entrée absente</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Arrêt d&apos;entrée (pas d&apos;autres tentatives)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Arrêt Entrée (essayer à nouveau)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Défaillance interne d&apos;entrée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Erreur isolation PV</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Défaut de masse détecté</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Surcharge convertisseur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Temp. convertisseur trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Courant de crête de l&apos;onduleur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Niveau CC interne de l&apos;onduleur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Niveau de sortie CA de l&apos;onduleur incorrect</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Défaut powerstage de l&apos;onduleur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Onduleur connecté au secteur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Défaillance test relais ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Défaillante test relais ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Appareil disparu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Appareil incompatible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Connexion BLS perdue</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Réseau mal configuré</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Rotation de phase</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Entrées AC multiples</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Surcharge de phase</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Erreur d&apos;écriture mémoire</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Température CPU trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Communication perdue</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Données d&apos;étalonnage perdues</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Micrologiciel incompatible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Matériel incompatible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Paramètres incorrects</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Échec Tension de référence</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Échec testeur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Historique non valide</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Compteurs de kWh non valides</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Erreur de tension CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Erreur capteur GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>erreur alimentation 3V3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>erreur alimentation 5V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>erreur alimentation 12V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>erreur alimentation 15V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Déconnexion de l&apos;entrée PV</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Erreur inconnue :</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Erreur inconnue :</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Erreur inconnue :</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Erreur inconnue :</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Aucune erreur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>Tension CA L1 trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>Tension CA trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Tension CA L1 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Tension CA trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Fréquence CA L1 trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Fréquence CA trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Fréquence CA L1 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Fréquence CA trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>Courant CA L1 trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>Courant CA trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Puissance CA L1 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>Puissance CA trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Arrêt d'urgence</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Courant servomoteur trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Pression d'huile trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Pression d'huile trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Température moteur trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Température moteur trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Température d'enroulement trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Température d'enroulement trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Température d'échappement trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Température d'échappement trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Température électronique basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Température électronique élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Tension de démarrage trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Courant de batterie de démarrage trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Tension de préchauffage trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Courant d'effluve trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Tension de l'aide au démarrage à froid trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Courant d'aide au démarrage à froid trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Tension de l'aimant de maintien du carburant trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Courant d'électroaimant de carburant trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Tension de la bobine de maintien du solénoïde d'arrêt trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Courant de bobine de fixation solenoïde d'arrêt trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Tension de la bobine de traction du solénoïde d'arrêt trop faible </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Courant de bobine de traction solenoïde d'arrêt trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Tension du ventilateur/de la pompe à eau trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Courant du ventilateur/de la pompe à eau trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Tension basse du capteur de courant</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Courant élevé du capteur de courant</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Tension de sortie de l'amplificateur trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Courant de sortie de pointe trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Tension d'alimentation du bus trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Courant d'alimentation du bus trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Tension de batterie de démarrage trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Tension de batterie de démarrage trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Rotation trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Rotation trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Arrêt inattendu/problème d'alimentation en carburant</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Tension du contacteur de puissance trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Courant de contacteur de puissance trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>Tension CA L2 trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Tension CA L2 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>Fréquence CA L2 trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Fréquence CA L2 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>Courant CA L2 trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>Puissance CA L2 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Tension CA L3 trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>Tension CA L3 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Fréquence CA L3 trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Fréquence CA L3 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>Courant CA L3 trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>Puissance CA L3 trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Sortie Tension de l'onduleur trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Sortie Courant de l'onduleur trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Tension de la sortie universelle (1A) trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Courant de la sortie universelle (1A) trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Tension de la sortie universelle (5A) trop faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Courant de sortie universel (5A) trop élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT Tension continue 1 faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>AGT Tension continue 1 élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT Courant continu 1 faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT Courant continu 1 élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>AGT Tension continue 2 faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Tension continue AGT 2 élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT Courant continu 2 faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT Courant continu 2 élevé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 cooler low</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 cooler high</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 rail (-) bas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 rail (-) haut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 rail (+) bas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 rail (+) haut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Température carburant trop basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Température carburant trop élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Niveau carburant trop bas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Unité de contrôle perdue</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Panneau perdu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Réparation nécessaire</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Module triphasé perdu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Module AGT perdu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Échec synchronisation</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Perte de l'ECU externe</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Filtre d'aspiration d'air</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Message de diagnostic (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Module sync. perdu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Échec équilibrage de charge</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Mode sync. désactivé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Feu rouge d'arrêt (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Lampe d'avertissement orange (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Témoin de dysfonctionnement (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Lampe de protection (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Champ de rotation incorrect</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Sonde de niveau de carburant perdue</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Démarrage sans onduleur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Le bus n° 1 est mort</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Demande de démarrage refusée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Démarrage à distance refusé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Interruption forcée du relais de charge</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Le module de synchronisation est hors ligne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>BMS perdu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Tension de liaison CC du convertisseur basse/inverse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Courant de liaison CC du convertisseur Faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Tension de précharge CC du convertisseur basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Convertisseur Tension de précharge CC élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Erreur du pilote du convertisseur IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Erreur du convertisseur Boucle de contrôle de puissance</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Détection de la fréquence CA du convertisseur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Défaut de la valeur de contrôle du convertisseur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Modification du réglage d'usine</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Paramètre modifié en mode administrateur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Intervention manuelle (système ext.)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Échec init.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Chien de garde</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Température élevée de l'onduleur L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Température élevée de l'onduleur L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Température de l'onduleur élevée L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Température de l'onduleur élevée Liaison DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Surcharge convertisseur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Communication convertisseur perdue</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Surcharge CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Surtension CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Pas de connexion</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Aucune erreur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Erreur inconnue : %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Erreur inconnue :</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Pression d'huile</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Surchauffe de la culasse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Contrôle de la charge</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Vitesse plus élevée que prévu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Survitesse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Température du pétrole plus élevée que prévu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Température de l'huile circuit ouvert / court-circuit d'alimentation</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Température de l'huile court-circuit à la masse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Point de consigne analogique élevé / court-circuit à l'alimentation</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Point de consigne analogique bas / court-circuit à la masse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Délai de réception du message TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Délai de réception des messages CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Tension de batterie élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Tension de batterie faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Signal de vitesse déformé</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Alimentation interne 5V du capteur élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Alimentation interne 5V du capteur faible</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Pression barométrique élevée</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Pression barométrique basse</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Court-circuit de la pompe à carburant de sortie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Court-circuit à la masse de la pompe à carburant de sortie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Court-circuit de la bougie de préchauffage de sortie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Court-circuit à la masse de la bougie de préchauffage de sortie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Injecteur en circuit ouvert/court-circuit à la masse du côté bas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Court-circuit interne de la bobine d'injecteur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Court-circuit d'alimentation du côté bas de l'injecteur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Heures de service expirées</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Défaillance du processeur</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Erreur inconnue :</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Batterie</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Batterie</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Réfrigérateur</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Réfrigérateur</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Générique</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Générique</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Chambre</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Chambre</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Extérieur</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Extérieur</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Chauffe-eau</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Chauffe-eau</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Congélateur</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Congélateur</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Erreur inconnue :</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>Tension CA L1 trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>Tension CA trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>Tension CA L1 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>Tension CA trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>Fréquence CA L1 trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>Fréquence CA trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>Fréquence CA L1 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>Fréquence CA trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>Courant CA L1 trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>Courant CA trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>Puissance CA L1 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>Puissance CA trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Arrêt d&apos;urgence</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Courant servomoteur trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Pression d&apos;huile trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Pression d&apos;huile trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Température moteur trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Température moteur trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Température d&apos;enroulement trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Température d&apos;enroulement trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Température d&apos;échappement trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Température d&apos;échappement trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Température électronique basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Température électronique élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Tension de démarrage trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Courant de batterie de démarrage trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Tension de préchauffage trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Courant d&apos;effluve trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Tension de l&apos;aide au démarrage à froid trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Courant d&apos;aide au démarrage à froid trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Tension de l&apos;aimant de maintien du carburant trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Courant d&apos;électroaimant de carburant trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Tension de la bobine de maintien du solénoïde d&apos;arrêt trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Courant de bobine de fixation solenoïde d&apos;arrêt trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Tension de la bobine de traction du solénoïde d&apos;arrêt trop faible </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Courant de bobine de traction solenoïde d&apos;arrêt trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Tension du ventilateur/de la pompe à eau trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Courant du ventilateur/de la pompe à eau trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Tension basse du capteur de courant</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Courant élevé du capteur de courant</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Tension de sortie de l&apos;amplificateur trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Courant de sortie de pointe trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Tension d&apos;alimentation du bus trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Courant d&apos;alimentation du bus trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Tension de batterie de démarrage trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Tension de batterie de démarrage trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Rotation trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Rotation trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Arrêt inattendu/problème d&apos;alimentation en carburant</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Tension du contacteur de puissance trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Courant de contacteur de puissance trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>Tension CA L2 trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>Tension CA L2 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>Fréquence CA L2 trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>Fréquence CA L2 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>Courant CA L2 trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>Puissance CA L2 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>Tension CA L3 trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>Tension CA L3 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>Fréquence CA L3 trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>Fréquence CA L3 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>Courant CA L3 trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>Puissance CA L3 trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Sortie Tension de l&apos;onduleur trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Sortie Courant de l&apos;onduleur trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Tension de la sortie universelle (1A) trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Courant de la sortie universelle (1A) trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Tension de la sortie universelle (5A) trop faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Courant de sortie universel (5A) trop élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT Tension continue 1 faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>AGT Tension continue 1 élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT Courant continu 1 faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT Courant continu 1 élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>AGT Tension continue 2 faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Tension continue AGT 2 élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT Courant continu 2 faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT Courant continu 2 élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 cooler low</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 cooler high</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 rail (-) bas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 rail (-) haut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 rail (+) bas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 rail (+) haut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Température carburant trop basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Température carburant trop élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Niveau carburant trop bas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Unité de contrôle perdue</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Panneau perdu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Réparation nécessaire</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Module triphasé perdu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Module AGT perdu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Échec synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Perte de l&apos;ECU externe</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Filtre d&apos;aspiration d&apos;air</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Message de diagnostic (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Module sync. perdu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Échec équilibrage de charge</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Mode sync. désactivé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Feu rouge d&apos;arrêt (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Lampe d&apos;avertissement orange (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Témoin de dysfonctionnement (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Lampe de protection (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Champ de rotation incorrect</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Sonde de niveau de carburant perdue</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Démarrage sans onduleur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Le bus n° 1 est mort</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Demande de démarrage refusée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Démarrage à distance refusé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Interruption forcée du relais de charge</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Le module de synchronisation est hors ligne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>BMS perdu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Tension de liaison CC du convertisseur basse/inverse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Courant de liaison CC du convertisseur Faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Tension de précharge CC du convertisseur basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Convertisseur Tension de précharge CC élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Erreur du pilote du convertisseur IGBT/MOSFET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Erreur du convertisseur Boucle de contrôle de puissance</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Détection de la fréquence CA du convertisseur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Défaut de la valeur de contrôle du convertisseur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Modification du réglage d&apos;usine</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Paramètre modifié en mode administrateur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Intervention manuelle (système ext.)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Échec init.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Chien de garde</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Température élevée de l&apos;onduleur L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Température élevée de l&apos;onduleur L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Température de l&apos;onduleur élevée L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Température de l&apos;onduleur élevée Liaison DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Surcharge convertisseur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Communication convertisseur perdue</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>Surcharge CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>Surtension CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Pas de connexion</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Erreur inconnue : %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Erreur inconnue :</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Pression d&apos;huile</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Surchauffe de la culasse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Contrôle de la charge</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Vitesse plus élevée que prévu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Survitesse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Température du pétrole plus élevée que prévu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Température de l&apos;huile circuit ouvert / court-circuit d&apos;alimentation</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Température de l&apos;huile court-circuit à la masse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Point de consigne analogique élevé / court-circuit à l&apos;alimentation</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Point de consigne analogique bas / court-circuit à la masse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Délai de réception du message TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Délai de réception des messages CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Tension de batterie élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Tension de batterie faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Signal de vitesse déformé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Alimentation interne 5V du capteur élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Alimentation interne 5V du capteur faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Pression barométrique élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Pression barométrique basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Court-circuit de la pompe à carburant de sortie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Court-circuit à la masse de la pompe à carburant de sortie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Court-circuit de la bougie de préchauffage de sortie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Court-circuit à la masse de la bougie de préchauffage de sortie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Injecteur en circuit ouvert/court-circuit à la masse du côté bas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Court-circuit interne de la bobine d&apos;injecteur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Court-circuit d&apos;alimentation du côté bas de l&apos;injecteur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Heures de service expirées</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Défaillance du processeur</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Placez l&apos;interrupteur en position déverrouillée pour modifier les réglages.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Utiliser la source de données D-Bus&#xa0;: connectez-vous à l&apos;adresse D-Bus spécifiée.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Utiliser la source de données D-Bus&#xa0;: connectez-vous à l&apos;adresse D-Bus par défaut</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Utiliser la source de données MQTT&#xa0;: connectez-vous à l&apos;adresse du courtier MQTT spécifiée.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>ID du portail du périphérique de source de données MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>IP Portail</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Fragment d&apos;hébergement Web MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>fragment</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Nom d&apos;utilisateur de la source de données MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Mot de passe de la source de données MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>Pass</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Jeton de source de données MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Jeton</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Activer le compteur FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Passer l&apos;écran de démarrage</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Utilisez une source de données fictive pour les tests.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Heure standard Maroc</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Heure standard Afrique centrale ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Heure standard Afrique du sud</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Heure standard Namibie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Heure standard Égypte</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Heure standard Afrique de l&apos;est</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Heure standard Argentine</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Heure standard Est Amérique du  sud</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Heure standard Groenland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Heure standard Montevideo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Heure standard Terre-Neuve-et-Labrador</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Heure standard AS de l&apos;est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Heure standard Atlantique</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Heure standard Brésil centre</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Heure standard Pacifique Asie du sud</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Heure standard Paraguay</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Heure standard AS de l&apos;ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Heure standard Venezuela</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Heure standard de l&apos;est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Heure standard Pacifique AS</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Heure standard É-U de l&apos;est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Heure standard Canada centre</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Heure standard Amérique centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Heure standard du Centre (Mexique)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Heure standard du Centre</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Heure standard des Rocheuses (Mexique)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Heure standard des Rocheuses</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Heure standard montagne É-U</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Heure standard Pacifique (Mexique)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Heure standard Pacifique</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Heure standard Alaska</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hawaii-Aléoutien</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Heure standard Nouvelle Zélande</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Heure standard Pacifique centre</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Heure standard Pacifique de l&apos;ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Heure standard Australie de l&apos;ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Heure standard Asie S-E</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Heure standard Asie centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Heure standard Asie de l&apos;ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Heure standard Afrique de l&apos;est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Heure standard Pacifique Asie du sud</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Heure standard AS de l&apos;ouest</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Heure standard Europe de l&apos;ouest</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Heure standard Kamchatka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Heure standard Magadan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Heure standard Vladivostok</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Heure standaard Yakoutsk</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Heure standard Tokyo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Heure standard Corée</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Heure standard Singapour</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Heure standard Oulanbator</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Heure standard Taïpei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Heure standard Nord Asie de l&apos;Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Heure standard Chine</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Heure standard Asie S-E</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Heure standard Asie du nord</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Heure standard Myanmar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Heure standard Asie centrale du N</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Heure standard Asie centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Heure standard Bangladesh</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Heure standard Népal</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Heure standard Sri Lanka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Heure standar Inde</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Heure standard Asie de l&apos;ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Heure standard Pakistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Heure standard Ekaterinbourg</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Heure standard Géorgie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Heure standard Caucase</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Heure standard Azerbaïdjan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Heure standard d&apos;Arabie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Heure standard Afghanistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Heure standard Iran</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Heure standard arabe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Heure standard arabe</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Heure standard Syrie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Heure standard Moyen-Orient</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Heure standard Jordanie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Heure standard Israël</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Heure standard Greenwich</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Heure standard Açores</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Heure standard Cap vert</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Heure standard Tasmanie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Heure standard Australie de l&apos;est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Heure standard AUS  de l&apos;est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Heure standard Australie centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Heure standard AUS  centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Heure standard Australie de l&apos;ouest</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Heure standard Mid-Atlantic</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Heure standard de la date</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>Temps standard GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Temps standard Europe centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Temps standard européen central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Temps standard europe centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Heure standard Europe de l&apos;ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Temps standard europe de l&apos;est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Temps standard FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Temps standard GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Heure standard Biélorussie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Heure standard Russie</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Heure standard Turquie</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Heure standard Ile Maurice</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Temps standard Ile Christmas</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Heure standard Tonga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Heure standard Fidji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Heure standard Nouvelle Zélande</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Heure standard Pacifique centre</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Heure standard Pacifique de l&apos;ouest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Heure standard Samoa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Heure standard Hawaï</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Temps standard Ile de Paques</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Erreur interne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Erreur inconnue :</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Erreur interne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Température de batterie élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Tension de batterie élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Tension de batterie basse</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Tenson de batterie dépassant le max configuré</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Température alternateur élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Vitesse alternateur élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Température élevée du FET de contrôle du champ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Capteur requis manquant</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Tension alternateur faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Décalage de tension alternateur élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Tension alternateur dépassant le max configuré</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Haute tension de l&apos;alternateur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Batterie déconnectée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Déconnection tension batterie élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Instance batterie en dehors de la plage</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Trop de BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Batterie sur le point de se déconnecter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Trop d&apos;appareils à suivre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Déconnection tension batterie faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Déconnection courant batterie élevé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Déconnection température batterie élevée</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Déconnection température batterie faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Connexion BLS perdue</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC désactivé</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>convertisseur DC/DC pas prêt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC tension primaire haute</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC tension primaire faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC tension secondaire haute</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC tension secondaire faible</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC température haute</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>mauvaise configuration DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Capteur de température de la batterie défectueux</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_it.ts
+++ b/i18n/venus-gui-v2_it.ts
@@ -1,10368 +1,11078 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="it">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Disattivato</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Disattivato</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Sovraccarico inverter</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Sovraccarico inverter</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Potenza</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Potenza</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Spento</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Spento</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Automatico</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Automatico</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Batteria</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connesso</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Disconnesso</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generatore</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Alta tensione batteria</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Alta tensione batteria</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Inverter / Caricabatterie</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Inverter / Caricabatterie</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Bassa tensione batteria</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Bassa tensione batteria</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manuale</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manuale</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Nessuno</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Nessuno</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Posizione</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Posizione</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Velocità</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Velocità</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Stato</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Stato</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installazione in corso %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installazione in corso %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Errore sconosciuto</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Errore sconosciuto</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>SOC minimo</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>SOC minimo</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Inserire password</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Inserire password</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Premere per verificare</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Premere per verificare</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Rete</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Rete</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Rendimento solare</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Rendimento solare</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Controllo esterno</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Controllo esterno</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Serbatoi</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Serbatoi</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Ambiente</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Ambiente</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Non sono presenti avvisi</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Non sono presenti avvisi</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Generale</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Generale</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Data e ora</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Data e ora</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Configurazione sistema</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Configurazione sistema</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Display e lingua</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Display e lingua</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>Portale VRM Online</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>Portale VRM Online</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Contatori di energia</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Contatori di energia</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>Inverter FV</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>Inverter FV</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>Modem GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>Modem GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Avvio/arresto generatore</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Avvio/arresto generatore</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Pompa del serbatoio</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Pompa del serbatoio</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Servizi</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Servizi</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Caratteristiche Venus OS Large</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Caratteristiche Venus OS Large</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Limite di vita della batteria: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Limite di vita della batteria: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Avvio automatico</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>L'avvio automatico sarà disattivato e il generatore non si avvierà automaticamente in base alle condizioni configurate.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>L&apos;avvio automatico sarà disattivato e il generatore non si avvierà automaticamente in base alle condizioni configurate.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Arresto manuale</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Arresto manuale</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Avvio manuale</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Avvio manuale</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Posizione</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Avvio automatico</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Avvio automatico</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Interruttori</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Interruttori</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Livello di accesso</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Livello di accesso</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Utente</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Utente</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Utente e installatore</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Utente e installatore</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superutente</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superutente</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Servizio</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Servizio</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Assicurarsi di ripristinare anche il sistema VE.Bus dopo aver disattivato il DVCC</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Assicurarsi di ripristinare anche il sistema VE.Bus dopo aver disattivato il DVCC</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Limite di corrente di carica</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Limite di corrente di carica</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Corrente di carica massima</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Corrente di carica massima</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Utiliz. %1 per avviare/fermare</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Utiliz. %1 per avviare/fermare</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Avviare quando %1 è superiore a</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Avviare quando %1 è superiore a</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Avviare quando %1 è inferiore a</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Avviare quando %1 è inferiore a</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Arrestare quando %1 è superiore a</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Arrestare quando %1 è superiore a</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Arrestare quando %1 è inferiore a</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Arrestare quando %1 è inferiore a</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Eliminare indirizzo IP?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Eliminare indirizzo IP?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Connessione</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Connessione</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Prodotto</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Prodotto</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Nome</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>ID prodotto</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>ID prodotto</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Versione hardware</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Versione hardware</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Nome dispositivo</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Nome dispositivo</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Controllo interruttore remoto disattivato</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Controllo interruttore remoto disattivato</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Generatore in stato di errore</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Generatore in stato di errore</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Generatore non rilevato nell'entrata CA</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Generatore non rilevato nell&apos;entrata CA</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Tempo funzionamento dall'ultimo test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Tempo funzionamento dall&apos;ultimo test</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Tempo restante per prossimo test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Tempo restante per prossimo test</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>In funzionamento</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>In funzionamento</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Avvio manuale</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Avvio manuale</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Avvia generatore</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Avvia generatore</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Tempo di funzionamento giornaliero</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Tempo di funzionamento giornaliero</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Il valore deve essere maggiore di quello di arresto</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Il valore deve essere maggiore di quello di arresto</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Il valore deve essere inferiore a quello di avvio</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Il valore deve essere inferiore a quello di avvio</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>Uscita CA</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>Uscita CA</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">Uscita CA</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Utilizzare il Carico CA per avviare/arrestare</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Utilizzare il Carico CA per avviare/arrestare</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Misurazione</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Misurazione</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Consumo totale</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Consumo totale</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>CA totale in uscita dell'inverter</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>CA totale in uscita dell&apos;inverter</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Fase più alta della CA di uscita dell'inverter</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Fase più alta della CA di uscita dell&apos;inverter</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Avviare quando la potenza sia superiore a</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Avviare quando la potenza sia superiore a</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Arrestare quando la potenza sia inferiore a</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Arrestare quando la potenza sia inferiore a</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Monitor batteria</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Monitor batteria</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Monitor non disponibile, impostarne un altro</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Monitor non disponibile, impostarne un altro</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Monitor batteria</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Monitor non disponibile, impostarne un altro</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Per perdita di comunicazione</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Per perdita di comunicazione</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Arresta generatore</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Arresta generatore</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Mantenere in funzionamento il generatore</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Mantenere in funzionamento il generatore</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Arresto del generatore quando è disponibile l'ingresso CA</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Arresto del generatore quando è disponibile l&apos;ingresso CA</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>SoC Batteria</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>SoC Batteria</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Alta temperatura inverter</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Alta temperatura inverter</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Alta temperatura inverter</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Avvia in caso di avviso di alta temperatura</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Avvia in caso di avviso di alta temperatura</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Avvia in caso di avviso sovraccarico</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Avvia in caso di avviso sovraccarico</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Funzionamento periodico</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Funzionamento periodico</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Intervallo di funzionamento</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Intervallo di funzionamento</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 giorno(i)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 giorno(i)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Salta funzionamento se ha funzionato per</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Salta funzionamento se ha funzionato per</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Avvia sempre</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Avvia sempre</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Data inizio intervallo esecuzione</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Data inizio intervallo esecuzione</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Durata esecuzione (oo:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Durata esecuzione (oo:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Funzionamento fino a carica completa della batteria</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Funzionamento fino a carica completa della batteria</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (fisso)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (fisso)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS connesso, ma senza GPS fisso</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS connesso, ma senza GPS fisso</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Nessun GPS connesso</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Nessun GPS connesso</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Latitudine</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Latitudine</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Longitudine</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Longitudine</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Corso</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Corso</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Altitudine</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Altitudine</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Numero di satelliti</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Numero di satelliti</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Impostazione rete</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Impostazione rete</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Impostazione CA in ingresso</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Impostazione CA in ingresso</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Corrente: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Corrente: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Tensione: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Tensione: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Limiti (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Limiti (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Carica: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Carica: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Scarica: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Scarica: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Limiti (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Limiti (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Visibile</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Visibile</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Nascosto</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Nascosto</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Misurazione ausiliare)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Misurazione ausiliare)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Uscita %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Uscita %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Monitoraggio attivo batteria</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Monitoraggio attivo batteria</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Inserire nome</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Inserire nome</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Inserire nome</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Scansione continua</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Scansione continua</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Adattatori Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Adattatori Bluetooth</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Codice PIN</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Codice PIN</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Potrebbe essere necessario eliminare le informazioni di accoppiamento esistenti prima della connessione.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Potrebbe essere necessario eliminare le informazioni di accoppiamento esistenti prima della connessione.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Tipo di fase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Tipo di fase</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Monofase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Monofase</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Multi fase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Multi fase</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>Inverter FV in fase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>Inverter FV in fase 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>Posizione inverter FV in fase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>Posizione inverter FV in fase 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>Profilo CAN-bus</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>Profilo CAN-bus</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Disattivato</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can e Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can e Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can e CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can e CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Attivo, ma senza servizi (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Attivo, ma senza servizi (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Dispositivi</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Dispositivi</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA 2000-out</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA 2000-out</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Selettore numero identità unico</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Selettore numero identità unico</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Si prega di attendere: il cambio e la verifica del numero unico richiedono un certo tempo</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Si prega di attendere: il cambio e la verifica del numero unico richiedono un certo tempo</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Tale selettore imposta il blocco di numeri di identità univoci da utilizzare per NAME Numeri Identità Univoci nel campo PGN 60928 NAME. Cambiarlo solo quando si utilizzano vari dispositivi GX nella stessa rete VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Tale selettore imposta il blocco di numeri di identità univoci da utilizzare per NAME Numeri Identità Univoci nel campo PGN 60928 NAME. Cambiarlo solo quando si utilizzano vari dispositivi GX nella stessa rete VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Tale selettore imposta il blocco di numeri di identità univoci da utilizzare per il numero di serie nel campo DGN 60928 ADDRESS_CLAIM. Cambiarlo solo quando si utilizzano vari dispositivi GX nella stessa rete RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Tale selettore imposta il blocco di numeri di identità univoci da utilizzare per il numero di serie nel campo DGN 60928 ADDRESS_CLAIM. Cambiarlo solo quando si utilizzano vari dispositivi GX nella stessa rete RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Controlla numeri ID unici</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Controlla numeri ID unici</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Premere per verificare</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>È presente un altro dispositivo collegato con questo numero univoco, si prega di selezionarne un altro.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>È presente un altro dispositivo collegato con questo numero univoco, si prega di selezionarne un altro.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: Non ci sono altri dispositivi collegati con questo numero unico.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: Non ci sono altri dispositivi collegati con questo numero unico.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Stato della rete</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Stato della rete</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Luminosità adattiva</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Luminosità adattiva</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Luminosità</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Luminosità</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Tempo di spegnimento display</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Tempo di spegnimento display</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 sec</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 sec</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 sec</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 sec</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Mai</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Mai</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Modalità visualizzazione</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Modalità visualizzazione</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Scuro</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Scuro</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Chiaro</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Chiaro</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Livelli di visualizzazione corti</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Livelli di visualizzazione corti</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Lingua</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Lingua</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Modifica della lingua in corso</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Modifica della lingua in corso</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Visualizzazione potenza elettrica</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Visualizzazione potenza elettrica</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Potenza (Watt)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Potenza (Watt)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Corrente (Ampere)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Corrente (Ampere)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Unità</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Unità</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Livello %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Livello %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;ATTENZIONE:&lt;/b&gt; Leggere il manuale prima di eseguire le regolazioni.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;ATTENZIONE:&lt;/b&gt; Leggere il manuale prima di eseguire le regolazioni.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Limita tensione di carica della batteria gestita</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Limita tensione di carica della batteria gestita</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Tensione di carica massima</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Tensione di carica massima</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Sensore di tensione condivisa</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Sensore di tensione condivisa</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Sensore di temperatura condivisa</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Sensore di temperatura condivisa</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Sensore non disponibile, impostarne un altro</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Sensore non disponibile, impostarne un altro</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Sensore non disponibile, impostarne un altro</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Sensore utilizzato</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Sensore utilizzato</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Sensore corrente condiviso</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Sensore corrente condiviso</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Stato SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Stato SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Disabilitato (Controllo esterno)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Disabilitato (Controllo esterno)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Disattivato (caricabatterie assenti)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Disattivato (caricabatterie assenti)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Disattivato (monitor batteria assente)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Disattivato (monitor batteria assente)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Selezione automatica</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Selezione automatica</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Controllo BMS assente</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Controllo BMS assente</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Controllo BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Controllo BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Non disponibile, impostarne un altro</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Non disponibile, impostarne un altro</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Auto-selezionato</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Auto-selezionato</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Nessuno</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Data/ora build</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Data/ora build</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Aggiornamenti online</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Aggiornamenti online</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Installare firmware da SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Installare firmware da SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Backup del firmware memorizzato</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Backup del firmware memorizzato</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Cercare aggiornamenti in SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Cercare aggiornamenti in SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Trovato firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Trovato firmware</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installazione in corso %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installazione in corso %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Premere per aggiornare a %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Premere per aggiornare a %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Premere per aggiornare a %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Data/ora build del firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Data/ora build del firmware</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Aggiornamento automatico</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Aggiornamento automatico</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Solo verifica</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Solo verifica</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Solo verifica e scarica</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Solo verifica e scarica</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Verifica e aggiorna</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Verifica e aggiorna</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Feed di aggiornamento</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Feed di aggiornamento</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Tipo immagine</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Tipo immagine</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normale</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normale</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Larga</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Larga</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Cerca aggiornamenti</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Cerca aggiornamenti</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Aggiornamento disponibile</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Aggiornamento disponibile</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Installazione in corso %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Installazione in corso %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Installazione in corso %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Aggiorna data/ora build</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Aggiorna data/ora build</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Inverter</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Inverter</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Trova inverter FV</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Trova inverter FV</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Rilevati indirizzi IP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Rilevati indirizzi IP</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Aggiungi manualmento indirizzo IP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Aggiungi manualmento indirizzo IP</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>Porta TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>Porta TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Multifase</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Multifase</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Split-phase (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Split-phase (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>mostra</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>mostra</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Cercare nuovamente indirizzi IP?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Cercare nuovamente indirizzi IP?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Nuova scansione</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Nuova scansione</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH su LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH su LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Assistenza remota</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Assistenza remota</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Tunnel di supporto remoto</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Tunnel di supporto remoto</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>Porta e ID di supporto remoto</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>Porta e ID di supporto remoto</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Esci ora</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Riavviare ora</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Riavviare ora</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Il dispositivo è stato riavviato.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Allarme udibile</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Allarme udibile</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Modalità demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Modalità demo</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS demo</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Barca/Camper demo 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Barca/Camper demo 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Barca/Camper demo 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Barca/Camper demo 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>L'avvio della modalità demo cambierà alcune impostazioni e l'interfaccia utente non risponderà per alcuni istanti.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>L&apos;avvio della modalità demo cambierà alcune impostazioni e l&apos;interfaccia utente non risponderà per alcuni istanti.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Condizioni</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Condizioni</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Tempo minimo funzionamento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Tempo minimo funzionamento</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Tempo di riscaldamento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Tempo di riscaldamento</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Tempo di raffreddamento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Tempo di raffreddamento</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>RIlevato generatore nell'entrata CA</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>RIlevato generatore nell&apos;entrata CA</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Nessuna entrata CA è impostata per il generatore. Entrare nella pagina di configurazione del sistema e impostare l'entrata CA corretta per il generatore, per attivare questa funzionalità.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Nessuna entrata CA è impostata per il generatore. Entrare nella pagina di configurazione del sistema e impostare l&apos;entrata CA corretta per il generatore, per attivare questa funzionalità.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Si attiverà un allarme quando non si rilevi energia proveniente dal generatore nell'entrata CA dell'inverter. Assicurarsi di aver impostato l'entrata CA corretta per il generatore nella pagina di configurazione del sistema.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Si attiverà un allarme quando non si rilevi energia proveniente dal generatore nell&apos;entrata CA dell&apos;inverter. Assicurarsi di aver impostato l&apos;entrata CA corretta per il generatore nella pagina di configurazione del sistema.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Inizio ore di silenzio</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Inizio ore di silenzio</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Fine ore di silenzio</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Fine ore di silenzio</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Tempo di funzionamento e servizio</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Tempo di funzionamento e servizio</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Ripristina contatori di funzionam. quotidiano</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Ripristina contatori di funzionam. quotidiano</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Il contatore di funzionamento quotidiano è stato ripristinato</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Il contatore di funzionamento quotidiano è stato ripristinato</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Non si possono modificare i contatori quando il generatore è in funzione</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Non si possono modificare i contatori quando il generatore è in funzione</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Intervallo di servizio del generatore (ore)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Intervallo di servizio del generatore (ore)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Intervallo di tempo di servizio impostato su %1h. Utilizzare il pulsante “Ripristino timer di servizio” per ripristinare il timer di servizio.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Intervallo di tempo di servizio impostato su %1h. Utilizzare il pulsante “Ripristino timer di servizio” per ripristinare il timer di servizio.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Ripristino timer di servizio</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Ripristino timer di servizio</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Impostazioni GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Impostazioni GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Formato</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Formato</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.2200</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.2200</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Unità velocità</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Unità velocità</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Chilometri all'ora</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Chilometri all&apos;ora</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Metri al secondo</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Metri al secondo</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Miglia all'ora</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Miglia all&apos;ora</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Nodi</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Nodi</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Nessun modem GSM collegato</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Nessun modem GSM collegato</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Corriere</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Corriere</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Potrebbe essere necessario configurare le impostazioni del APN in questa pagina: rivolgersi al proprio operatore per i dettagli.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Potrebbe essere necessario configurare le impostazioni del APN in questa pagina: rivolgersi al proprio operatore per i dettagli.
 Se ciò non funziona, verificare la sim-card del cellulare, per assicurarsi di avere credito e/o che sia registrata per l’uso dei dati.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Consentire il roaming</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Consentire il roaming</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Stato SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Stato SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM non inserita</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM non inserita</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN richiesto</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN richiesto</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK richiesto</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK richiesto</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Errore della SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Errore della SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM occupata</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM occupata</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>SIM sbagliata</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>SIM sbagliata</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>PIN errato</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>PIN errato</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Pronto</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Pronto</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Errore sconosciuto</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Per impostazione predefinita</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Per impostazione predefinita</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Usa l'APN predefinito</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Usa l&apos;APN predefinito</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Nome APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Nome APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Usare autenticazione</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Usare autenticazione</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Nome utente</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Nome utente</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>Il numero IMEI deve avere 15 caratteri di lunghezza.</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>Il numero IMEI deve avere 15 caratteri di lunghezza.</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Autoconsumo</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Autoconsumo</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Non è stato trovato l'Assistente ESS</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Non è stato trovato l&apos;Assistente ESS</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Misurazioni di rete</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Misurazioni di rete</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Contatore esterno</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Contatore esterno</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Inverter/Caricabatterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Inverter/Caricabatterie</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Uscita CA dell'inverter in uso</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Uscita CA dell&apos;inverter in uso</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Regolazione multifase</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Regolazione multifase</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Totale di tutte le fasi</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Totale di tutte le fasi</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Fase singola</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Fase singola</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Ogni fase è regolata per raggiungere singolarmente il valore di riferimento della rete (l'efficienza del sistema è diminuita).
+        <translation>Ogni fase è regolata per raggiungere singolarmente il valore di riferimento della rete (l&apos;efficienza del sistema è diminuita).
 
 ATTENZIONE: Utilizzare solo se richiesto dal fornitore di servizi.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Il totale di tutte le fasi è regolato in modo intelligente per raggiungere il valore di riferimento della rete (l'efficienza del sistema è ottimizzata).
+        <translation>Il totale di tutte le fasi è regolato in modo intelligente per raggiungere il valore di riferimento della rete (l&apos;efficienza del sistema è ottimizzata).
 
 Utilizzare se non è vietato dal gestore della rete</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inattivo</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">ESS dinamico</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>SOC minima di scarico (a meno fallimento griglia)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>SOC minima di scarico (a meno fallimento griglia)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Limite SoC attivo</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Limite SoC attivo</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Supporto</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Caricamento</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Riduzione dei picchi</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Riduzione dei picchi</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Solo al di sopra della SoC minima</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Solo al di sopra della SoC minima</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Sempre</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Scarica disattivata</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Scarica disattivata</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Carica lenta</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Carica lenta</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Supporto</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Supporto</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Caricamento</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Caricamento</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Limite potenza di carica</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Limite potenza di carica</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Potenza di carica massima</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Potenza di carica massima</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Limite potenza inverter</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Limite potenza inverter</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Massima potenza inverter</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Massima potenza inverter</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Impostazione rete</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Impostazione rete</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Iniezione a rete</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Iniezione a rete</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>FV abbinato a CA - immettere eccesso</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>FV abbinato a CA - immettere eccesso</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>FV abbinato a CC - immettere eccesso</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>FV abbinato a CC - immettere eccesso</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Limitare l'iniezione del sistema alla rete</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Limitare l&apos;iniezione del sistema alla rete</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Iniezione massima</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Iniezione massima</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Limitazione immissione attiva</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Limitazione immissione attiva</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Entrate analogiche</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Entrate analogiche</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Entrate digitali</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Entrate digitali</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Ingresso digitale %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Ingresso digitale %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Contatore di impulsi</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Contatore di impulsi</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Allarme porta</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Allarme porta</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Pompa di sentina</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Pompa di sentina</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Allarme di sentina</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Allarme di sentina</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Allarme furti</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Allarme furti</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Allarme fumo</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Allarme fumo</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Allarme fuoco</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Allarme fuoco</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>Allarme CO2</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>Allarme CO2</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Sensori Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Sensori Bluetooth</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Si noti che queste caratteristiche non sono ufficialmente supportate da Victron. Rivolgersi alla community.victronenergy.com per domande.
+        <translation>Si noti che queste caratteristiche non sono ufficialmente supportate da Victron. Rivolgersi alla community.victronenergy.com per domande.
 
 Documentazione disponibile su https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Segnale K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Segnale K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>(modalità di sicurezza) attivata</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>(modalità di sicurezza) attivata</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Posticipato da %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Posticipato da %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID Portale VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID Portale VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Intervallo di registrazione</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Intervallo di registrazione</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 ora</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 ora</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 ore</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 ore</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 ore</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 ore</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 ore</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 ore</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 giorno</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 giorno</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Utilizzare la connessione sicura (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Utilizzare la connessione sicura (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Ultimo contatto</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Ultimo contatto</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Testo di risposta inatteso</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Testo di risposta inatteso</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Risposta HTTP inattesa</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Risposta HTTP inattesa</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Timeout collegamento</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Timeout collegamento</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Errore di collegamento</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Errore di collegamento</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Errore del DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Errore del DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Errore di instradamento</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Errore di instradamento</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM non disponibile</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM non disponibile</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Errore sconosciuto</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Errore sconosciuto</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Messaggio di errore: 
+        <translation>Messaggio di errore: 
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Se non ci sono contatti, riavviare il dispositivo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Se non ci sono contatti, riavviare il dispositivo</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Ritardo ripristino contatto assente (oo:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Ritardo ripristino contatto assente (oo:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Ubicazione memorizzazione</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Ubicazione memorizzazione</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Non ci sono buffer attivi</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Non ci sono buffer attivi</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Memoria interna</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Memoria interna</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Trasferimento in corso</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Trasferimento in corso</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Memoria esterna</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Memoria esterna</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Errore sconosciuto</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Nessun errore</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Nessun errore</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Spazio di archiviazione esaurito</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Spazio di archiviazione esaurito</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Errore IO</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Errore IO</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Errore durante il mount</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Errore durante il mount</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Contiene immagini di firmware. Non usare.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Contiene immagini di firmware. Non usare.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>Scheda SD / chiavetta USB non scrivibile</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>Scheda SD / chiavetta USB non scrivibile</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Spazio libero nel disco</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Spazio libero nel disco</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>byte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>byte</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bytes</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bytes</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Registrazioni memorizzate</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Registrazioni memorizzate</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 registri</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 registri</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Tempo delle registrazioni più vecchie</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Tempo delle registrazioni più vecchie</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Attiva Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Attiva Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Non ci sono errori segnalati</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Non ci sono errori segnalati</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Ora dell'ultimo errore</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Ora dell&apos;ultimo errore</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Servizi disponibili</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Servizi disponibili</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>ID Unità: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>ID Unità: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Funzione (Relè 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Funzione (Relè 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Funzione</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Funzione</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Relè allarme</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Relè allarme</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Pompa del serbatoio</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuale</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polarità relè allarme</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polarità relè allarme</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normalmente aperto</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normalmente aperto</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normalmente chiuso</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normalmente chiuso</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relè 1 Acceso</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relè 1 Acceso</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relè attivo</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relè attivo</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Funzione (Relè 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Funzione (Relè 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relè 2 Acceso</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relè 2 Acceso</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Regole di cotrollo della temperatura</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Regole di cotrollo della temperatura</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Attivazione relè secondo temperatura</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Attivazione relè secondo temperatura</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Nessun relè configurato per essere attivato dalla temperatura. Entrare nella pagina di impostazione del relè, sita nel menù delle impostazioni principali, e impostare la funzione relè su \“Temperatura\”</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Nessun relè configurato per essere attivato dalla temperatura. Entrare nella pagina di impostazione del relè, sita nel menù delle impostazioni principali, e impostare la funzione relè su \“Temperatura\”</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Questa opzione vi consente di alternare la corrente versione del firmare e la precedente. Non sono necessari né un collegamento a internet né una memoria SD.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Questa opzione vi consente di alternare la corrente versione del firmare e la precedente. Non sono necessari né un collegamento a internet né una memoria SD.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Premere per riavviare</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Premere per riavviare</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Riavvio a %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Riavvio a %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Non è possibile cambiare la versione del firmware quando l'aggiornamento automatico è impostato su \”Verifica e aggiorna\”. Per attivare questa opzione, impostare l'aggiornamento automatico su "Disattivato" o "Solo verifica".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Non è possibile cambiare la versione del firmware quando l&apos;aggiornamento automatico è impostato su \”Verifica e aggiorna\”. Per attivare questa opzione, impostare l&apos;aggiornamento automatico su &quot;Disattivato&quot; o &quot;Solo verifica&quot;.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Non è disponibile un backup del firmware</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Non è disponibile un backup del firmware</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Console su VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-bus su TCP/IP (Debug)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-bus su TCP/IP (Debug)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Potenza banchina</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Potenza banchina</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Veicolo</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Veicolo</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Imbarcazione</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Imbarcazione</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Nome del sistema</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Nome del sistema</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatico</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatico</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Rete</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatico</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Definito dall'utente</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Definito dall&apos;utente</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Nome definito dall’utente</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Nome definito dall’utente</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>Ingresso CA 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>Ingresso CA 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>Ingresso CA 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>Ingresso CA 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Monitoraggio guasti di rete</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Monitoraggio guasti di rete</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Monitoraggio disconnessioni banchina</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Monitoraggio disconnessioni banchina</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Auto-selezionato</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Auto-selezionato</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Ha sistema CC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Ha sistema CC</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Sincronizza VE.Bus SOC con la batteria</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Sincronizza VE.Bus SOC con la batteria</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Utilizzare la corrente del caracabatterie solare per migliorare il VE.Bus SOC</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Utilizzare la corrente del caracabatterie solare per migliorare il VE.Bus SOC</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Controllo della tensione del caricabatterie solare</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Controllo della tensione del caricabatterie solare</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Controllo corrente caricabatterie solare</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Controllo corrente caricabatterie solare</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Controllo BMS</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>Controllo BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>Controllo BMS</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>La funzione di avvio/arresto della pompa del serbatoio non è attiva. Entrare nelle impostazioni dei relè e impostare la funzione su "Pompa serbatoio".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>La funzione di avvio/arresto della pompa del serbatoio non è attiva. Entrare nelle impostazioni dei relè e impostare la funzione su &quot;Pompa serbatoio&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Stato pompa</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Stato pompa</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Automatico</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Sensore serbatoio</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Sensore serbatoio</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Livello di avvio</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Livello di avvio</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Livello di arresto</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Livello di arresto</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Connessione persa</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Connessione persa</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Scollegato</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Scollegato</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Nascosto]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Nascosto]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Connettere alla rete?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Connettere alla rete?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Collegamento</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Collegamento</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Dimentica rete?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Dimentica rete?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Dimentica</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Dimentica</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Siete sicuri di voler dimenticare questa rete?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Siete sicuri di voler dimenticare questa rete?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>Indirizzo MAC</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>Indirizzo MAC</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>Configurazione IP</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>Configurazione IP</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuale</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Spento</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Fissa</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Fissa</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Maschera di rete</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Maschera di rete</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Gateway</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Gateway</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>Server DNS</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>Server DNS</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Link indirizzo IP locale</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Link indirizzo IP locale</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Attenzione, per i sistemi ESS, come per quelli con una batteria gestita, l'istanza del dispositivo CAN-bus deve rimanere configurata a 0. Vedere il manuale GX per ulteriori informazioni.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Attenzione, per i sistemi ESS, come per quelli con una batteria gestita, l&apos;istanza del dispositivo CAN-bus deve rimanere configurata a 0. Vedere il manuale GX per ulteriori informazioni.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Istanza dispositivo</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Istanza dispositivo</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Indirizzo di Rete</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Indirizzo di Rete</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Dispositivi VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Dispositivi VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Dispositivo# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Dispositivo# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Nessun punto di accesso</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Nessun punto di accesso</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Nessun adattatore Wi-Fi connesso</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Nessun adattatore Wi-Fi connesso</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Crea punto di accesso</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Crea punto di accesso</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Reti Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Reti Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Siete sicuri di voler disattivare il punto di accesso?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Siete sicuri di voler disattivare il punto di accesso?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Data/Ora UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Data/Ora UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Data/Ora locale</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Data/Ora locale</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Zona oraria</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Zona oraria</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Africa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Africa</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>America</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>America</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antartide</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antartide</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Artico</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Artico</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asia</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantico</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantico</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australia</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indiano</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indiano</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pacifico</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pacifico</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Ecc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Ecc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Non collegato %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Non collegato %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Riavviare ora?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Riavviare ora?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Le modifiche all'istanza VRM verranno applicate dopo il riavvio del dispositivo.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Le modifiche all&apos;istanza VRM verranno applicate dopo il riavvio del dispositivo.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Il dispositivo si sta riavviando...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Il dispositivo si sta riavviando...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Il dispositivo è stato riavviato.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Il dispositivo è stato riavviato.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Allarme bassa tensione batteria</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Allarme bassa tensione batteria</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Allarme alta tensione batteria</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Allarme alta tensione batteria</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Ultimo errore</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Ultimo errore</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Penultimo errore</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Penultimo errore</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Terzultimo errore</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Terzultimo errore</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Quartultimo errore</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Quartultimo errore</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>In rete</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>In rete</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Impostazioni modalità</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Impostazioni modalità</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Indipendente</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Indipendente</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Indipendente</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Carico</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Carico</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Controllo esterno</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Carica e HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Carica e HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Carica e BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Carica e BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Controllo Est. e BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Controllo Est. e BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Carica, Hub-1 e BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Carica, Hub-1 e BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Impostazioni master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Impostazioni master</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Slave</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Slave</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Slave</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Gruppo Master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Gruppo Master</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Carica master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Carica master</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Gruppo e Carica master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Gruppo e Carica master</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Tensione di carica</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Tensione di carica</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Ripristina</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Ripristina</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Il controllo del BMS si attiva automaticamente quando è presente il BMS. Ripristinare se la configurazione del sistema è cambiata o se non è presente un BMS.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Il controllo del BMS si attiva automaticamente quando è presente il BMS. Ripristinare se la configurazione del sistema è cambiata o se non è presente un BMS.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Potenza totale</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Carico</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Carico</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 trovato</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 trovato</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Cronologia</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Cronologia</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Cronologia</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Funzionamento in rete</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Funzionamento in rete</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Vista della tabella</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Vista della tabella</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Grafico</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Grafico</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Avvertimento</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Avvertimento</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Allarme</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Allarme</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Allarme</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Volume</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Volume</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>In corto circuito</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>In corto circuito</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Polarità inversa</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Polarità inversa</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>EV Charging Station</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>EV Charging Station</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Sessione</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Sessione</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Ora</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Ora</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Modalità di carica</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Modalità di carica</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Avviare e interrompere il processo personalmente. Utilizzarlo per cariche rapide e un monitoraggio accurato.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Avviare e interrompere il processo personalmente. Utilizzarlo per cariche rapide e un monitoraggio accurato.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Si avvia e si arresta in base al livello di carica della batteria. Ottimale per cariche notturne e prolungate, al fine di evitare sovraccarichi.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Si avvia e si arresta in base al livello di carica della batteria. Ottimale per cariche notturne e prolungate, al fine di evitare sovraccarichi.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Tariffe elettriche più basse durante le ore non di punta o se ci si vuole assicurare che il veicolo elettrico sia completamente carico e pronto a partire a un orario specifico.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Tariffe elettriche più basse durante le ore non di punta o se ci si vuole assicurare che il veicolo elettrico sia completamente carico e pronto a partire a un orario specifico.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Attiva carica</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Attiva carica</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Blocca il display del caricatore</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Blocca il display del caricatore</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Indirizzo Sorgente</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Indirizzo Sorgente</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Impostazione</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Impostazione</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Istanza linea #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Istanza linea #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Istanza linea</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Istanza linea</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Istanza caricabatterie</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Istanza caricabatterie</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Istanza inverter</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Istanza inverter</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Istanza sorgente CC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Istanza sorgente CC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Istanza sorgente CC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Istanza sorgente CC</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Priorità sorgente CC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Priorità sorgente CC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Priorità sorgente CC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Priorità sorgente CC</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Istanza serbatoio</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Istanza serbatoio</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Dispositivi RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Dispositivi RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Attivare il visualizzatore di frequenza dei fotogrammi</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Attivare il visualizzatore di frequenza dei fotogrammi</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Non supportato</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Non supportato</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Rimuovi dispositivi scollegati</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Rimuovi dispositivi scollegati</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Rilevato dispositivo non supportato</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Rilevato dispositivo non supportato</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Funzione relè</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Funzione relè</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Allarme</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Avvio/arresto caricatore o generatore</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Avvio/arresto caricatore o generatore</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Controllo manuale</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Fusibile bruciato</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Controllo manuale</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Controllo manuale</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Sempre aperto (non usa il relè)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Sempre aperto (non usa il relè)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Tenere presente che cambiando l'impostazione Basso livello di carica cambia anche l'impostazione Tempo restante soglia di scarica nel menu batteria</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Tenere presente che cambiando l&apos;impostazione Basso livello di carica cambia anche l&apos;impostazione Tempo restante soglia di scarica nel menu batteria</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Fusibile bruciato</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Fusibile bruciato</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Stato LED</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Stato LED</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Nessuno</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Interruttore principale</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Interruttore principale</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Riscaldatore</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Riscaldatore</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Ventola Interna</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Ventola Interna</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Segnali avvertimento</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Segnali avvertimento</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Segnali Allarme</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Segnali Allarme</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Interruttore</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Interruttore</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>In fase di inizializzazione</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>In fase di inizializzazione</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Arresto</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Arresto</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Aggiornamento in corso</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Aggiornamento in corso</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Prossimo funzionamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Prossimo funzionamento</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Pre-caricamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Pre-caricamento</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Verifica contattore</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Verifica contattore</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Stato di salute</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Stato di salute</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Temperatura batteria</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Temperatura batteria</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Temperatura aria</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Temperatura aria</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Tensione di avviamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Tensione di avviamento</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Tensione Bus</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Tensione Bus</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Tensione sezione superiore</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Tensione sezione superiore</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Errore di comunicazione</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Stato di salute</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Tensione Bus</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Tensione sezione inferiore</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Tensione sezione inferiore</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Deviazione punto intermedio</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Deviazione punto intermedio</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Amperora consumati</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Amperora consumati</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Tempo restante</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Tempo restante</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Particolari</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Particolari</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Allarmi livello modulo</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Allarmi livello modulo</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnostica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostica</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Fusibili</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Fusibili</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>Sistema</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>Sistema</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parametri</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parametri</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Rileva nuovamente la batteria</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Rileva nuovamente la batteria</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Premere per rilevare nuovamente</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Premere per rilevare nuovamente</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Premere per rilevare nuovamente</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Il nuovo rilevamento della batteria potrebbe richiedere fino a 60 secondi. Il nome della batteria potrebbe essere erroneo.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Il nuovo rilevamento della batteria potrebbe richiedere fino a 60 secondi. Il nome della batteria potrebbe essere erroneo.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Corrente di carica alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Corrente di carica alta</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Corrente di scarica alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Corrente di scarica alta</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>SOC basso</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>SOC basso</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Alta tensione batteria</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">SOC basso</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Bassa tensione batteria di avviamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Bassa tensione batteria di avviamento</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Tensione batteria avviamento alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Tensione batteria avviamento alta</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Sensore temperatura batteria</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Sensore temperatura batteria</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Tensione del punto medio</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Tensione del punto medio</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Fusibile bruciato</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Temperatura interna alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Temperatura interna alta</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Temperatura di carica bassa</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Temperatura di carica bassa</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Temperatura di carica alta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Temperatura di carica alta</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Errore interno</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Errore interno</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Disgiuntore è sconnesso</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Disgiuntore è sconnesso</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Sbilanciamento della cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Sbilanciamento della cella</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Bassa tensione cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Bassa tensione cella</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Tensione minima della cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Tensione minima della cella</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Tensione massima della cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Tensione massima della cella</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Temperatura minima cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Temperatura minima cella</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Temperatura massima cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Temperatura massima cella</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Moduli batteria</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Moduli batteria</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Numero di moduli che bloccano la carica o la scarica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Numero di moduli che bloccano la carica o la scarica</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Installato / Capacità disponibile</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Installato / Capacità disponibile</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Scarica massima</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Scarica massima</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Ultima scarica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Ultima scarica</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Scarica media</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Scarica media</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Cicli complessivi di carica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Cicli complessivi di carica</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Numero di scariche complete</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Numero di scariche complete</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Numero accumulativo di Ah assorbiti</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Numero accumulativo di Ah assorbiti</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Tensione cell minima</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Tensione cell minima</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Tensione cell massima</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Tensione cell massima</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Tempo trascorso dall'ultima carica completa</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Tempo trascorso dall&apos;ultima carica completa</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Conteggio sincronizzazione</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Conteggio sincronizzazione</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Allarmi di bassa tensione batteria di avviamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Allarmi di bassa tensione batteria di avviamento</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Tensione minima batteria di avviamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Tensione minima batteria di avviamento</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Tensione massima batteria di avviamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Tensione massima batteria di avviamento</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Energia scaricata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Energia scaricata</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Energia caricata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Energia caricata</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Limite Tensione di Carica (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Limite Tensione di Carica (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Limite Corrente di Carica (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Limite Corrente di Carica (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Limite Corrente di Scarica (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Limite Corrente di Scarica (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Disconnessione per Bassa Tensione (sempre ignorato)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Disconnessione per Bassa Tensione (sempre ignorato)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Banco batterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Banco batterie</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relè (sul monitor batteria)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relè (sul monitor batteria)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Ripristina impostazioni di fabbrica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Ripristina impostazioni di fabbrica</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Premere per ripristinare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Premere per ripristinare</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Ripristinare impostazioni di fabbrica?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Ripristinare impostazioni di fabbrica?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth attivo</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth attivo</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Tensione Nominale</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Tensione Nominale</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Capacità</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Capacità</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacità</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Tensione caricata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Tensione caricata</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Corrente di coda</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Corrente di coda</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Tempo di rilevamento batteria carica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Tempo di rilevamento batteria carica</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Coefficiente Peukert</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Coefficiente Peukert</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Fattore di efficienza di carica</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Fattore di efficienza di carica</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Soglia corrente</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Soglia corrente</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Periodo medio rimanente di autonomia</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Periodo medio rimanente di autonomia</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Tempo restante soglia di scaricamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Tempo restante soglia di scaricamento</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Discrepanza di corrente</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Discrepanza di corrente</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Sincronizza stato di carica al 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Sincronizza stato di carica al 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Premi per sincronizzare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Premi per sincronizzare</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Calibrazione corrente a zero</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Calibrazione corrente a zero</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Premi per impostare su 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Premi per impostare su 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Distributore %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Distributore %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Nessuna alimentazione sulla busbar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Nessuna alimentazione sulla busbar</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Connessione persa</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n fusibile(i) bruciato(i)</numerusform>
-        <numerusform>%n fusibile(i) bruciato(i)</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n fusibile(i) bruciato(i)</numerusform>
+            <numerusform>%n fusibile(i) bruciato(i)</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Nessuna informazione disponibile, vedere la pagina precedente per lo stato del Distributore.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Nessuna informazione disponibile, vedere la pagina precedente per lo stato del Distributore.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Fusibile %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Fusibile %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Non in uso</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Non in uso</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Fuso</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Fuso</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Arresti dovuti a errore</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Arresti dovuti a errore</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Ultimo errore</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">Penultimo errore</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">Terzultimo errore</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">Quartultimo errore</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Interruttore di sistema</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Interruttore di sistema</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Relè esterno</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Relè esterno</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Contatto programmabile</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Contatto programmabile</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Batterie</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Batterie</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacità</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Batterie</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Parallelo</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Parallelo</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Serie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Serie</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Tensione min/max cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Tensione min/max cella</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Temperatura min/max cella</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Temperatura min/max cella</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Bilanciamento</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Bilanciamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Bilanciamento</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Uscita</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Uscita</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Azionamento di campo</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Azionamento di campo</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Velocità motore</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Velocità motore</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Tensione ausiliare</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Tensione ausiliare</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>nessun allarme</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>nessun allarme</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Tensione bassa</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Tensione bassa</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Tensione alta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Tensione alta</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Tensione ausiliare bassa</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Tensione ausiliare bassa</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Tensione ausiliare alta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Tensione ausiliare alta</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Allarmi per bassa tensione ausiliare</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Allarmi per bassa tensione ausiliare</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Allarmi per alta tensione ausiliare</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Allarmi per alta tensione ausiliare</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Tensione ausiliare minima</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Tensione ausiliare minima</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Tensione ausiliare massima</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Tensione ausiliare massima</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Energia prodotta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Energia prodotta</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Energia consumata</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Energia consumata</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Attiva allarme</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Attiva allarme</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Livello attivo</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Livello attivo</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Ripristina livello</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Ripristina livello</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Ritardo</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Ritardo</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Livello</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Livello</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Rimanente</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Rimanente</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Batteria sensore</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Batteria sensore</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Batteria sensore</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Tipo di sensore</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Tipo di sensore</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Per impostazione predefinita</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Per impostazione predefinita</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Europeo (da 0 a 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Europeo (da 0 a 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>Americano (da 240 a 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>Americano (da 240 a 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Personalizza</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Personalizza</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Personalizza</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Valore sensore a vuoto</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Valore sensore a vuoto</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Tipo di fluido</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Tipo di fluido</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Rapporto butano</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Rapporto butano</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Forma personalizzata</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Forma personalizzata</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Tempo medio</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Tempo medio</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Valore sensore</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Valore sensore</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Non sono state definite forme personalizzate. È possibile definirne una con un massimo di dieci punti. Si noti che 0 % e 100 % sono impliciti.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Non sono state definite forme personalizzate. È possibile definirne una con un massimo di dieci punti. Si noti che 0 % e 100 % sono impliciti.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punto %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punto %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Aggiungi punto</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Aggiungi punto</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Livello Sensore</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Livello Sensore</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Volume</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Non sono consentiti valori di livello del sensore duplicati.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Non sono consentiti valori di livello del sensore duplicati.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>I valori volume devono essere crescenti.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>I valori volume devono essere crescenti.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Sbloccato (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Sbloccato (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Sbloccato (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Sbloccato (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Sbloccato (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Sbloccato (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Bloccato</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Bloccato</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Configurazione fase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Configurazione fase</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Cambia posizione</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Cambia posizione</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Monofase</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>Bifase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>Bifase</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>Trifase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>Trifase</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Dispositivi</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>CA</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>CA</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motore</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motore</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Velocità</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Carico</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Temperatura di raffreddamento</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Temperatura di raffreddamento</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Temperatura di scarico</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Temperatura di scarico</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Temperatura di avvolgimento</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Temperatura di avvolgimento</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Tensione batteria di avviamento</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Tensione batteria di avviamento</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Numero di avvii</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Numero di avvii</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Controllo BMS</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Selettore frontale bloccato (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Selettore frontale bloccato (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Nessun errore (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Nessun errore (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>Totali CA</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>Totali CA</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energia L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energia L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Sequenza Fase</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Sequenza Fase</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Versione del gestore di dati</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Versione del gestore di dati</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Nessuno</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Il LED lampeggiante indica questo CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Il LED lampeggiante indica questo CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Dispositivi bus Smappee</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Dispositivi bus Smappee</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>Caricabatterie FV</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>Caricabatterie FV</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Questa impostazione viene disattivata quando e collegato un Digital Multi Control.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Questa impostazione viene disattivata quando e collegato un Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Questa impostazione viene disattivata quando è collegato un VE.Bus BMS.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Questa impostazione viene disattivata quando è collegato un VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC in %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC in %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>CC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>CC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Invertito</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Invertito</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Attiva allarme</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Invertito</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Invertire logica allarme</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Invertire logica allarme</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Irraggiamento</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Irraggiamento</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Temperatura cella</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Temperatura cella</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Temperatura esterna (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Temperatura esterna (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Temperatura esterna</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Temperatura esterna</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Temperatura esterna (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Temperatura esterna (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Velocità del vento</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Velocità del vento</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Rilevamento automatico</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Rilevamento automatico</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Sensore di velocità vento</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Sensore di velocità vento</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Sensore temperatura esterno</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Sensore temperatura esterno</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Aggregato</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Aggregato</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Moltiplica</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Moltiplica</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Ripristino contatore</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Ripristino contatore</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">In corto circuito</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Polarità inversa</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Sensore batteria bassa</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Sensore batteria bassa</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Umidità</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Umidità</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Pressione</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Pressione</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Basso</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Discrepanza</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Discrepanza</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Scala</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Scala</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Tensione sensore</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Tensione sensore</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Potenza totale</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Potenza totale</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Pagina prodotto</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Pagina prodotto</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Sensore CA %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Sensore CA %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>È disponibile una nuova versione dell’MK3.
-NOTE: L'aggiornamento potrebbe arrestare temporaneamente il sistema.</translation>
+        <translation>È disponibile una nuova versione dell’MK3.
+NOTE: L&apos;aggiornamento potrebbe arrestare temporaneamente il sistema.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Aggiornare l'MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Aggiornare l&apos;MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Premere per aggiornare</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Premere per aggiornare</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Aggiornamento dell’MK3 in corso: i valori riappariranno al termine dell'aggiornamento</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Aggiornamento dell’MK3 in corso: i valori riappariranno al termine dell&apos;aggiornamento</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Carica della batteria al 100 %</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Carica della batteria al 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Carica della batteria al 100 %</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Avanzate</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>In corso</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>In corso</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Premere per interrompere</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Premere per interrompere</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Premere per avviare</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Premere per avviare</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Caricare la batteria al 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Caricare la batteria al 100 %</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Il sistema tornerà a funzionare normalmente, dando priorità alle energie rinnovabili.Si desidera continuare?</translation>
+        <translation>Il sistema tornerà a funzionare normalmente, dando priorità alle energie rinnovabili.Si desidera continuare?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>L'alimentazione da banchina verrà utilizzata quando disponibile e l'opzione "Priorità solare ed eolico" verrà ignorata.Si desidera continuare?</translation>
+        <translation>L&apos;alimentazione da banchina verrà utilizzata quando disponibile e l&apos;opzione &quot;Priorità solare ed eolico&quot; verrà ignorata.Si desidera continuare?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>L'alimentazione da banchina verrà utilizzata una sola volta per integrare la carica completa della batteria.
+        <translation>L&apos;alimentazione da banchina verrà utilizzata una sola volta per integrare la carica completa della batteria.
 Al termine del processo di carica, il sistema tornerà al funzionamento normale, dando priorità alle energie rinnovabili.
 Si desidera continuare?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Tensione CC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Tensione CC</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>Corrente CC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>Corrente CC</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Avanzate</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Avanzate</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Configurazione allarme</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Configurazione allarme</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>Un VE.Bus BMS spegne automaticamente il sistema quando necessario per proteggere la batteria. Controllare il sistema dal Color Control non è pertanto possibile.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>Un VE.Bus BMS spegne automaticamente il sistema quando necessario per proteggere la batteria. Controllare il sistema dal Color Control non è pertanto possibile.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>È stato installato un assistente BMS, configurato per un VE.Bus BMS, ma non è stato trovato il VE.Bus BMS!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>È stato installato un assistente BMS, configurato per un VE.Bus BMS, ma non è stato trovato il VE.Bus BMS!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Avvertenza: L'attivazione dell'equalizzazione in un sistema ESS che comprende caricabatterie solari può portare a una carica della batteria ad alta tensione con una corrente troppo elevata.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Avvertenza: L&apos;attivazione dell&apos;equalizzazione in un sistema ESS che comprende caricabatterie solari può portare a una carica della batteria ad alta tensione con una corrente troppo elevata.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Il sistema passerà automaticamente a mantenimento quando l'equalizzazione si sia completamente caricata.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Il sistema passerà automaticamente a mantenimento quando l&apos;equalizzazione si sia completamente caricata.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Interrompi equalizzazione</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Interrompi equalizzazione</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Compensazione</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Compensazione</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Interruzione in corso...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Interruzione in corso...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Avvio in corso...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Avvio in corso...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Avvio in corso...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Premere per interrompere</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Premere per interrompere</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Interrompi e riavvia assorbimento</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Interrompi e riavvia assorbimento</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Interrompi e vai a mantenimento</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Interrompi e vai a mantenimento</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Interrompi</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Interrompi</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Non interrompere</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Non interrompere</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Rileva nuovamente sistema</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Rileva nuovamente sistema</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Rilevazione in corso...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Rilevazione in corso...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Riavvia sistema VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Riavvia sistema VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Riavvio in corso...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Riavvio in corso...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Premere per riavviare</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Premere per riavviare</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>Entrata CA 1 ignorata</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>Entrata CA 1 ignorata</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>Entrata CA 2 ignorata</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>Entrata CA 2 ignorata</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Test Relè ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Test Relè ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Completo</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">In attesa</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Completo</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Completo</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>In attesa</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>In attesa</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Diagnosi VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Diagnosi VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Contatore di qualità della rete Fase L%1, dispositivo %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Contatore di qualità della rete Fase L%1, dispositivo %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>Rapporto Error 8 / 11 VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>Rapporto Error 8 / 11 VE.Bus</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Solo allarme</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Solo allarme</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Allarmi &amp; avvertenze</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Allarmi &amp; avvertenze</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Errore BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Errore BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Numeri di serie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Numeri di serie</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Ultimo rapporto Error 11 VE.Bus #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Ultimo rapporto Error 11 VE.Bus #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Test di sicurezza BF in corso</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Test di sicurezza BF in corso</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Test di sicurezza BF OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Test di sicurezza BF OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Discrepanza CA0 /CA1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Discrepanza CA0 /CA1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Errore di comunicazione</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Errore di comunicazione</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>Errore relè GND</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>Errore relè GND</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Discrepanza UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Discrepanza UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Discrepanza periodo di tempo</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Discrepanza periodo di tempo</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Discrepanza azionamento relè BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Discrepanza azionamento relè BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Errore: PE2 aperto</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Errore: PE2 aperto</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Errore: PE2 chiuso</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Errore: PE2 chiuso</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Errore passo: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Errore passo: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Fase L%1, dispositivo %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Fase L%1, dispositivo %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>La segnalazione dell'Errore 11 del VE.Bus richiede almeno la versione 454 del firmware del VE.Bus.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>La segnalazione dell&apos;Errore 11 del VE.Bus richiede almeno la versione 454 del firmware del VE.Bus.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus Quirks</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus Quirks</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energia</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energia</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Potenza</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Potenza</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Tensione</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Tensione</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Corrente</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Corrente</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Ubicazione</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Ubicazione</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Fase</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Entrata CA attiva</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Entrata CA attiva</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Ondulazione CC elevata</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Ondulazione CC elevata</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Alta tensione CC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Alta tensione CC</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Corrente CC alta</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Corrente CC alta</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Errore di rilevamento temperatura</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Errore di rilevamento temperatura</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Errore di rilevamento tensione</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Errore di rilevamento tensione</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Sovraccarico</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Sovraccarico</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>Ondulazione CC</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>Ondulazione CC</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Sensore di tensione</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Sensore di tensione</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Rotazione fase</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Rotazione fase</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Rotazione fase</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Versione VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Versione VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>Dispositivo MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>Dispositivo MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Versione MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Versione MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Versione Multi Control</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Versione Multi Control</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Versione VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Versione VE.Bus BMS</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Salvo interruzione di rete</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Salvo interruzione di rete</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>Ingresso CA</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>Ingresso CA</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>Ingresso CA</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>Ingresso CA</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>Ingresso CA 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>Ingresso CA 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>Ingresso CA 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>Ingresso CA 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Ruolo</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Ruolo</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>Carico CA</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>Carico CA</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>Uscita CA</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>Uscita CA</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>Uscita CA</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>Uscita CA</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Fase CA L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Fase CA L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Sensore CA %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Sensore CA %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Sensori CA</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Sensori CA</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Attivo</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Attivo</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Allarme</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Sovraccarico</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Stato allarme</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Stato allarme</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Allarmi</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Allarmi</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Autorizza carica</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Autorizza carica</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Consenti scarica</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Consenti scarica</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Scansione automatica</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Scansione automatica</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Batteria</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Batteria</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Corrente Batteria</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Corrente Batteria</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Tensione della batteria</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Tensione della batteria</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Corrente di carica</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Corrente di carica</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Carica in corso</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Carica in corso</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Errore di cancellazione</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Errore di cancellazione</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Chiuso</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Chiuso</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Connesso</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Connesso</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Corrente</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Corrente</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Trasformatori di corrente</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Trasformatori di corrente</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Nome personalizzato</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Nome personalizzato</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Debug</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Debug</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Dispositivo</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Dispositivo</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Disattivato</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Scarica in corso</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Scarica in corso</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Disconnesso</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Disconnesso</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Attiva</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Attiva</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Attivato</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Attivato</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energia</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energia</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Errore</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Errore</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Errore:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Errore:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Codice di errore</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Codice di errore</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Versione firmware</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Versione firmware</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generatore</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generatore</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Alta temperatura batteria</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Alta temperatura batteria</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Allarme livello alto</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Allarme livello alto</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Alta tensione batteria di avviamento</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Alta tensione batteria di avviamento</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Temperatura alta</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Temperatura alta</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Allarmi di alta tensione</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Allarmi di alta tensione</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Cronologia</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Cronologia</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Ora/e</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Ora/e</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Inattivo</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Inattivo</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inattivo</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inattivo</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Inverter / Caricabatterie</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>Indirizzo IP</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>Indirizzo IP</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Bassa temperatura batteria</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Bassa temperatura batteria</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Allarme livello basso</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Allarme livello basso</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Bassa tensione batteria di avviamento</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Bassa tensione batteria di avviamento</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Basso stato di carica</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Basso stato di carica</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Bassa temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Bassa temperatura</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Allarmi di bassa tensione</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Allarmi di bassa tensione</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Produttore</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Produttore</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Temperatura massima</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Temperatura massima</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Tensione massima</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Tensione massima</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Temperatura minima</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Temperatura minima</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Tensione minima</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Tensione minima</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Modalità</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Modalità</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Nome Modello</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Nome Modello</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>No</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>No</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Nessun errore</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Nessun errore</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Non disponibile</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Non disponibile</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Non connesso</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Non connesso</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Offline</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Offline</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>Ok</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>Ok</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Acceso</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Acceso</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Aperto</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Aperto</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Password</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Password</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Fase</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Premere per cancellare</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Premere per cancellare</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Premere per ripristinare</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Premere per ripristinare</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Premere per scansionare</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Premere per scansionare</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>Inverter FV</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>Inverter FV</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>Potenza FV</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>Potenza FV</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Ore di silenzio</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Ore di silenzio</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relè</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relè</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Riavvio</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Riavvio</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Rimuovi</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Rimuovi</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>In funzionamento</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>In funzionamento</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Scansione %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Scansione %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Numero di serie</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Numero di serie</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Impostazioni</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Impostazioni</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Impostazione</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Impostazione</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Forza del segnale</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Forza del segnale</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Standby</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Standby</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Avviare quando la condizione sia attiva per</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Avviare quando la condizione sia attiva per</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Ora di avviamento</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Ora di avviamento</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Valore di avvio durante ore di silenzio</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Valore di avvio durante ore di silenzio</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Avvia quando l'avviso è attivo per</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Avvia quando l&apos;avviso è attivo per</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Stato della carica</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Stato della carica</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Stato</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Stato</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Avvio (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Avvio (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Valore di arresto nelle ore di silenzio</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Valore di arresto nelle ore di silenzio</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Arrestare quando la condizione sia attiva per</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Arrestare quando la condizione sia attiva per</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Arrestato</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Arrestato</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatura</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Sensore di temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Sensore di temperatura</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Oggi</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Oggi</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Totale</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Totale</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Tracciatore</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Tracciatore</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Tipo</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Numero Identificativo Univoco</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Numero Identificativo Univoco</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Sconosciuto</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Sconosciuto</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Errore VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Errore VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Tensione</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Tensione</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Istanza VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Istanza VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Una volta cancellato l'avviso, arresta dopo</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Una volta cancellato l&apos;avviso, arresta dopo</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Sì</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Sì</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Ieri</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Ieri</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Rendimento</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Rendimento</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Limite di potenza di zero feed-in</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Limite di potenza di zero feed-in</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Data impostata</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Data impostata</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Avvia ora</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Avvia ora</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Funzionamento a tempo</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Funzionamento a tempo</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Arresta ora</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Arresta ora</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Tempo di esecuzione totale</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Tempo di esecuzione totale</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Tempo impostato %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Tempo impostato %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Il generatore continuerà a funzionare se viene soddisfatta una condizione di avvio automatico.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Il generatore continuerà a funzionare se viene soddisfatta una condizione di avvio automatico.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Modalità Inverter / Caricabatterie</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Modalità Inverter / Caricabatterie</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Imposta</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Imposta</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Cancella</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Cancella</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Chiudi</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Chiudi</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Tempo impostato</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Tempo impostato</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Già in uso</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Già in uso</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Errore di scambio</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Errore di scambio</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Scambio completato</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Scambio completato</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Scambio istanze dispositivo in corso...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Scambio istanze dispositivo in corso...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>L'istanza del dispositivo %1 è già utilizzata da “%3”. Scambiare le istanze del dispositivo e assegnarle a %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>L&apos;istanza del dispositivo %1 è già utilizzata da “%3”. Scambiare le istanze del dispositivo e assegnarle a %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>L'istanza del dispositivo %1 è già utilizzata da un altro dispositivo dello stesso tipo. Scambiare le istanze del dispositivo e assegnarle a %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>L&apos;istanza del dispositivo %1 è già utilizzata da un altro dispositivo dello stesso tipo. Scambiare le istanze del dispositivo e assegnarle a %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Impossibile scambiare le istanze del dispositivo: l'operazione è scaduta.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Impossibile scambiare le istanze del dispositivo: l&apos;operazione è scaduta.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Le nuove istanze del dispositivo saranno attive al riavvio.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Le nuove istanze del dispositivo saranno attive al riavvio.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Scambio</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Scambio</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Errore durante la verifica degli aggiornamenti del firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Errore durante la verifica degli aggiornamenti del firmware</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Download e installazione del firmware in corso%1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Download e installazione del firmware in corso%1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Installazione del firmware in corso...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Installazione del firmware in corso...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Errore durante l'installazione del firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Errore durante l&apos;installazione del firmware</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Non ci sono nuove versioni disponibili</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Non ci sono nuove versioni disponibili</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Non sono stati trovati firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Non sono stati trovati firmware</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Carburante</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Carburante</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Acqua dolce</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Acqua dolce</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Acque reflue</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Acque reflue</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Serbatoio</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Serbatoio</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Olio</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Olio</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>ACQUE NERE</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>ACQUE NERE</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzina</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzina</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diesel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diesel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Olio idraulico</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Olio idraulico</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Acqua grezza</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Acqua grezza</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Impostazione bloccata per livello accesso</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Impostazione bloccata per livello accesso</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Password erronea</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Password erronea</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Ragguagli</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Ragguagli</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Panoramica</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Panoramica</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Livelli</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Livelli</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Notifiche</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Notifiche</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Ora</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Ora</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1m fa</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1m fa</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1h %2m fa</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1h %2m fa</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Ogni giorno</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Ogni giorno</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Durante la settimana</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Durante la settimana</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Fine settimana</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Fine settimana</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Lunedì</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Lunedì</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Martedì</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Martedì</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Mercoledì</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Mercoledì</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Giovedì</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Giovedì</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Venerdì</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Venerdì</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Sabato</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Sabato</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Domenica</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Domenica</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 or %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 or %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Orario %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Orario %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Giorno</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Giorno</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Non impostata</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Non impostata</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Limite SoC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Limite SoC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Autoconsumo oltre il limite</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Autoconsumo oltre il limite</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">FV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>FV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>FV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>FV e Batteria</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>FV e Batteria</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Verifica in corso...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Verifica in corso...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Stato allarme</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Stato allarme</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Allarme</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Cancellare cronologia</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Cancellare cronologia</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Cancellazione in corso</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Cancellazione in corso</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Accensione forzata</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Accensione forzata</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Spegnimento forzato</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Spegnimento forzato</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Stato relè</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Stato relè</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Ripristinare la cronologia sul monitor stesso</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Ripristinare la cronologia sul monitor stesso</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Premere per espellere</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Premere per espellere</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Espulsione, si prega di attendere</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Espulsione, si prega di attendere</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Nessuna archiviazione trovata</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Nessuna archiviazione trovata</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 sensore di temperatura</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 sensore di temperatura</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 sensore temperatura (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 sensore temperatura (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Sensore della temperatura (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Sensore della temperatura (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Nessuna azione</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Nessuna azione</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Avvertenza: Le temperature di attivazione e disattivazione sono impostate sullo stesso valore. Tale situazione porta a ignorare la condizione.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Avvertenza: Le temperature di attivazione e disattivazione sono impostate sullo stesso valore. Tale situazione porta a ignorare la condizione.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Condizione %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Condizione %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Funzione disattivata</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Funzione disattivata</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Nessuno (Disattiva)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Nessuno (Disattiva)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relè 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relè 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relè 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relè 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Avvertenza: Il relè precedentemente selezionato non è configurato per la temperatura, questa condizione verrà ignorata.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Avvertenza: Il relè precedentemente selezionato non è configurato per la temperatura, questa condizione verrà ignorata.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Valore attivazione</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Valore attivazione</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Unità volume</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Unità volume</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Metri cubi</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Metri cubi</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Litri (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Litri (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Galloni (USA)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Galloni (USA)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Galloni (Imperiali)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Galloni (Imperiali)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Tensione min.</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Tensione min.</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Tensione massima</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Tensione massima</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Tensione massima</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Corrente max</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Corrente max</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Tempo di carica</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Tempo di carica</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Prima fase</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Mantenimento</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">h</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Prima fase</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Prima fase</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Assorbimento</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Assorbimento</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Mantenimento</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Mantenimento</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>h</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>h</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 si è verificato un errore/i</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 si è verificato un errore/i</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Carico</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Carico</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Penultimo</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Penultimo</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Terzultimo</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Terzultimo</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Quartultimo</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Quartultimo</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Potenza max</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Potenza max</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Impossibile connettersi</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Impossibile connettersi</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Disconnesso, tentativo di riconnessione in corso</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Disconnesso, tentativo di riconnessione in corso</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Collegamento in corso</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Collegamento in corso</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Collegamento in corso</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Connesso, in attesa dei messaggi del broker</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Connesso, in attesa dei messaggi del broker</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Connesso, ricezione dei messaggi del broker in corso</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Connesso, ricezione dei messaggi del broker in corso</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Connesso, caricamento interfaccia utente in corso</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Connesso, caricamento interfaccia utente in corso</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Versione del protocollo non valida</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Versione del protocollo non valida</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>ID cliente rifiutato</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>ID cliente rifiutato</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Servizio del broker non disponibile</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Servizio del broker non disponibile</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Nome utente o password errati</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Nome utente o password errati</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Cliente non autorizzato</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Cliente non autorizzato</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Errore di connessione trasporto</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Errore di connessione trasporto</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Errore di violazione del protocollo</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Errore di violazione del protocollo</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Errore di livello 5 del protocollo MQTT</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Errore di livello 5 del protocollo MQTT</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Silenziamento allarme</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Silenziamento allarme</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Potenza totale</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Potenza totale</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1h %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1h %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Errore</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Errore</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Recupero dell'indirizzo IP in corso</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Recupero dell&apos;indirizzo IP in corso</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connesso</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Disconnettere</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Disconnettere</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Disconnesso</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>Carichi CA</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>Carichi CA</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>Carichi CC</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>Carichi CC</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Vento</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Vento</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Banchina</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Banchina</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Limite di corrente di rete</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Limite di corrente di rete</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Limite di corrente del generatore</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Limite di corrente del generatore</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Limite di corrente da banchina</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Limite di corrente da banchina</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">In interruzione</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>In interruzione</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>In interruzione</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 al termine</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 al termine</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 Serbatoio (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 Serbatoio (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>Caricabatterie CA</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>Caricabatterie CA</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Generatore</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Generatore</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>Caricabatterie CC</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>Caricabatterie CC</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Generatore di CC</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Generatore di CC</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>SISTEMA CC</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>SISTEMA CC</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Cella a combustibile</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Cella a combustibile</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Generatore Asse</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Generatore Asse</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Generatore ad acqua</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Generatore ad acqua</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Caricabatterie Eolico</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Caricabatterie Eolico</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Basso</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Basso</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Alto</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Alto</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Conservare batterie cariche</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Conservare batterie cariche</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Ottimizzato per la durata della batteria</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Ottimizzato per la durata della batteria</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Ottimizzato senza Batterylife</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Ottimizzato senza Batterylife</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Controllo esterno</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Caricato</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Caricato</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>In attesa di sole</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>In attesa di sole</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>In attesa di RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>In attesa di RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>In attesa dell'avvio</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>In attesa dell&apos;avvio</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Errore del test di messa a terra</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Errore del test di messa a terra</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Errore del test dell’ingresso CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Errore del test dell’ingresso CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Rilevata corrente residua</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Rilevata corrente residua</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Rilevata sottotensione</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Rilevata sottotensione</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Rilevata sovratensione</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Rilevata sovratensione</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Rilevato surriscaldamento</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Rilevato surriscaldamento</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Limite di carica</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Limite di carica</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Avvio della carica</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Avvio della carica</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Programmato</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Programmato</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Programmato</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Riscaldamento</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Riscaldamento</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Raffreddamento</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Raffreddamento</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Esecuzione di prova</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Esecuzione di prova</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Avviato manualmente</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Avviato manualmente</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Caricamento avvio</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Caricamento avvio</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>In funzionamento (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>In funzionamento (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>In funzionamento (Throttled)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>In funzionamento (Throttled)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relè %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relè %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Errore</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Errore</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Assorbimento</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Assorbimento</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Accumulo</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Accumulo</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Equalizza</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Equalizza</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Controllo esterno</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Modalità AES</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Modalità AES</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Condizione di errore</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Condizione di errore</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Carica Bulk</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Carica Bulk</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Carica Absorption</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Carica Absorption</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Carica Float</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Carica Float</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Modalità conservazione</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Modalità conservazione</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Carica di equalizzazione</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Carica di equalizzazione</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Pass-thru</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Pass-thru</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Inversione in corso</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Inversione in corso</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Assistenza in corso</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Assistenza in corso</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Modalità alimentazione</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Modalità alimentazione</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Supporto</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Risveglio</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Risveglio</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Assorbimento ripetuto</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Assorbimento ripetuto</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Equalizzazione automatica</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Equalizzazione automatica</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>BatterySafe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>BatterySafe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Rilevamento del carico</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Rilevamento del carico</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Bloccato</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Bloccato</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">ESS dinamico</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>ESS dinamico</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>ESS dinamico</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Gruppo Master</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Gruppo Master</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Istanza Master</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Istanza Master</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Gruppo e Istanza Master</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Gruppo e Istanza Master</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Autonomo e Gruppo Master</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Autonomo e Gruppo Master</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Solo caricabatterie</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Solo caricabatterie</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Solo inverter</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Solo inverter</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Allarme bassa tensione batteria</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Allarme alta tensione batteria</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Allarme cortocircuito</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Allarme cortocircuito</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Disattiva Punto di Accesso</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Disattiva Punto di Accesso</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Ingresso CC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Ingresso CC</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Per le batterie al litio, si sconsiglia di scendere sotto il 10 % della carica. Per altri tipi di batterie, consultare nella scheda tecnica il livello minimo raccomandato dal produttore.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Per le batterie al litio, si sconsiglia di scendere sotto il 10 % della carica. Per altri tipi di batterie, consultare nella scheda tecnica il livello minimo raccomandato dal produttore.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Disattivare Avvio automatico?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Disattivare Avvio automatico?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Inverter / Caricabatterie (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Inverter / Caricabatterie (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Visualizza utilizzo CPU</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Visualizza utilizzo CPU</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Esci dall’applicazione</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Esci dall’applicazione</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Abbandonare</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Abbandonare</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Versione dell'applicazione</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Versione dell&apos;applicazione</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Temperatura dell'olio</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Temperatura dell&apos;olio</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Tenere presente che cambiando l’impostazione "Soglia di scarica tempo restante" cambia anche l'impostazione "Basso livello di carica" nel menù relè.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Tenere presente che cambiando l’impostazione &quot;Soglia di scarica tempo restante&quot; cambia anche l&apos;impostazione &quot;Basso livello di carica&quot; nel menù relè.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Tempo funzionamento</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Tempo funzionamento</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Ah caricati</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Ah caricati</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Cicli iniziati</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Cicli iniziati</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Cicli completati</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Cicli completati</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Numero di accensioni</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Numero di accensioni</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Numero di scariche profonde</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Numero di scariche profonde</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Cronologia ciclo di carica</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Cronologia ciclo di carica</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Valore sensore quando è pieno</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Valore sensore quando è pieno</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Tempo rimanente al servizio</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Tempo rimanente al servizio</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Funzionalità di avvio automatico</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Funzionalità di avvio automatico</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Assicurarsi che il generatore non sia collegato all'ingresso CA %1 quando si utilizza questa opzione.</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Assicurarsi che il generatore non sia collegato all&apos;ingresso CA %1 quando si utilizza questa opzione.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Il timer di servizio è stato ripristinato</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Il timer di servizio è stato ripristinato</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>La scansione continua può interferire con il funzionamento del WiFi.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>La scansione continua può interferire con il funzionamento del WiFi.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Intervalli indicatori minimi e massimi</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Intervalli indicatori minimi e massimi</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Riavvio dell'applicazione in corso...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Riavvio dell&apos;applicazione in corso...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Non è stato possibile cambiare la lingua!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Non è stato possibile cambiare la lingua!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Mai</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Si prega di attendere mentre si modifica la lingua.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Si prega di attendere mentre si modifica la lingua.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Unità di visualizzazione brevi</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Unità di visualizzazione brevi</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Non ci sono etichette</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Non ci sono etichette</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Mostra volumi serbatoi</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Mostra volumi serbatoi</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Mostra percentuali</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Mostra percentuali</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Nota: Se non è possibile visualizzare la corrente (ad esempio, quando si mostra un totale per le sorgenti combinate CA e CC), al suo posto viene mostrata la potenza.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Nota: Se non è possibile visualizzare la corrente (ad esempio, quando si mostra un totale per le sorgenti combinate CA e CC), al suo posto viene mostrata la potenza.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Limiti corrente di carica</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Limiti corrente di carica</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Release ufficiale</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Release ufficiale</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Versione beta</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Versione beta</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Test (interno di Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Test (interno di Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Sviluppo (interno di Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Sviluppo (interno di Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Riavvio in corso...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Riavvio in corso...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Abilitazione dei LED di stato</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Abilitazione dei LED di stato</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Riscaldamento e raffreddamento</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Riscaldamento e raffreddamento</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Tempo di arresto del generatore</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Tempo di arresto del generatore</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Allarme se il generatore non si trova in modalità di avvio automatico</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Allarme se il generatore non si trova in modalità di avvio automatico</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Quando la funzione di avvio automatico rimane disattivata per più di 10 minuti, scatta un allarme</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Quando la funzione di avvio automatico rimane disattivata per più di 10 minuti, scatta un allarme</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Autoconsumo da batteria</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Autoconsumo da batteria</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Tutti i carichi del sistema</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Tutti i carichi del sistema</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Solo carichi critici</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Solo carichi critici</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">SOC minima di scarico (a meno fallimento griglia)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Stato vita utile della batteria</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Stato vita utile della batteria</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Accedere a Signal K in http://venus.local:3000 e tramite VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Accedere a Signal K in http://venus.local:3000 e tramite VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Accedere a Node-RED in https://venus.local:1881 e tramite VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Accedere a Node-RED in https://venus.local:1881 e tramite VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Misurazioni batteria</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Misurazioni batteria</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Stato del sistema</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Stato del sistema</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Elenco dispositivi</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Elenco dispositivi</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Istanze dispositivo VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Istanze dispositivo VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Allarme temperatura alta</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Allarme temperatura alta</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Controllato dal BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Controllato dal BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Allarmi ed Errori</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Allarmi ed Errori</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Questa funzione richiede la versione 400 o successiva del firmware. Contattare l'installatore per aggiornare il Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Questa funzione richiede la versione 400 o successiva del firmware. Contattare l&apos;installatore per aggiornare il Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Caricabatterie non pronto, l'equalizzazione non può iniziare</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Caricabatterie non pronto, l&apos;equalizzazione non può iniziare</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Non si può attivare l'equalizzazione durante la fase di carica di massa.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Non si può attivare l&apos;equalizzazione durante la fase di carica di massa.</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Corrente massima</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Corrente massima</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Potenza massima</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Potenza massima</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Corrente minima</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Corrente minima</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Nessuno</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Non disponibile</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Spento</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">Ok</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Cronologia complessiva</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Cronologia complessiva</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Impostazioni</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Rendimento odierno</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Rendimento odierno</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware installato, riavvio del dispositivo in corso</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware installato, riavvio del dispositivo in corso</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Controllo ingresso touch</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Controllo ingresso touch</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Errore del test dei contatti saldati (in cortocircuito)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Errore del test dei contatti saldati (in cortocircuito)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Commutazione a trifase in corso</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Commutazione a trifase in corso</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Commutazione a monofase in corso</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Commutazione a monofase in corso</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Arrestare la carica</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Arrestare la carica</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Riservato</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Riservato</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Modalità inverter</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Modalità inverter</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Out L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Out L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Entrata</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Entrata</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Passaggio</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Passaggio</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>La pagina si ricaricherà automaticamente dopo dieci secondi per caricare la versione più recente.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>La pagina si ricaricherà automaticamente dopo dieci secondi per caricare la versione più recente.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Inverter (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Inverter (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Inverter/Caricabatterie</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Inverter/Caricabatterie</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Non sono stati trovati contatori di energia
+        <translation>Non sono stati trovati contatori di energia
 
 Notare che questo menu mostra solo i contatori Carlo Gavazzi collegati tramite RS485. Per tutti gli altri contatori, compresi i Carlo Gavazzi collegati via Ethernet, consultare il menu Dispositivi Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Autocalibrazione</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Autocalibrazione</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Se attiva, i valori minimi e massimi di indicatori e grafici vengono regolati automaticamente in base ai valori passati.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Se attiva, i valori minimi e massimi di indicatori e grafici vengono regolati automaticamente in base ai valori passati.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Ripristina tutti i valori degli intervalli a zero</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Ripristina tutti i valori degli intervalli a zero</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Ripristina intervalli valori</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Ripristina intervalli valori</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Siete sicuri di voler azzerare tutti i valori?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Siete sicuri di voler azzerare tutti i valori?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Corrente massima: AC in 1 collegato</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Corrente massima: AC in 1 collegato</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Corrente massima: AC in 2 collegato</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Corrente massima: AC in 2 collegato</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Corrente massima: non ci sono ingressi CA</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Corrente massima: non ci sono ingressi CA</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>Uscita CC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>Uscita CC</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solare</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solare</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>RPM motore</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>RPM motore</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Temperatura motore</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Temperatura motore</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Temperatura regolatore</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Temperatura regolatore</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Ciclo attivo</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Ciclo attivo</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Ciclo %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Ciclo %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>Disconnessione CC</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>Disconnessione CC</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Spento</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Spento</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Cambio di funzione</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Cambio di funzione</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Aggiornamento firmware</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Aggiornamento firmware</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Ripristino del software</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Ripristino del software</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Incompleto</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Incompleto</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Tempo trascorso</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Tempo trascorso</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Carica / mantenimento (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Carica / mantenimento (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Batteria (V&lt;sub&gt;inizio&lt;/sub&gt;/V&lt;sub&gt;fine&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Batteria (V&lt;sub&gt;inizio&lt;/sub&gt;/V&lt;sub&gt;fine&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Bassa tensione CA USCITA</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Bassa tensione CA USCITA</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Alta tensione CA in uscita</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Alta tensione CA in uscita</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Rendimento totale</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Rendimento totale</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Rendimento sistema</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Rendimento sistema</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Cronologia giornaliera</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Cronologia giornaliera</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Nessun allarme da configurare</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Nessun allarme da configurare</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Tensione massima FV</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Tensione massima FV</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Tensione massima della batteria</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Tensione massima della batteria</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Tensione minima della batteria</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Tensione minima della batteria</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Errore banco batterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Errore banco batterie</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Tensione batteria non supportata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Tensione batteria non supportata</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Numero di batterie non corretto</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Numero di batterie non corretto</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Configurazione della batteria non valida</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Configurazione della batteria non valida</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Stato del Balancer</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Stato del Balancer</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Bilanciato</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Bilanciato</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Sbilanciamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Sbilanciamento</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Utilizzare quest’opzione nei sistemi che non eseguono la riduzione dei picchi.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Utilizzare quest’opzione nei sistemi che non eseguono la riduzione dei picchi.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Utilizzare questa opzione per la riduzione dei picchi.</translation>
+        <translation>Utilizzare questa opzione per la riduzione dei picchi.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>La soglia di riduzione dei picchi viene impostata mediante l'impostazione del limite di corrente di ingresso CA. Per ulteriori informazioni, consultare la documentazione.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>La soglia di riduzione dei picchi viene impostata mediante l&apos;impostazione del limite di corrente di ingresso CA. Per ulteriori informazioni, consultare la documentazione.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>In questa schermata è possibile modificare le soglie di riduzione dei picchi per l'importazione e l'esportazione. Per ulteriori informazioni, consultare la documentazione.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>In questa schermata è possibile modificare le soglie di riduzione dei picchi per l&apos;importazione e l&apos;esportazione. Per ulteriori informazioni, consultare la documentazione.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Limitazione della corrente di importazione CA del sistema</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Limitazione della corrente di importazione CA del sistema</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Per utilizzare questa funzione, la Misurazione della rete deve essere impostata su Contatore esterno e deve essere installato un assistente ESS aggiornato.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Per utilizzare questa funzione, la Misurazione della rete deve essere impostata su Contatore esterno e deve essere installato un assistente ESS aggiornato.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Massima corrente di importazione del sistema (per fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Massima corrente di importazione del sistema (per fase)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Per utilizzare questa funzione, la Misurazione della rete deve essere impostata su Contatore esterno.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Per utilizzare questa funzione, la Misurazione della rete deve essere impostata su Contatore esterno.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Massima corrente di esportazione del sistema (per fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Massima corrente di esportazione del sistema (per fase)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Cablato</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Cablato</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Ragguagli</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Carico di sistema elevato, chiusura del pannello laterale per ridurre il carico della CPU in corso</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Carico di sistema elevato, chiusura del pannello laterale per ridurre il carico della CPU in corso</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Limite corrente in ingresso</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Limite corrente in ingresso</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Cortocircuito</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Cortocircuito</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Acquisto</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Acquisto</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Vendita</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Vendita</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Obiettivo SoC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Obiettivo SoC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>Uscita CA %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>Uscita CA %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Tracciatori</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Tracciatori</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Dispositivi RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Dispositivi RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Mettere in pausa le animazioni degli elettroni</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Mettere in pausa le animazioni degli elettroni</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Capacità totale</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Capacità totale</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Numero di BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Numero di BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Limitazione della corrente di esportazione CA del sistema</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Limitazione della corrente di esportazione CA del sistema</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Dispositivi Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Dispositivi Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Aggiungi dispositivo</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Aggiungi dispositivo</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Ricerca dispositivi</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Ricerca dispositivi</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Dispositivi salvati</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Dispositivi salvati</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Dispositivi rilevati</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Dispositivi rilevati</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Aggiungi dispositivo Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Aggiungi dispositivo Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protocollo</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protocollo</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Porta</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Porta</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Unità</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Unità</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Nessun dispositivo Modbus salvato</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Nessun dispositivo Modbus salvato</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Dispositivo %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Dispositivo %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Eliminare il dispositivo Modbus?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Eliminare il dispositivo Modbus?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Nessun dispositivo Modbus rilevato</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Nessun dispositivo Modbus rilevato</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Batteria %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Batteria %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>Corrente CA</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>Corrente CA</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Avvio/arresto generatore disattivato</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Avvio/arresto generatore disattivato</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>La funzionalità di avvio remoto è disattivata nel generatore. Il GX non sarà in grado di avviare o arrestare il generatore. Attivarla sul pannello di controllo del generatore.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>La funzionalità di avvio remoto è disattivata nel generatore. Il GX non sarà in grado di avviare o arrestare il generatore. Attivarla sul pannello di controllo del generatore.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Funzione avvio automatico</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Funzione avvio automatico</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Tempo di funzionamento attuale</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Stato del controllo</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Stato del controllo</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Stato del generatore</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Stato del generatore</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Modalità avvio remoto</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Modalità avvio remoto</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Pressione dell'olio</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Pressione dell&apos;olio</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Livelli di carica programmati</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Livelli di carica programmati</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Attivo (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Attivo (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Arresto manuale</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Arresto manuale</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Circuito aperto</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Circuito aperto</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (non disponibile)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (non disponibile)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Ingresso Touch on</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Ingresso Touch on</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Ingresso Touch off</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Ingresso Touch off</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Ingresso Touch disattivato</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Ingresso Touch disattivato</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Riconoscere gli avvisi</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Riconoscere gli avvisi</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Codice errore del controllo</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Codice errore del controllo</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Utilizzare questo menu per definire i dati della batteria visualizzati quando si fa clic sull'icona Batteria nella pagina Panoramica. La stessa selezione è visibile anche sul portale VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Utilizzare questo menu per definire i dati della batteria visualizzati quando si fa clic sull&apos;icona Batteria nella pagina Panoramica. La stessa selezione è visibile anche sul portale VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Tensione del sistema [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Tensione del sistema [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Informazioni sulla connessione</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Informazioni sulla connessione</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Si prega di selezionare...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Si prega di selezionare...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Sicuro</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Sicuro</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Protetto da password e comunicazione in rete crittografata</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Protetto da password e comunicazione in rete crittografata</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Debole</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Debole</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Protetto da password, ma la comunicazione di rete non è crittografata</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Protetto da password, ma la comunicazione di rete non è crittografata</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Non sicuro</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Non sicuro</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Nessuna password e la comunicazione di rete non è crittografata</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Nessuna password e la comunicazione di rete non è crittografata</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">La password deve avere una lunghezza di almeno 8 caratteri</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Inserire password</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>La password deve avere una lunghezza di almeno 8 caratteri</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>La password deve avere una lunghezza di almeno 8 caratteri</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Selezionare il profilo "Protetto"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Selezionare il profilo &quot;Protetto&quot;?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Selezionare il profilo "Debole"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Selezionare il profilo &quot;Debole&quot;?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Selezionare il profilo "Non sicuro"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Selezionare il profilo &quot;Non sicuro&quot;?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>• I servizi della rete locale sono protetti da password\n• La comunicazione di rete è criptata
+        <translation>• I servizi della rete locale sono protetti da password\n• La comunicazione di rete è criptata
 • È attiva una connessione sicura con il VRM
 • Non è possibile attivare impostazioni non sicure</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• I servizi della rete locale sono protetti da password
+        <translation>• I servizi della rete locale sono protetti da password
 • È attivo anche l’accesso non criptato ai siti web locali (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• I servizi della rete locale non richiedono password
+        <translation>• I servizi della rete locale non richiedono password
 • È attivo anche l’accesso non criptato ai siti web locali (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Password di root</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Password di root</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Esci</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Esci</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Esci ora</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Esci ora</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Uscire?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Uscire?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>In questo modo si scollegano tutte le connessioni alla rete locale.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>In questo modo si scollegano tutte le connessioni alla rete locale.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Log out</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Log out</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Sola lettura</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Sola lettura</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Completo</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Completo</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Siete sicuri?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Siete sicuri?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Se si modifica questa impostazione in Sola lettura o Off, l'utente viene bloccato.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Se si modifica questa impostazione in Sola lettura o Off, l&apos;utente viene bloccato.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Accesso MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Accesso MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' non è un numero.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; non è un numero.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Conferma</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Conferma</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Utilizzare un numero di %1 cifre o meno.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Utilizzare un numero di %1 cifre o meno.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' non è un indirizzo IP valido</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; non è un indirizzo IP valido</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' non è un numero di porta valido Utilizzare un numero compreso tra 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; non è un numero di porta valido Utilizzare un numero compreso tra 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 non è un numero di unità valido. Utilizzare un numero compreso tra 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 non è un numero di unità valido. Utilizzare un numero compreso tra 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Tempo di funzionamento attuale</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Tempo di funzionamento attuale</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Codici errore del generatore</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Codici errore del generatore</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Temperatura del dissipatore</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Temperatura del dissipatore</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Tensione di carica</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>La tensione di carica è attualmente controllata dal BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>La tensione di carica è attualmente controllata dal BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Limite corrente di carica</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Limite corrente di carica</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>Controllato dal BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>Controllato dal BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Il controllo del BMS è automaticamente attivo quando è presente un BMS. Ripristinarlo se è cambiata la configurazione del sistema o se non sono presenti BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Il controllo del BMS è automaticamente attivo quando è presente un BMS. Ripristinarlo se è cambiata la configurazione del sistema o se non sono presenti BMS.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Timer di servizio disattivato.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Timer di servizio disattivato.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Portale VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Portale VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (accesso VPN remoto)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (accesso VPN remoto)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SoC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SoC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Prima di poter attivare i servizi di rete, è necessario configurare un profilo di sicurezza, vedere Impostazioni - Generale</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Prima di poter attivare i servizi di rete, è necessario configurare un profilo di sicurezza, vedere Impostazioni - Generale</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' è stato sostituito da '%2' poiché conteneva caratteri non validi.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; è stato sostituito da &apos;%2&apos; poiché conteneva caratteri non validi.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Inizializzazione in corso...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Inizializzazione in corso...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Avvio backend in corso...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Avvio backend in corso...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend arrestato.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend arrestato.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Connessione non riuscita.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Connessione non riuscita.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Questo dispositivo GX si è disconnesso da Tailscale.
+        <translation>Questo dispositivo GX si è disconnesso da Tailscale.
 
 Si prega di attendere o di controllare la connessione a Internet.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>In attesa di una risposta da Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>In attesa di una risposta da Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Collegare questo dispositivo GX al proprio account Tailscale aprendo questo link:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Collegare questo dispositivo GX al proprio account Tailscale aprendo questo link:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Si prega di attendere o di controllare la connessione a Internet.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Si prega di attendere o di controllare la connessione a Internet.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Stato sconosciuto: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Stato sconosciuto: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Errore: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Errore: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Disattivare Tailscale per modificare queste impostazioni.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Disattivare Tailscale per modificare queste impostazioni.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Attivare Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Attivare Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Nome della macchina</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Nome della macchina</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Logout dall'account Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Logout dall&apos;account Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Accesso alla rete locale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Accesso alla rete locale</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Accesso alla rete Ethernet locale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Accesso alla rete Ethernet locale</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Accesso alla rete WiFi locale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Accesso alla rete WiFi locale</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Rete/i personalizzata/e</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Rete/i personalizzata/e</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Esempio: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Esempio: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Spiegazione:
+        <translation>Spiegazione:
 
-Questa funzione, che Tailscale chiama route di sottorete, consente l'accesso remoto ad altri dispositivi della rete locale.
+Questa funzione, che Tailscale chiama route di sottorete, consente l&apos;accesso remoto ad altri dispositivi della rete locale.
 
 Il campo reti personalizzate accetta un elenco di sottoreti con notazione CIDR separate da virgole.
 
 Dopo aver aggiunto/attivato una nuova rete, è necessario approvarla una volta nella consolle di amministrazione di Tailscale.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Argomenti personalizzati "tailscale up"</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Argomenti personalizzati &quot;tailscale up&quot;</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>URL del server personalizzato (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>URL del server personalizzato (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Questo controllore del generatore deve essere controllato da un relè ausiliare, ma tale relè non è configurato. Configurare il Relè 1 in Impostazioni → Relè come "Relè ausiliare del generatore collegato".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Questo controllore del generatore deve essere controllato da un relè ausiliare, ma tale relè non è configurato. Configurare il Relè 1 in Impostazioni → Relè come &quot;Relè ausiliare del generatore collegato&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Allarmi di alta tensione batteria di avviamento</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Allarmi di alta tensione batteria di avviamento</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Saltare il riscaldamento del generatore</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Saltare il riscaldamento del generatore</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Attivo, ma senza servizi (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Attivo, ma senza servizi (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>La password di root è stata modificata come %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>La password di root è stata modificata come %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Relè ausiliare del generatore collegato</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Relè ausiliare del generatore collegato</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Posizione dei carichi CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Posizione dei carichi CA</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Ingresso e uscita CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Ingresso e uscita CA</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Utilizzare quest’opzione quando sull'ingresso dell'inverter/caricabatterie sono presenti carichi CA. Utilizzare quest’opzione se non si è sicuri.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Utilizzare quest’opzione quando sull&apos;ingresso dell&apos;inverter/caricabatterie sono presenti carichi CA. Utilizzare quest’opzione se non si è sicuri.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Solo uscita CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Solo uscita CA</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Utilizzare quest’opzione se il sistema utilizza un contatore di rete, ma tutti i carichi CA sono sull'uscita dell'inverter/caricabatterie.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Utilizzare quest’opzione se il sistema utilizza un contatore di rete, ma tutti i carichi CA sono sull&apos;uscita dell&apos;inverter/caricabatterie.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Mensilmente</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Mensilmente</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>Caricabatterie EV</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>Caricabatterie EV</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Pompa di calore</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Pompa di calore</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Carichi essenziali</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Carichi essenziali</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Avviare e arrestare il generatore in base alle condizioni di avvio automatico configurate.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Avviare e arrestare il generatore in base alle condizioni di avvio automatico configurate.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Impostazioni del generatore CC</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Impostazioni del generatore CC</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Temperatura alternatore</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Temperatura alternatore</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Temperatura motore</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Temperatura motore</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Tempo di esecuzione totale</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Tempo di esecuzione totale</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Profilo di sicurezza della rete</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Profilo di sicurezza della rete</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Ultimi %1 giorni</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Ultimi %1 giorni</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Il generatore si arresterà tra %1 a meno che non siano attivate condizioni di autoavvio che lo mantengano in funzione.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Il generatore si arresterà tra %1 a meno che non siano attivate condizioni di autoavvio che lo mantengano in funzione.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Il generatore funziona finché non viene arrestato manualmente, salvo che non siano state attivate condizioni di avvio automatico che lo mantengano in funzione.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Il generatore funziona finché non viene arrestato manualmente, salvo che non siano state attivate condizioni di avvio automatico che lo mantengano in funzione.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>IU classica</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>IU classica</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Nuova IU</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Nuova IU</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Cambio di lingua riuscito!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Limitazione della potenza</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Cambio di lingua riuscito!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Per i dispositivi Multi-RS e HS19, le impostazioni ESS sono disponibili nella pagina del prodotto RS System.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Per i dispositivi Multi-RS e HS19, le impostazioni ESS sono disponibili nella pagina del prodotto RS System.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Avvio/arresto generatore</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Avvio/arresto generatore</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>La commutazione della versione del firmware non è possibile se non è selezionato "Profilo di sicurezza della rete" in "Impostazioni / Generali".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>La commutazione della versione del firmware non è possibile se non è selezionato &quot;Profilo di sicurezza della rete&quot; in &quot;Impostazioni / Generali&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Durata</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Durata</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Allarmi di sistema</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Allarmi di sistema</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Nessun allarme di sistema</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Nessun allarme di sistema</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Indietro</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Indietro</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Novità</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Novità</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>salta</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>salta</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Benvenuti!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Benvenuti!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Siamo entusiasti di presentare un'interfaccia completamente ridisegnata che migliora sia l'usabilità che l'estetica del vostro GX. Grazie a una navigazione semplificata e a un nuovo aspetto, tutto ciò che amate è ora ancora più facile da raggiungere e più attraente dal punto di vista visivo.</translation>
+        <translation>Siamo entusiasti di presentare un&apos;interfaccia completamente ridisegnata che migliora sia l&apos;usabilità che l&apos;estetica del vostro GX. Grazie a una navigazione semplificata e a un nuovo aspetto, tutto ciò che amate è ora ancora più facile da raggiungere e più attraente dal punto di vista visivo.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Modalità scura - chiara</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Modalità scura - chiara</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Ambienti diversi richiedono impostazioni di visualizzazione diverse. Le modalità Scura e Chiara assicurano la migliore esperienza visiva, indipendentemente dalla posizione in cui ci si trova.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Ambienti diversi richiedono impostazioni di visualizzazione diverse. Le modalità Scura e Chiara assicurano la migliore esperienza visiva, indipendentemente dalla posizione in cui ci si trova.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Tutte le informazioni chiave di cui avete bisogno, presentate in un layout semplice e pulito. Il fulcro è costituito da un widget personalizzabile con anelli, che consente di accedere rapidamente alle informazioni sul sistema con un solo sguardo.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Tutte le informazioni chiave di cui avete bisogno, presentate in un layout semplice e pulito. Il fulcro è costituito da un widget personalizzabile con anelli, che consente di accedere rapidamente alle informazioni sul sistema con un solo sguardo.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Ottenete un maggiore controllo grazie al nostro pannello panoramico aggiornato che visualizza dati di sistema in tempo reale, tutti in un'unica posizione per un facile monitoraggio.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Ottenete un maggiore controllo grazie al nostro pannello panoramico aggiornato che visualizza dati di sistema in tempo reale, tutti in un&apos;unica posizione per un facile monitoraggio.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Comandi:</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Comandi:</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Tutti i controlli quotidiani sono ora riuniti nel nuovo quadro Controlli. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Tutti i controlli quotidiani sono ora riuniti nel nuovo quadro Controlli. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watt e Ampere</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watt e Ampere</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Ora è possibile passare da Watt ad Ampere. Scegliete l'unità che meglio si adatta alle vostre preferenze.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Ora è possibile passare da Watt ad Ampere. Scegliete l&apos;unità che meglio si adatta alle vostre preferenze.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Ulteriori informazioni</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Ulteriori informazioni</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Accedete al link sottostante per saperne di più sull'IU rinnovata.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Accedete al link sottostante per saperne di più sull&apos;IU rinnovata.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Scansionate il codice QR per saperne di più sull'IU rinnovata.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Scansionate il codice QR per saperne di più sull&apos;IU rinnovata.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Fatto</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Fatto</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Successivo</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Successivo</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Errore: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Errore: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Errore attivo</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Errore attivo</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Tempo di funzionamento del generatore (ore)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Tempo di funzionamento del generatore (ore)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation></translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation></translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation></translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation></translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation></translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation></translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Ripristino di fabbrica del Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Ripristino di fabbrica del Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Siete sicuri di voler ripristinare il Node-RED ai predefiniti di fabbrica? Tale azione cancellerà tutti i vostri flussi.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Siete sicuri di voler ripristinare il Node-RED ai predefiniti di fabbrica? Tale azione cancellerà tutti i vostri flussi.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation></translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation></translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation></translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Valore disattivazione</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Valore disattivazione</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation></translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation></translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation></translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation></translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation></translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Ragguagli</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Panoramica</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation></translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation></translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation></translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Funzione avvio/arresto generatore non attivata, vai alle impostazioni relè e imposta la funzione "Avvio/arresto generatore"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Fuso Orario del Marocco</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Fuso Orario dell'Africa Centrale Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Fuso Orario del Sud Africa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Fuso Orario della Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Fuso Orario dell'Egitto</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Fuso Orario dell'Africa Orientale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Fuso Orario dell'Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Fuso Orario del Sud America Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Fuso Orario della Groenlandia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Fuso Orario di Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Fuso Orario di Terranova</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Fuso Orario del SA Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Fuso Orario dell'Atlantico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Fuso Orario del Brasile Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Fuso Orario del Pacifico Sudamericano</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Fuso Orario del Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Fuso Orario del Sud America Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Fuso Orario del Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Fuso Orario Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Sudamericano</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Fuso Orario degli USA Orientali</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Fuso Orario del Canada Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Fuso Orario dell'America Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Fuso Orario Centrale (Messico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Fuso Orario Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Fuso Orario zona Montagne (Messico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Fuso Orario zona Montagne</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Fuso Orario zona Montagne degli USA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Fuso Orario del Pacifico (Messico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Fuso Orario dell'Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutine</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Fuso Orario della Nuova Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Fuso Orario del Sud Est Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Fuso Orario dell'Africa Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Fuso Orario del Pacifico Sudamericano</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Fuso Orario del Sud America Occidentale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Occidentale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Fuso Orario della Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Fuso Orario di Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Fuso Orario di Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Fuso Orario di Jakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Fuso Orario di Tokio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Fuso Orario della Corea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Fuso Orario di Singapore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Fuso Orario di Ulan Bator</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Fuso Orario di Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Fuso Orario del Nord Est Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Fuso Orario della Cina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Fuso Orario del Sud Est Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Fuso Orario del Nord Asia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Fuso Orario di Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Fuso Orario del Centro Nord Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Fuso Orario del Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Fuso Orario del Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Fuso Orario dello Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Fuso Orario dell'India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Fuso Orario del Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Fuso Orario di Ekaterinburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Fuso Orario della Georgia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Fuso Orario del Caucaso</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Fuso Orario dell'Azerbaigian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Fuso Orario dell'Arabia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Fuso Orario dell'Afganistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Fuso Orario dell'Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Fuso Orario Arabo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Fuso Orario Arab</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Fuso Orario della Siria</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Fuso Orario del Medio Oriente</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Fuso Orario della Giordania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Fuso Orario di Israele</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Tempo Medio di Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Fuso Orario delle Azzorre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Fuso Orario di Capo Verde</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Fuso Orario della Tasmania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Fuso Orario dell'AUS Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Fuso Orario dell'AUS Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Occidentale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Fuso Orario dell'Atlantico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Fuso Orario della Linea Internazionale del Cambiamento di Data</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Tempo Medio GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Fuso Orario dell'Europa Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Fuso Orario FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Fuso Orario GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Fuso Orario della Bielorussia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Fuso Orario della Russia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Fuso Orario della Turchia</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Fuso Orario delle Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Fuso Orario dell’Isola di Natale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Fuso Orario di Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fuso Orario delle Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Fuso Orario della Nuova Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Fuso Orario di Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Fuso Orario delle Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Fuso Orario dell’Isola di Pasqua</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Funzione avvio/arresto generatore non attivata, vai alle impostazioni relè e imposta la funzione &quot;Avvio/arresto generatore&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Rendimento solare</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Ingresso CC</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">Carichi CA</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">Carichi CC</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Panoramica</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Stato</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">FV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Rendimento totale</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Rendimento sistema</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Solo allarme</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Allarmi &amp; avvertenze</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Avvertimento</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Nessun errore</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Nessun errore</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Errore sconosciuto: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Errore sconosciuto: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Nessun errore</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Nessun errore</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Errore inizializ. batteria</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Errore inizializ. batteria</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Nessuna batteria connessa</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Nessuna batteria connessa</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Batteria sconosciuta</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Batteria sconosciuta</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Tipi di batterie diverse</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Tipi di batterie diverse</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>N. di batterie non corretto</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>N. di batterie non corretto</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt non trovato</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt non trovato</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Errore di misurazione batteria</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Errore di misurazione batteria</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Errore di calcolo interno</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Errore di calcolo interno</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>N. di batterie in serie non corretto</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>N. di batterie in serie non corretto</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Errore hardware</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Errore hardware</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Errore Watchdog</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Errore Watchdog</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Sovratensione</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Sovratensione</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Sottotensione</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Sottotensione</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Sovratemperatura</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Sovratemperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Sottotemperatura</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Sottotemperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Standby per sotto-carica</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Standby per sotto-carica</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Errore ADC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Errore ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Errore com. della batteria</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Errore com. della batteria</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Errore di pre-carica</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Errore di pre-carica</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Errore contattore di sicurezza</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Errore contattore di sicurezza</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Errore di aggiornamento batteria</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Errore di aggiornamento batteria</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Errore cavo BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Errore cavo BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Errore di tensione di riferimento</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Errore di tensione di riferimento</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Tensione del sistema erronea</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Tensione del sistema erronea</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Timeout di pre-carica</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Timeout di pre-carica</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Errore ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Errore ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Dati di calibrazione persi</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Dati di calibrazione persi</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Impostazioni non valide</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Impostazioni non valide</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Interblocco</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Interblocco</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Arresto di emergenza</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Arresto di emergenza</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Timeout di comunicazione</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Timeout di comunicazione</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Blocco di sicurezza</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Blocco di sicurezza</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Sovratemperatura terminale</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Sovratemperatura terminale</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Nessun errore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Alta temperatura della batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Alta tensione batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Errore di cablaggio Tsense batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Tsense batteria mancante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Errore di cablaggio del Vsense della batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Vsense batteria mancante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Alte perdite del cavo della batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Basso Voltaggio della Batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Ondulazione CC elevata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Basso stato di carica della batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Problema con la tensione del punto medio della batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Temperatura batteria troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Alta temperatura caricabatterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Eccesso di corrente nel caricabatterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Corrente negativa caricabatterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Tempo corr. cost. caricab. es.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problema del sensore di corrente del caricabatterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Tsensor interno mal collegato</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Tsensor interno mancante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Ventola caricabatterie non rilevato</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Sovracorrente nel ventilatore del caricabatterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Surriscaldamento morsetto caricabatterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Corto circuito caricatore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Problema di livello di potenza del caricabatterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Protezione contro sovraccarica</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Alta tensione di entrata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Eccessiva corrente di entrata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Eccessiva potenza di entrata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Problema di polarità in ingresso</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Tensione assente in entrata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Arresto dell'entrata (non è possibile riprovare)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Arresto uscita (riprova)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Errore interno entrata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Isolamento del FV difettoso</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Rilevato errore di messa a terra</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Sovraccarico inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Temperatura inverter troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Picco corrente inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Livello CC interno inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Livello erroneo ACout inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Errore fase potenza inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Inverter collegato a CA</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Errore nel test del relè ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Errore nel test del relè ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Dispositivo scomparso</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Dispositivo incompatibile</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Perso collegamento BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Rete mal configurata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Rotazione fase</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Vari ingressi CA</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Sovraccarico fase</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Errore di scrittura memoria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Temperatura CPU troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Persa comunicazione</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Dati di calibrazione persi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Firmware incompatibile</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Hardware incompatibile</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Impostazioni non valide</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Errore di tensione di riferimento</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Errore tester</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Cronologia non valida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Contatori kWh non validi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Errore tensione CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Errore del sensore GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Errore alimentazione 3,3 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Errore di alimentazione 5 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Errore alimentazione 12V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Errore di alimentazione 15 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Arresto ingresso FV</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Per cambiare le impostazioni, posizionare l’interruttore su una posizione di sblocco.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Utilizzare l’origine dati D-Bus: connettersi all'indirizzo D-Bus specificato.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>Indirizzo</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Utilizzare l’origine dati D-Bus: connettersi all'indirizzo D-Bus predefinito.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Utilizzare l’origine dati MQTT: connettersi all'indirizzo del broker MQTT specificato.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>Indirizzo</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>ID portale del dispositivo dell'origine dati MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>ID Portale</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Frammento host web VRM di MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>frammento</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Nome utente dell'origine dati MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Utente</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Password dell'origine dati MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>Passaggio</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Token dell'origine dati MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Simbolo</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Attivare il contatore FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Saltare la schermata iniziale</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Utilizzare un'origine dati finta per i test.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Dispositivo spento</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>MK2 misto vecchio/nuovo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Errore dispositivi previsto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Non sono stati rilevati altri dispositivi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Sovratensione in CA-out</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Errore di programma DCC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS senza assistente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Test del relè di massa non riuscito</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Errore di sincronizzazine ora sistema</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Errore nel test del relè di rete</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Disallineamento config. con 2º mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Errore di trasmissione del dispositivo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>In attesa di configurazione o dongle assente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Master fase assente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Si è verificata una sovratensione</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Lo slave non ha ingresso CA!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Il dispositivo non può essere uno slave</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Protezione di sistema avviata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Incompatibilità di firmware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Errore interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>I test di errore del relè impediscono la connessione</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Errore VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Errore sconosciuto:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Errore interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Nessun errore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Alta temperatura della batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Alta tensione batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Basso Voltaggio della Batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>La tensione della batteria ha superato il valore massimo configurato</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Alta temperatura dell’alternatore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Alti giri/min dell’alternatore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Alta temperatura FET azionamento di campo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Sensore richiesto mancante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Bassa tensione alternatore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Offset alta tensione alternatore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>La tensione dell’alternatore ha superato il valore massimo configurato</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Alta tensione dell’alternatore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Batteria scollegata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Disconnessione alta tensione batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Le istanze della batteria non rientrano nell’intervallo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Troppi BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>La batteria sta per scollegarsi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Troppi dispositivi da monitorare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Disconnessione per bassa tensione batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Disconnessione alta corrente batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Disconnessione per alta temperatura batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Disconnessione per bassa temperatura batteria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Perso collegamento BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC disabilitato</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>Convertitore CC/CC non pronto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>Tensione principale CC/CC alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>Tensione principale CC/CC bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>Tensione secondaria CC/CC alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>Tensione secondaria CC/CC bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>Temperatura alta CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>Configurazione errata CC/CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Sensore di temperatura batteria difettoso</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Errore sconosciuto:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Errore sconosciuto:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Nessun errore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Alta temperatura della batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Alta tensione batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Errore di cablaggio Tsense batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Tsense batteria mancante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Errore di cablaggio del Vsense della batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Vsense batteria mancante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Alte perdite del cavo della batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Basso Voltaggio della Batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Ondulazione CC elevata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Basso stato di carica della batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Problema con la tensione del punto medio della batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Temperatura batteria troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Alta temperatura caricabatterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Eccesso di corrente nel caricabatterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Corrente negativa caricabatterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Tempo corr. cost. caricab. es.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Problema del sensore di corrente del caricabatterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Tsensor interno mal collegato</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Tsensor interno mancante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Ventola caricabatterie non rilevato</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Sovracorrente nel ventilatore del caricabatterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Surriscaldamento morsetto caricabatterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Corto circuito caricatore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Problema di livello di potenza del caricabatterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Protezione contro sovraccarica</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Alta tensione di entrata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Eccessiva corrente di entrata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Eccessiva potenza di entrata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Problema di polarità in ingresso</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Tensione assente in entrata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Arresto dell&apos;entrata (non è possibile riprovare)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Arresto uscita (riprova)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Errore interno entrata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Isolamento del FV difettoso</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Rilevato errore di messa a terra</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Sovraccarico inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Temperatura inverter troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Picco corrente inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Livello CC interno inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Livello erroneo ACout inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Errore fase potenza inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Inverter collegato a CA</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Errore nel test del relè ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Errore nel test del relè ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Dispositivo scomparso</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Dispositivo incompatibile</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Perso collegamento BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Rete mal configurata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Rotazione fase</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Vari ingressi CA</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Sovraccarico fase</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Errore di scrittura memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Temperatura CPU troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Persa comunicazione</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Dati di calibrazione persi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Firmware incompatibile</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Hardware incompatibile</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Impostazioni non valide</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Errore di tensione di riferimento</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Errore tester</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Cronologia non valida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Contatori kWh non validi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Errore tensione CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Errore del sensore GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>Errore alimentazione 3,3 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>Errore di alimentazione 5 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>Errore alimentazione 12V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>Errore di alimentazione 15 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Arresto ingresso FV</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Errore sconosciuto:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Errore sconosciuto:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Errore sconosciuto:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Errore sconosciuto:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Nessun errore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>Tensione CA L1 troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>Tensione CA troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Tensione CA L1 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Tensione CA troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Frequenza CA L1 troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Frequenza CA troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Frequenza CA L1 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Frequenza CA troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>Corrente CA L1 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>Corrente CA troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Potenza CA L1 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>Potenza CA troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Arresto di emergenza</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Corrente servomotore troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Pressione dell'olio troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Pressione dell'olio troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Temperatura motore troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Temperatura motore troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Temperatura avvolgimento troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Temperatura avvolgimento troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Temperatura di scarico troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Temperatura di scarico troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Temperatura elettronica bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Temperatura elettronica alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Tensione di avviamento troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Corrente avviamento troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Tensione di luminescenza troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Corrente luminescente troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Tensione di avviamento a freddo troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Corrente di avviamento a freddo troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Tensione magnete di ritenzione del carburante troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Corrente del magnete di ritenzione del carburante troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Tensione bobina di ritenzione del solenoide di arresto troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Corrente bobina di ritenzione del solenoide di arresto troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Tensione bobina di tiraggio del solenoide di arresto troppo bassa </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Corrente bobina di spinta troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Tensione ventola/pompa dell’acqua troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Corrente ventola/pompa dell'acqua troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Tensione sensore di corrente bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Corrente sensore di corrente alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Tensione uscita dell’incremento troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Corrente uscita dell’incremento troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Tensione di alimentazione del bus troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Corrente di alimentazione del bus troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Tensione batteria di avviamento troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Tensione della batteria di avviamento troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Rotazione insufficiente</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Rotazione eccessiva</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Arresto imprevisto/problema dell'alimentazione del carburante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Tensione del contattore di potenza troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Corrente del contattore di potenza troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>Tensione CA L2 troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Tensione CA L2 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>Frequenza CA L2 troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Frequenza CA L2 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>Corrente CA L2 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>Potenza CA L2 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Tensione CA L3 troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>Tensione CA L3 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Frequenza CA L3 troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Frequenza CA L3 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>Corrente CA L3 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>Potenza CA L3 troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Tensione di uscita dell'inverter troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Corrente di uscita dell'inverter troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Tensione uscita universale (1 A) troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Corrente uscita universale (1 A) troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Tensione uscita universale (5 A) troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Corrente uscita universale (5 A) troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Tensione CC AGT 1 bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Tensione CC AGT 1 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>Corrente CC AGT 1 bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>Corrente CC AGT 1 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Tensione CC AGT 2 bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Tensione CC AGT 2 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>Corrente CC AGT 2 bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>Corrente CC AGT 2 alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Refrigerante B6 AGT basso</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>Refrigerante B6 AGT alto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>Guida (-) B6 AGT bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>Guida (-) B6 AGT alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>Guida (+) B6 AGT bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>Guida (+) B6 AGT alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Temperatura carburante troppo bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Temperatura carburante troppo alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Livello carburante troppo basso</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Perdita controllo dell'unità</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Perdita pannello</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Servizio necessario</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Perdita modulo trifase</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Perdita modulo AGT</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Errore di sincronizzazione</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>ECU esterna persa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Filtro di immissione dell'aria</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Messaggio diagnostico (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Perdita di sincr. del modulo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Errore di bilanciamento del carico</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Modalità di sincr. disattivata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Spia di arresto rossa (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Spia di avviso ambra (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Spia di malfunzionamento (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Spia di protezione (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Errore nel campo rotante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Perdita del sensore di livello del carburante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Avviamento senza inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Bus #1 non funzionante</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Richiesta di avvio negata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Avvio remoto negato</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Relè di carico a disattivazione forzata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Il modulo di sincronizzazione è offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>BMS perso</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Tensione bassa/inversa collegamento CC convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Corrente bassa collegamento CC convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Tensione bassa precarica CC convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Tensione alta precarica CC convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Errore del driver IGBT/MOSFET convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Errore del ciclo di controllo della potenza del convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Rilevamento frequenza CA del convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Errore del valore di controllo del convertitore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Impostazioni di fabbrica modificate</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parametro modificato in modalità amministratore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Intervento manuale (sistema esterno)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Inizializzazione non riuscita</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Temperatura inverter alta L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Temperatura inverter alta L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Temperatura inverter alta L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Temperatura inverter alta collegamento CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Sovraccarico inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Perdita comunicazione inverter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Sovraccarico CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Sovratensione CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Connessione non presente</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Nessun errore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Errore sconosciuto: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Errore sconosciuto:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Pressione dell'olio</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Sovratemperatura della testa del cilindro</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Controllo della carica</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Velocità superiore al previsto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Velocità eccessiva</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Temperatura dell'olio più alta del previsto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Temperatura dell'olio circuito aperto / cortocircuito di alimentazione</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Temperatura dell'olio cortocircuito a terra</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Setpoint analogico alto / cortocircuito di alimentazione</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Setpoint analogico basso / cortocircuito a terra</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Timeout ricezione messaggi TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Timeout ricezione messaggi CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Tensione batteria alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Tensione batteria bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Segnale di velocità distorto</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Alimentazione interna del sensore a 5 V alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Alimentazione interna del sensore a 5 V bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Pressione barometrica alta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Pressione barometrica bassa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Cortocircuito di alimentazione pompa carburante in uscita</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Cortocircuito a terra pompa carburante in uscita</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Cortocircuito di alimentazione uscita candeletta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Cortocircuito a terra uscita candeletta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Cortocircuito a terra circuito aperto/lato basso iniettore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Cortocircuito interno bobina iniettore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Cortocircuito di alimentazione lato basso iniettore</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Ore di servizio scadute</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Guasto del processore</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Errore sconosciuto:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Batteria</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Batteria</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Frigorifero</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Frigorifero</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Generico</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Generico</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Stanza</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Stanza</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Esterno</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Esterno</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Scaldabagno</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Scaldabagno</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Congelatore</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Congelatore</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Errore sconosciuto:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Nessun errore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>Tensione CA L1 troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>Tensione CA troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>Tensione CA L1 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>Tensione CA troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>Frequenza CA L1 troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>Frequenza CA troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>Frequenza CA L1 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>Frequenza CA troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>Corrente CA L1 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>Corrente CA troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>Potenza CA L1 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>Potenza CA troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Arresto di emergenza</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Corrente servomotore troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Pressione dell&apos;olio troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Pressione dell&apos;olio troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Temperatura motore troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Temperatura motore troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Temperatura avvolgimento troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Temperatura avvolgimento troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Temperatura di scarico troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Temperatura di scarico troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Temperatura elettronica bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Temperatura elettronica alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Tensione di avviamento troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Corrente avviamento troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Tensione di luminescenza troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Corrente luminescente troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Tensione di avviamento a freddo troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Corrente di avviamento a freddo troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Tensione magnete di ritenzione del carburante troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Corrente del magnete di ritenzione del carburante troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Tensione bobina di ritenzione del solenoide di arresto troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Corrente bobina di ritenzione del solenoide di arresto troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Tensione bobina di tiraggio del solenoide di arresto troppo bassa </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Corrente bobina di spinta troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Tensione ventola/pompa dell’acqua troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Corrente ventola/pompa dell&apos;acqua troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Tensione sensore di corrente bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Corrente sensore di corrente alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Tensione uscita dell’incremento troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Corrente uscita dell’incremento troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Tensione di alimentazione del bus troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Corrente di alimentazione del bus troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Tensione batteria di avviamento troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Tensione della batteria di avviamento troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Rotazione insufficiente</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Rotazione eccessiva</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Arresto imprevisto/problema dell&apos;alimentazione del carburante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Tensione del contattore di potenza troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Corrente del contattore di potenza troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>Tensione CA L2 troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>Tensione CA L2 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>Frequenza CA L2 troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>Frequenza CA L2 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>Corrente CA L2 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>Potenza CA L2 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>Tensione CA L3 troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>Tensione CA L3 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>Frequenza CA L3 troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>Frequenza CA L3 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>Corrente CA L3 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>Potenza CA L3 troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Tensione di uscita dell&apos;inverter troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Corrente di uscita dell&apos;inverter troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Tensione uscita universale (1 A) troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Corrente uscita universale (1 A) troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Tensione uscita universale (5 A) troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Corrente uscita universale (5 A) troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>Tensione CC AGT 1 bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>Tensione CC AGT 1 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>Corrente CC AGT 1 bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>Corrente CC AGT 1 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Tensione CC AGT 2 bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Tensione CC AGT 2 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>Corrente CC AGT 2 bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>Corrente CC AGT 2 alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>Refrigerante B6 AGT basso</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>Refrigerante B6 AGT alto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>Guida (-) B6 AGT bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>Guida (-) B6 AGT alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>Guida (+) B6 AGT bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>Guida (+) B6 AGT alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Temperatura carburante troppo bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Temperatura carburante troppo alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Livello carburante troppo basso</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Perdita controllo dell&apos;unità</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Perdita pannello</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Servizio necessario</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Perdita modulo trifase</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Perdita modulo AGT</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Errore di sincronizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>ECU esterna persa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Filtro di immissione dell&apos;aria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Messaggio diagnostico (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Perdita di sincr. del modulo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Errore di bilanciamento del carico</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Modalità di sincr. disattivata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Spia di arresto rossa (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Spia di avviso ambra (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Spia di malfunzionamento (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Spia di protezione (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Errore nel campo rotante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Perdita del sensore di livello del carburante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Avviamento senza inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Bus #1 non funzionante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Richiesta di avvio negata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Avvio remoto negato</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Relè di carico a disattivazione forzata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Il modulo di sincronizzazione è offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>BMS perso</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Tensione bassa/inversa collegamento CC convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Corrente bassa collegamento CC convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Tensione bassa precarica CC convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Tensione alta precarica CC convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Errore del driver IGBT/MOSFET convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Errore del ciclo di controllo della potenza del convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Rilevamento frequenza CA del convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Errore del valore di controllo del convertitore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Impostazioni di fabbrica modificate</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parametro modificato in modalità amministratore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Intervento manuale (sistema esterno)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Inizializzazione non riuscita</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Temperatura inverter alta L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Temperatura inverter alta L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Temperatura inverter alta L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Temperatura inverter alta collegamento CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Sovraccarico inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Perdita comunicazione inverter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>Sovraccarico CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>Sovratensione CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Connessione non presente</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Nessun errore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Errore sconosciuto: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Errore sconosciuto:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Pressione dell&apos;olio</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Sovratemperatura della testa del cilindro</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Controllo della carica</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Velocità superiore al previsto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Velocità eccessiva</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Temperatura dell&apos;olio più alta del previsto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Temperatura dell&apos;olio circuito aperto / cortocircuito di alimentazione</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Temperatura dell&apos;olio cortocircuito a terra</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Setpoint analogico alto / cortocircuito di alimentazione</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Setpoint analogico basso / cortocircuito a terra</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Timeout ricezione messaggi TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Timeout ricezione messaggi CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Tensione batteria alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Tensione batteria bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Segnale di velocità distorto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Alimentazione interna del sensore a 5 V alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Alimentazione interna del sensore a 5 V bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Pressione barometrica alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Pressione barometrica bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Cortocircuito di alimentazione pompa carburante in uscita</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Cortocircuito a terra pompa carburante in uscita</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Cortocircuito di alimentazione uscita candeletta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Cortocircuito a terra uscita candeletta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Cortocircuito a terra circuito aperto/lato basso iniettore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Cortocircuito interno bobina iniettore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Cortocircuito di alimentazione lato basso iniettore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Ore di servizio scadute</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Guasto del processore</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Per cambiare le impostazioni, posizionare l’interruttore su una posizione di sblocco.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Utilizzare l’origine dati D-Bus: connettersi all&apos;indirizzo D-Bus specificato.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>Indirizzo</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Utilizzare l’origine dati D-Bus: connettersi all&apos;indirizzo D-Bus predefinito.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Utilizzare l’origine dati MQTT: connettersi all&apos;indirizzo del broker MQTT specificato.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>Indirizzo</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>ID portale del dispositivo dell&apos;origine dati MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>ID Portale</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Frammento host web VRM di MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>frammento</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Nome utente dell&apos;origine dati MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Utente</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Password dell&apos;origine dati MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>Passaggio</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Token dell&apos;origine dati MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Simbolo</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Attivare il contatore FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Saltare la schermata iniziale</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Utilizzare un&apos;origine dati finta per i test.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Fuso Orario del Marocco</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Fuso Orario dell&apos;Africa Centrale Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Fuso Orario del Sud Africa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Fuso Orario della Namibia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Fuso Orario dell&apos;Egitto</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Fuso Orario dell&apos;Africa Orientale</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Fuso Orario dell&apos;Argentina</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Fuso Orario del Sud America Orientale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Fuso Orario della Groenlandia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Fuso Orario di Montevideo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Fuso Orario di Terranova</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Fuso Orario del SA Orientale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Fuso Orario dell&apos;Atlantico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Fuso Orario del Brasile Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Fuso Orario del Pacifico Sudamericano</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Fuso Orario del Paraguay</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Fuso Orario del Sud America Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Fuso Orario del Venezuela</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Fuso Orario Orientale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Fuso Orario del Pacifico Sudamericano</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Fuso Orario degli USA Orientali</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Fuso Orario del Canada Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Fuso Orario dell&apos;America Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Fuso Orario Centrale (Messico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Fuso Orario Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Fuso Orario zona Montagne (Messico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Fuso Orario zona Montagne</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Fuso Orario zona Montagne degli USA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Fuso Orario del Pacifico (Messico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Fuso Orario del Pacifico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Fuso Orario dell&apos;Alaska</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hawaii-Aleutine</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Fuso Orario della Nuova Zelanda</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Fuso Orario del Pacifico Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Fuso Orario del Pacifico Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Australia Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Fuso Orario del Sud Est Asiatico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Asia Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Asia Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Fuso Orario dell&apos;Africa Orientale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Fuso Orario del Pacifico Sudamericano</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Fuso Orario del Sud America Occidentale</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Fuso Orario dell&apos;Europa Occidentale</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Fuso Orario della Kamchatka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Fuso Orario di Magadan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Fuso Orario di Vladivostok</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Fuso Orario di Jakutsk</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Fuso Orario di Tokio</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Fuso Orario della Corea</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Fuso Orario di Singapore</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Fuso Orario di Ulan Bator</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Fuso Orario di Taipei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Fuso Orario del Nord Est Asiatico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Fuso Orario della Cina</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Fuso Orario del Sud Est Asiatico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Fuso Orario del Nord Asia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Fuso Orario di Myanmar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Fuso Orario del Centro Nord Asiatico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Asia Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Fuso Orario del Bangladesh</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Fuso Orario del Nepal</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Fuso Orario dello Sri Lanka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Fuso Orario dell&apos;India</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Asia Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Fuso Orario del Pakistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Fuso Orario di Ekaterinburg</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Fuso Orario della Georgia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Fuso Orario del Caucaso</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Fuso Orario dell&apos;Azerbaigian</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Fuso Orario dell&apos;Arabia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Fuso Orario dell&apos;Afganistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Fuso Orario dell&apos;Iran</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Fuso Orario Arabo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Fuso Orario Arab</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Fuso Orario della Siria</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Fuso Orario del Medio Oriente</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Fuso Orario della Giordania</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Fuso Orario di Israele</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Tempo Medio di Greenwich</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Fuso Orario delle Azzorre</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Fuso Orario di Capo Verde</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Fuso Orario della Tasmania</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Australia Orientale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Fuso Orario dell&apos;AUS Orientale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Australia Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Fuso Orario dell&apos;AUS Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Fuso Orario dell&apos;Australia Occidentale</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Fuso Orario dell&apos;Atlantico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Fuso Orario della Linea Internazionale del Cambiamento di Data</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>Tempo Medio GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Fuso Orario dell&apos;Europa Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Fuso Orario dell&apos;Europa Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Fuso Orario dell&apos;Europa Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Fuso Orario dell&apos;Europa Orientale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Fuso Orario FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Fuso Orario GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Fuso Orario della Bielorussia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Fuso Orario della Russia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Fuso Orario della Turchia</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Fuso Orario delle Mauritius</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Fuso Orario dell’Isola di Natale</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Fuso Orario di Tonga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Fuso Orario delle Fiji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Fuso Orario della Nuova Zelanda</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Fuso Orario del Pacifico Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Fuso Orario del Pacifico Occidentale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Fuso Orario di Samoa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Fuso Orario delle Hawaii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Fuso Orario dell’Isola di Pasqua</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Errore interno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Errore sconosciuto:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Errore interno</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Nessun errore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Alta temperatura della batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Alta tensione batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Basso Voltaggio della Batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>La tensione della batteria ha superato il valore massimo configurato</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Alta temperatura dell’alternatore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Alti giri/min dell’alternatore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Alta temperatura FET azionamento di campo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Sensore richiesto mancante</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Bassa tensione alternatore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Offset alta tensione alternatore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>La tensione dell’alternatore ha superato il valore massimo configurato</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Alta tensione dell’alternatore</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Batteria scollegata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Disconnessione alta tensione batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Le istanze della batteria non rientrano nell’intervallo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Troppi BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>La batteria sta per scollegarsi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Troppi dispositivi da monitorare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Disconnessione per bassa tensione batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Disconnessione alta corrente batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Disconnessione per alta temperatura batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Disconnessione per bassa temperatura batteria</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Perso collegamento BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC disabilitato</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>Convertitore CC/CC non pronto</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>Tensione principale CC/CC alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>Tensione principale CC/CC bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>Tensione secondaria CC/CC alta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>Tensione secondaria CC/CC bassa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>Temperatura alta CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>Configurazione errata CC/CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Sensore di temperatura batteria difettoso</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_nl.ts
+++ b/i18n/venus-gui-v2_nl.ts
@@ -1,10378 +1,11083 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="nl">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Uitgeschakeld</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Uitgeschakeld</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Overbelasting omvormer</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Overbelasting omvormer</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Vermogen</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Vermogen</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Uit</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Uit</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Automatisch</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Automatisch</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Accu</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbonden</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Losgekoppeld</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Aggregaat</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Hoge accuspanning</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Hoge accuspanning</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Omvormer / Lader</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Omvormer / Lader</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Lage accuspanning</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Lage accuspanning</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Handmatig</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Handmatig</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Geen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Geen</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Positie</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Positie</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Snelheid</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Snelheid</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Status</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Status</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>%1 wordt geïnstalleerd...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>%1 wordt geïnstalleerd...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Onbekende fout</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Onbekende fout</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Minimum laadtoestand</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Minimum laadtoestand</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Onbekend</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Geef wachtwoord</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Geef wachtwoord</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Drukken om te controleren</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Drukken om te controleren</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Net</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Net</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Zon opbrengst</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Zon opbrengst</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Externe besturing</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Externe besturing</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Tanks</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Tanks</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Omgeving</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Omgeving</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Geen huidige waarschuwingen</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Geen huidige waarschuwingen</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Algemeen</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Algemeen</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Datum &amp; Tijd</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Datum &amp; Tijd</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Systeem set-up</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Systeem set-up</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Weergave &amp; Taal</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Weergave &amp; Taal</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM online portaal</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM online portaal</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Energiemeters</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Energiemeters</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>PV-omvormers</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>PV-omvormers</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>WiFi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>WiFi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM modem</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM modem</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Start/stop aggregaat</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Start/stop aggregaat</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Tankpomp</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Tankpomp</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Diensten</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Diensten</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Venus OS Large eigenschappen</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Venus OS Large eigenschappen</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Accu levensduur limiet: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Accu levensduur limiet: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Automatisch starten</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Autostart wordt uitgeschakeld en het aggregaat zal niet automatisch starten op basis van de ingestelde voorwaarden.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Autostart wordt uitgeschakeld en het aggregaat zal niet automatisch starten op basis van de ingestelde voorwaarden.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Handmatig stoppen</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Handmatig stoppen</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Handmatig starten</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Handmatig starten</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Positie</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Automatisch starten</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Automatisch starten</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Schakelaars</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Schakelaars</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Toegangsniveau</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Toegangsniveau</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Gebruiker</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Gebruiker</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Gebruiker &amp; Installateur</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Gebruiker &amp; Installateur</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superuser</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superuser</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Service</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Service</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Zorg ervoor dat ook het VE.Bus-systeem gereset wordt na het uitschakelen van DVCC.</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Zorg ervoor dat ook het VE.Bus-systeem gereset wordt na het uitschakelen van DVCC.</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Laadstroom beperken</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Laadstroom beperken</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Maximale laadstroom</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Maximale laadstroom</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Gebruik waarde %1 voor Start / Stop</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Gebruik waarde %1 voor Start / Stop</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Start als %1 hoger is dan</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Start als %1 hoger is dan</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Start als %1 lager is dan</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Start als %1 lager is dan</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Stop als %1 hoger is dan</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Stop als %1 hoger is dan</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Stop als %1 lager is dan</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Stop als %1 lager is dan</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>IP-adres verwijderen?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>IP-adres verwijderen?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Verbinding</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Verbinding</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Product</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Product</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Naam</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Naam</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>Product ID</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>Product ID</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Hardware versie</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Hardware versie</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Apparaatnaam</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Apparaatnaam</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Afstandsbediening uitgeschakeld</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Afstandsbediening uitgeschakeld</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Aggregaat in storing</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Aggregaat in storing</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Aggregaat niet gedetecteerd bij AC-ingang</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Aggregaat niet gedetecteerd bij AC-ingang</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Totale bedrijfstijd sinds laatste testbedrijf</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Totale bedrijfstijd sinds laatste testbedrijf</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Tijd tot volgende testbedrijf</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Tijd tot volgende testbedrijf</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>In bedrijf</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>In bedrijf</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Handmatig starten</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Handmatig starten</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Aggregaat starten</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Aggregaat starten</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Dagelijkse bedrijfstijd</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Dagelijkse bedrijfstijd</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Waarde moet hoger zijn dan stopwaarde</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Waarde moet hoger zijn dan stopwaarde</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Waarde moet lager zijn dan startwaarde</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Waarde moet lager zijn dan startwaarde</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>AC uitgang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>AC uitgang</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">AC uitgang</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>AC1 belasting voor Start / Stop gebruiken</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>AC1 belasting voor Start / Stop gebruiken</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Meting</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Meting</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Totaal verbruik</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Totaal verbruik</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Totaal AC uitgangsvermogen omvormer</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Totaal AC uitgangsvermogen omvormer</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Hoogste fase AC uitgangsvermogen omvormer</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Hoogste fase AC uitgangsvermogen omvormer</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Starten als vermogen hoger is dan</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Starten als vermogen hoger is dan</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Stoppen als vermogen lager is dan</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Stoppen als vermogen lager is dan</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Accumonitor</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Accumonitor</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Onbeschikbare monitor, stel een andere in</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Onbeschikbare monitor, stel een andere in</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Accumonitor</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Onbeschikbare monitor, stel een andere in</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Bij communicatie verlies</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Bij communicatie verlies</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Aggregaat stoppen</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Aggregaat stoppen</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Laat aggregaat draaien</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Laat aggregaat draaien</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Stop aggregaat, als AC ingang beschikbaar is</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Stop aggregaat, als AC ingang beschikbaar is</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>Accu laadtoestand</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>Accu laadtoestand</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Hoge temperatuur omvormer</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Hoge temperatuur omvormer</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Hoge temperatuur omvormer</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Starten bij melding hoge temperatuur</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Starten bij melding hoge temperatuur</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Starten bij melding overbelasting</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Starten bij melding overbelasting</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Periodiek in bedrijf</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Periodiek in bedrijf</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Bedrijfsinterval</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Bedrijfsinterval</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 dag(en)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 dag(en)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Bedrijf overslaan indien in bedrijf gedurende</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Bedrijf overslaan indien in bedrijf gedurende</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Altijd starten</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Altijd starten</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Begindatum in bedrijfsinterval</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Begindatum in bedrijfsinterval</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Duur in bedrijf (uu:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Duur in bedrijf (uu:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Werkt tot accu volledig is opgeladen</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Werkt tot accu volledig is opgeladen</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (fix)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (fix)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS aangesloten, maar geen GPS fix</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS aangesloten, maar geen GPS fix</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Geen GPS aangesloten</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Geen GPS aangesloten</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Breedtegraad</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Breedtegraad</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Lengtegraad</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Lengtegraad</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kn</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kn</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Koers</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Koers</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Hoogte</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Hoogte</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Aantal satellieten</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Aantal satellieten</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Instelwaarde stroomnet</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Instelwaarde stroomnet</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Instelwaarde AC-ingangsvermogen</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Instelwaarde AC-ingangsvermogen</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Stroom: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Stroom: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Spanning: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Spanning: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Grenzen (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Grenzen (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Opladen: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Opladen: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Ontlading: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Ontlading: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Grenzen (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Grenzen (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Zichtbaar</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Zichtbaar</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Verborgen</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Verborgen</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (aanvullende meting)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (aanvullende meting)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Uitgang %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Uitgang %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Actieve accumonitor</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Actieve accumonitor</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Naam</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Naam invoeren</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Naam invoeren</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Naam invoeren</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Continue zoeken</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Continue zoeken</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Bluetooth sensoren</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Bluetooth sensoren</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>PIN code</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>PIN code</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Het kan nodig zijn bestaande koppelinformatie te verwijderen om verbinding te maken.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Het kan nodig zijn bestaande koppelinformatie te verwijderen om verbinding te maken.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Fasetype</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Fasetype</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>1-Fase</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>1-Fase</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Meer fasen</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Meer fasen</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>PV-omvormer op fase 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>PV-omvormer op fase 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>PV-omvormer op fase 2 Positie</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>PV-omvormer op fase 2 Positie</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>CAN-bus profiel</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>CAN-bus profiel</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Uitgeschakeld</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Beschikbaar, maar geen diensten (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Beschikbaar, maar geen diensten (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Apparaten</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Apparaten</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000-uit</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000-uit</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Keuze uniek identiteitsnummer</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Keuze uniek identiteitsnummer</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Even geduld, het wijzigen en controleren van het unieke nummer duurt even</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Even geduld, het wijzigen en controleren van het unieke nummer duurt even</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Bovenstaande keuze stelt in welk blok unieke identificatienummers moet worden gebruikt voor de unieke identificatienummers in het veld PGN 60928 NAME. Alleen wijzigen bij gebruik van meerdere GX apparaten in één VE.Can netwerk.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Bovenstaande keuze stelt in welk blok unieke identificatienummers moet worden gebruikt voor de unieke identificatienummers in het veld PGN 60928 NAME. Alleen wijzigen bij gebruik van meerdere GX apparaten in één VE.Can netwerk.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Bovenstaande keuze stelt in welk blok unieke identificatienummers moet worden gebruikt voor het serienummer in het veld DGN 60928 ADDRESS_CLAIM. Alleen wijzigen bij gebruik van meerdere GX Apparaten in één RV-C netwerk.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Bovenstaande keuze stelt in welk blok unieke identificatienummers moet worden gebruikt voor het serienummer in het veld DGN 60928 ADDRESS_CLAIM. Alleen wijzigen bij gebruik van meerdere GX Apparaten in één RV-C netwerk.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Controleer unieke ID-nummers</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Controleer unieke ID-nummers</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Drukken om te controleren</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Er is een ander apparaat verbonden met dit unieke nummer, selecteer een nieuw nummer.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Er is een ander apparaat verbonden met dit unieke nummer, selecteer een nieuw nummer.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: Geen ander apparaat met dit unieke nummer is verbonden.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: Geen ander apparaat met dit unieke nummer is verbonden.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Netwerkstatus</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Netwerkstatus</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Adaptieve helderheid</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Adaptieve helderheid</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Helderheid</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Helderheid</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Uitschakeltijd scherm</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Uitschakeltijd scherm</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 sec</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 sec</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 sec</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 sec</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Nooit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Nooit</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Weergavemodus</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Weergavemodus</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Donker</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Donker</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Licht</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Licht</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Korte weergaveniveaus</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Korte weergaveniveaus</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Taal</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Taal</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Taal veranderen</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Taal veranderen</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Weergave elektrisch vermogen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Weergave elektrisch vermogen</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Vermogen (Watt)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Vermogen (Watt)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Stroom (Ampère)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Stroom (Ampère)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Eenheden</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Eenheden</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Niveau %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Niveau %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;LET OP:&lt;/b&gt; Lees de handleiding vóór het aanpassen.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;LET OP:&lt;/b&gt; Lees de handleiding vóór het aanpassen.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Begrens accu laadspanning</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Begrens accu laadspanning</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Maximum laadspanning</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Maximum laadspanning</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Gedeelde spanningsdetectie</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Gedeelde spanningsdetectie</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS – Gedeelde temperatuursensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS – Gedeelde temperatuursensor</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Onbeschikbare sensor, stel een andere in</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Onbeschikbare sensor, stel een andere in</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Onbeschikbare sensor, stel een andere in</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Gebruikte sensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Gebruikte sensor</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Gedeelde stroomsensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Gedeelde stroomsensor</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>SCS status</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>SCS status</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Uitgeschakeld (externe besturing)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Uitgeschakeld (externe besturing)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Uitgeschakeld (geen opladers)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Uitgeschakeld (geen opladers)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Uitgeschakeld (geen accumonitor)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Uitgeschakeld (geen accumonitor)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Automatische keuze</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Automatische keuze</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Geen BMS besturing</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Geen BMS besturing</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>BMS besturing</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>BMS besturing</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Niet beschikbaar, kies andere</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Niet beschikbaar, kies andere</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Automatisch geselecteerd</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Automatisch geselecteerd</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Geen</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Aanmaakdatum/-tijd</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Aanmaakdatum/-tijd</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Online updates</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Online updates</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Firmware van SD/USB installeren</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Firmware van SD/USB installeren</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Opgeslagen backup firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Opgeslagen backup firmware</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Controleren op updates op SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Controleren op updates op SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Firmware gevonden</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Firmware gevonden</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installeren %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installeren %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Druk voor bijwerken naar %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Druk voor bijwerken naar %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Druk voor bijwerken naar %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Aanmaakdatum/-tijd firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Aanmaakdatum/-tijd firmware</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Automatisch bijwerken</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Automatisch bijwerken</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Alleen controleren</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Alleen controleren</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Alleen controleren en downloaden</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Alleen controleren en downloaden</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Controleren en bijwerken</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Controleren en bijwerken</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Soort update</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Soort update</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Soort image</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Soort image</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normaal</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normaal</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Large</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Large</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Controleren op updates</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Controleren op updates</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Update beschikbaar</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Update beschikbaar</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Installeren %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Installeren %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">%1 wordt geïnstalleerd...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Aanmaakdatum/-tijd update</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Aanmaakdatum/-tijd update</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Omvormers</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Omvormers</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>PV-omvormers zoeken</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>PV-omvormers zoeken</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Gedetecteerde IP-adressen</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Gedetecteerde IP-adressen</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>IP adres handmatig toevoegen</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>IP adres handmatig toevoegen</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>TCP poort</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>TCP poort</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Meerfasen</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Meerfasen</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Gesplitste fase (L1 + L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Gesplitste fase (L1 + L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Weergeven</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Weergeven</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC uit MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC uit MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC uit L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC uit L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC uit --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC uit --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Opnieuw IP-adressen zoeken?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Opnieuw IP-adressen zoeken?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Opnieuw zoeken</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Opnieuw zoeken</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH op LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH op LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Remote support</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Remote support</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Tunnel voor remote ondersteuning</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Tunnel voor remote ondersteuning</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>IP en poort voor remote ondersteuning</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>IP en poort voor remote ondersteuning</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Nu uitloggen</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Nu herstarten</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Nu herstarten</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Apparaat is opnieuw opgestart.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Akoestisch alarm</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Akoestisch alarm</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Demomodus</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Demomodus</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS demo</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Boot/Camper demo 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Boot/Camper demo 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Boot/Camper demo 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Boot/Camper demo 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Door de demomodus te starten, veranderen er enkele instellingen en zal de gebruikersinterface even niet reageren.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Door de demomodus te starten, veranderen er enkele instellingen en zal de gebruikersinterface even niet reageren.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Voorwaarden</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Voorwaarden</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Minimum bedrijfstijd</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Minimum bedrijfstijd</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Opwarmingstijd</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Opwarmingstijd</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Afkoeltijd</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Afkoeltijd</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Aggregaat op AC ingang detecteren</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Aggregaat op AC ingang detecteren</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Geen van de AC-ingangen is ingesteld op het aggregaat. Ga naar de pagina systeem instellingen en stel de juiste AC ingang in op het aggregaat om deze functionaliteit in te schakelen.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Geen van de AC-ingangen is ingesteld op het aggregaat. Ga naar de pagina systeem instellingen en stel de juiste AC ingang in op het aggregaat om deze functionaliteit in te schakelen.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Er gaat een alarm af als er geen stroom van het aggregaat is gedetecteerd bij de AC ingang van de omvormer. Let er op dat de juiste AC ingang is ingesteld voor het aggregaat op de pagina systeem instellingen.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Er gaat een alarm af als er geen stroom van het aggregaat is gedetecteerd bij de AC ingang van de omvormer. Let er op dat de juiste AC ingang is ingesteld voor het aggregaat op de pagina systeem instellingen.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Begin tijd rustige uren</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Begin tijd rustige uren</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Eind tijd rustige uren</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Eind tijd rustige uren</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Looptijd en onderhoud</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Looptijd en onderhoud</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Dagelijkse bedrijfstijdtellers resetten</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Dagelijkse bedrijfstijdtellers resetten</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>De dagelijkse bedrijfstijdteller is gereset</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>De dagelijkse bedrijfstijdteller is gereset</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>De tellers kunnen niet worden aangepast als het aggregaat loopt</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>De tellers kunnen niet worden aangepast als het aggregaat loopt</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Aggregaat onderhoudsinterval (uren)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Aggregaat onderhoudsinterval (uren)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Servicetimerinterval ingesteld op %1h. Gebruik de knop 'Reset servicetimer' om de servicetimer opnieuw in te stellen.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Servicetimerinterval ingesteld op %1h. Gebruik de knop &apos;Reset servicetimer&apos; om de servicetimer opnieuw in te stellen.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Onderhoudstimer herstarten</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Onderhoudstimer herstarten</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>GPS instellingen</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>GPS instellingen</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>jjjj-mm-dd</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>jjjj-mm-dd</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" O</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; O</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 O</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 O</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Snelheidseenheid</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Snelheidseenheid</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilometer per uur</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilometer per uur</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Meters per seconde</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Meters per seconde</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Mijlen per uur</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Mijlen per uur</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Knopen</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Knopen</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Geen GSM modem aangesloten</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Geen GSM modem aangesloten</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Provider</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Provider</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Het kan noodzakelijk zijn de APN-instellingen hieronder op deze pagina in te stellen, neem contact op met de operator voor aanvullende informatie.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Het kan noodzakelijk zijn de APN-instellingen hieronder op deze pagina in te stellen, neem contact op met de operator voor aanvullende informatie.
 Als dit niet werkt, controleer dan de SIM kaart in een telefoon om er zeker van te zijn dat er beltegoed is en/of geregistreerd is om te worden gebruikt voor mobiele data.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Roaming toestaan</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Roaming toestaan</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>SIM status</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>SIM status</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM niet geplaatst</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM niet geplaatst</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN vereist</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN vereist</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK vereist</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK vereist</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>SIM fout</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>SIM fout</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM bezig</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM bezig</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Verkeerde SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Verkeerde SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Verkeerde PIN code</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Verkeerde PIN code</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Gereed</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Gereed</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Onbekende fout</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Standaard</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Standaard</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Gebruik standaard APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Gebruik standaard APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>APN naam</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>APN naam</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Gebruik authenticatie</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Gebruik authenticatie</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Gebruikers naam</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Gebruikers naam</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Eigen verbruik</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Eigen verbruik</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>ESS wizard niet gevonden</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>ESS wizard niet gevonden</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Net meting</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Net meting</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Externe meter</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Externe meter</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Omvormer/Acculader</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Omvormer/Acculader</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>AC uitgang omvormer in gebruik</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>AC uitgang omvormer in gebruik</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Meer fasen regeling</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Meer fasen regeling</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Totaal van alle fasen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Totaal van alle fasen</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Individuele fase</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Individuele fase</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Elke fase wordt geregeld om individueel het instelpunt van het stroomnet te bereiken (de efficiëntie van het systeem neemt af).
+        <translation>Elke fase wordt geregeld om individueel het instelpunt van het stroomnet te bereiken (de efficiëntie van het systeem neemt af).
 
 LET OP: Alleen gebruiken indien vereist door de energieleverancier.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Het totaal van alle fasen wordt intelligent geregeld om het setpoint van het stroomnet te bereiken (systeemrendement wordt geoptimaliseerd).
+        <translation>Het totaal van alle fasen wordt intelligent geregeld om het setpoint van het stroomnet te bereiken (systeemrendement wordt geoptimaliseerd).
 
 Gebruik tenzij verboden door de energieleverancier.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inactief</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamic ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Minimale laadtoestand (tenzij net uitvalt)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Minimale laadtoestand (tenzij net uitvalt)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Huidige laadtoestand limiet</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Huidige laadtoestand limiet</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Onderhouden</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Opnieuw laden</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Peak shaving</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Peak shaving</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Alleen boven de minimale laadtoestand</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Alleen boven de minimale laadtoestand</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Altijd</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Altijd</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Ontlading uitgeschakeld</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Ontlading uitgeschakeld</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Langzaam laden</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Langzaam laden</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Onderhouden</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Onderhouden</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Opnieuw laden</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Opnieuw laden</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Limiet laadvermogen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Limiet laadvermogen</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Maximaal laadvermogen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Maximaal laadvermogen</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Vermogen omvormer beperken</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Vermogen omvormer beperken</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Maximaal vermogen omvormer</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Maximaal vermogen omvormer</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Instelwaarde stroomnet</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Instelwaarde stroomnet</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Net teruglevering</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Net teruglevering</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>Met AC gekoppeld zonnepaneel - overschot terugleveren</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>Met AC gekoppeld zonnepaneel - overschot terugleveren</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>Met DC gekoppeld zonnepaneel - overschot terugleveren</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>Met DC gekoppeld zonnepaneel - overschot terugleveren</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Beperken systeem terugleveren</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Beperken systeem terugleveren</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Maximaal terugleveren</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Maximaal terugleveren</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Beperking terugleveren actief</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Beperking terugleveren actief</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Analoge ingangen</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Analoge ingangen</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Digitale ingangen</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Digitale ingangen</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Digitale ingang %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Digitale ingang %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Impulsmeter</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Impulsmeter</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Deuralarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Deuralarm</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Lenspomp</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Lenspomp</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Lenswateralarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Lenswateralarm</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Inbraakalarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Inbraakalarm</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Rookalarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Rookalarm</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Brandalarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Brandalarm</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>CO2 alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>CO2 alarm</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Bluetooth sensoren</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Bluetooth sensoren</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Let op, deze eigenschappen worden niet officieel ondersteund door Victron.
+        <translation>Let op, deze eigenschappen worden niet officieel ondersteund door Victron.
 Voor vragen ga naar community.victronenergy.com
 
 Documentatie op https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Ingeschakeld (veilige modus)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Ingeschakeld (veilige modus)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>%1s uitgesteld</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>%1s uitgesteld</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>VRM Portal ID</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>VRM Portal ID</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Log interval</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Log interval</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 uur</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 uur</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 uur</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 uur</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 uur</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 uur</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 uur</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 uur</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 dag</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 dag</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Gebruik veilige verbinding (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Gebruik veilige verbinding (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Laatste contact</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Laatste contact</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Onverwachte antwoordtekst</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Onverwachte antwoordtekst</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Onverwachte HTTP respons</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Onverwachte HTTP respons</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Time-out verbinding</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Time-out verbinding</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Fout in verbinding</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Fout in verbinding</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 DNS storing</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 DNS storing</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Routefout</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Routefout</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM niet beschikbaar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM niet beschikbaar</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Onbekende fout</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Onbekende fout</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Foutbericht:
+        <translation>Foutbericht:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Herstart apparaat bij geen contact</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Herstart apparaat bij geen contact</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Geen contact resetvertraging (uu:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Geen contact resetvertraging (uu:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Opslaglocatie</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Opslaglocatie</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Geen buffer actief</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Geen buffer actief</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Interne opslag</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Interne opslag</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Overdracht bezig</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Overdracht bezig</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Externe opslag</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Externe opslag</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Onbekende fout</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Geen fout</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Geen fout</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Geen ruimte meer op opslag</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Geen ruimte meer op opslag</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>IO-storing</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>IO-storing</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <extracomment>I assume this concerns a volume mount error</extracomment>
-      <translation>Mount fout</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Mount fout</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Bevat firmware-afbeelding. Niet in gebruik.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Bevat firmware-afbeelding. Niet in gebruik.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD-kaart / USB-stick niet beschrijfbaar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD-kaart / USB-stick niet beschrijfbaar</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Vrije schijfruimte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Vrije schijfruimte</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>byte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>byte</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bytes</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bytes</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Opgeslagen records</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Opgeslagen records</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 records</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 records</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Oudste recordleeftijd</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Oudste recordleeftijd</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Inschakelen Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Inschakelen Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Geen storingen gemeld</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Geen storingen gemeld</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Tijdstip van laatste storing</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Tijdstip van laatste storing</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Beschikbare diensten</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Beschikbare diensten</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>Unit ID: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>Unit ID: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Functie (relais 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Functie (relais 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Functie</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Functie</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Alarm relais</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Alarm relais</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Tankpomp</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Handmatig</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Alarm relais polariteit</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Alarm relais polariteit</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normaal open</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normaal open</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normaal gesloten</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normaal gesloten</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relais 1 Aan</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relais 1 Aan</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relais Aan</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relais Aan</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Functie (Relais 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Functie (Relais 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relais 2 Aan</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relais 2 Aan</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Temperatuurregeling regels</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Temperatuurregeling regels</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Relais actief bij temperatuur</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Relais actief bij temperatuur</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Er is geen relais ingesteld om geactiveerd te worden door temperatuur. Ga naar de pagina met relaisinstellingen in het hoofdmenu Instellingen en stel de relaisfunctie in op "Temperatuur".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Er is geen relais ingesteld om geactiveerd te worden door temperatuur. Ga naar de pagina met relaisinstellingen in het hoofdmenu Instellingen en stel de relaisfunctie in op &quot;Temperatuur&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Deze optie maakt het mogelijk om te wisselen tussen de huidige en de vorige firmwareversie. Hiervoor is geen internet of SD-kaart nodig.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Deze optie maakt het mogelijk om te wisselen tussen de huidige en de vorige firmwareversie. Hiervoor is geen internet of SD-kaart nodig.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Drukken om op te starten</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Drukken om op te starten</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Herstarten met %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Herstarten met %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Het omschakelen tussen firmware versies is niet mogelijk als Automatisch Bijwerken ingesteld staat op "Controleren en Bijwerken" Zet Automatisch Bijwerken op "Uitgeschakeld" of "Alleen Controleren om deze optie mogelijk te maken.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Het omschakelen tussen firmware versies is niet mogelijk als Automatisch Bijwerken ingesteld staat op &quot;Controleren en Bijwerken&quot; Zet Automatisch Bijwerken op &quot;Uitgeschakeld&quot; of &quot;Alleen Controleren om deze optie mogelijk te maken.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Backup firmware niet beschikbaar</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Backup firmware niet beschikbaar</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Console aan VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-bus over TCP/IP (Debug)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-bus over TCP/IP (Debug)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Walstroom</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Walstroom</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Voertuig</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Voertuig</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Boot</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Boot</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Systeemnaam</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Systeemnaam</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatisch</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatisch</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Net</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatisch</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Gebruikersgedefinieerd</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Gebruikersgedefinieerd</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Door gebruiker gedefinieerde naam</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Door gebruiker gedefinieerde naam</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>AC ingang 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>AC ingang 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>AC ingang 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>AC ingang 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Bewaken op elektriciteitsstoring</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Bewaken op elektriciteitsstoring</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Bewaken op ontkoppeling walstroom</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Bewaken op ontkoppeling walstroom</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Automatisch geselecteerd</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Automatisch geselecteerd</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Heeft DC systeem</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Heeft DC systeem</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>VE.Bus laadtoestand synchroniseren met accu</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>VE.Bus laadtoestand synchroniseren met accu</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>PV stroom gebruiken om VE.Bus laadtoestand te verbeteren</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>PV stroom gebruiken om VE.Bus laadtoestand te verbeteren</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>PV lader spanningsregeling</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>PV lader spanningsregeling</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>PV lader stroomregeling</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>PV lader stroomregeling</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS-besturing</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS-besturing</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS-besturing</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>De start/stop-functie van de tankpomp is niet ingeschakeld. Ga naar relaisinstellingen en stel de functie in op "Tankpomp".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>De start/stop-functie van de tankpomp is niet ingeschakeld. Ga naar relaisinstellingen en stel de functie in op &quot;Tankpomp&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Pompstatus</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Pompstatus</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Automatisch</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Tanksensor</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Tanksensor</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Startpeil</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Startpeil</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Stoppeil</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Stoppeil</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Verbinding onderbroken</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Verbinding onderbroken</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Losgekoppeld</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Losgekoppeld</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Verborgen]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Verborgen]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Verbinden met netwerk?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Verbinden met netwerk?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Verbinden</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Verbinden</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Netwerk vergeten?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Netwerk vergeten?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Vergeten</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Vergeten</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Dit netwerk vergeten?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Dit netwerk vergeten?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC adres</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC adres</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>IP instellingen</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>IP instellingen</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Handmatig</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Uit</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Vast</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Vast</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Netmask</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Netmask</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Gateway</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Gateway</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS server</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS server</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Link lokaal IP adres</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Link lokaal IP adres</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Opgelet, voor ESS systemen en ook systemen met een beheerde accu, moet het CAN bus-apparaat op 0 blijven ingesteld. Raadpleeg GX handleiding voor meer informatie.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Opgelet, voor ESS systemen en ook systemen met een beheerde accu, moet het CAN bus-apparaat op 0 blijven ingesteld. Raadpleeg GX handleiding voor meer informatie.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Device instance</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Device instance</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Netwerkadres</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Netwerkadres</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>VE.CAN apparaten</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>VE.CAN apparaten</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Apparaat# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Apparaat# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Geen toegangspunten</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Geen toegangspunten</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Geen WiFi-adapter aangesloten</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Geen WiFi-adapter aangesloten</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Access point maken</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Access point maken</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>WiFi netwerken</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>WiFi netwerken</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Access Point uitzetten?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Access Point uitzetten?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Datum/Tijd UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Datum/Tijd UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Datum/Tijd plaatselijk</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Datum/Tijd plaatselijk</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Tijdzone</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Tijdzone</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afrika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afrika</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Amerika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Amerika</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antarctica</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antarctica</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Arctic</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Arctic</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Azië</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Azië</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantische Oceaan</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantische Oceaan</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australië</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australië</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indische Oceaan</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indische Oceaan</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Stille Oceaan</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Stille Oceaan</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Enz.</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Enz.</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Niet verbonden %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Niet verbonden %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Nu opnieuw opstarten?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Nu opnieuw opstarten?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Wijzigingen aan de VRM instance worden pas toegepast als het apparaat opnieuw wordt opgestart.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Wijzigingen aan de VRM instance worden pas toegepast als het apparaat opnieuw wordt opgestart.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Apparaat start opnieuw op...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Apparaat start opnieuw op...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Apparaat is opnieuw opgestart.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Apparaat is opnieuw opgestart.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Alarm lage accuspanning</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Alarm lage accuspanning</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Alarm hoge accuspanning</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Alarm hoge accuspanning</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Laatste fout</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Laatste fout</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>1 na laatste fout</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>1 na laatste fout</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>2 na laatste fout</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>2 na laatste fout</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>3 na laatste fout</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>3 na laatste fout</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Via netwerk</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Via netwerk</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Modusinstelling</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Modusinstelling</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Stand-alone</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Stand-alone</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Stand-alone</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Laden</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Laden</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Externe besturing</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Laden &amp; HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Laden &amp; HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Laden &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Laden &amp; BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Ext. besturing &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Ext. besturing &amp; BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Laden, Hub-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Laden, Hub-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Master instelling</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Master instelling</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Slave</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Slave</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Slave</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Groep master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Groep master</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Laad master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Laad master</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Groeps- &amp; laadmaster</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Groeps- &amp; laadmaster</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Laadspanning</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Laadspanning</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Reset</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Reset</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>BMS-regeling wordt automatisch ingeschakeld als er een BMS aanwezig is. Reset als de systeemconfiguratie is gewijzigd of als er geen BMS aanwezig is.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>BMS-regeling wordt automatisch ingeschakeld als er een BMS aanwezig is. Reset als de systeemconfiguratie is gewijzigd of als er geen BMS aanwezig is.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Totaal PV energie</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Belasting</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Belasting</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 gevonden</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 gevonden</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Geschiedenis</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Geschiedenis</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Geschiedenis</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Netwerkbedrijf</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Netwerkbedrijf</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Tabelweergave</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Tabelweergave</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Kaart</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Kaart</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Waarschuwing</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Waarschuwing</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarm</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Volume</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Volume</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Kortsluiting</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Kortsluiting</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Omgekeerde polariteit</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Omgekeerde polariteit</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>EV Charging Stations</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>EV Charging Stations</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Sessie</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Sessie</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Tijd</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Tijd</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Laad modus</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Laad modus</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Start en stop het proces zelf. Gebruik dit voor snel laden en nauwgezette bewaking.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Start en stop het proces zelf. Gebruik dit voor snel laden en nauwgezette bewaking.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Start en stopt op basis van het laadniveau van de accu. Optimaal voor 's nachts en langere ladingen om te veel laden te voorkomen.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Start en stopt op basis van het laadniveau van de accu. Optimaal voor &apos;s nachts en langere ladingen om te veel laden te voorkomen.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Lagere elektriciteitstarieven tijdens daluren of als ervoor gezord moet worden dat de EV volledig opgeladen is en klaar om te vertrekken op een specifiek tijdstip.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Lagere elektriciteitstarieven tijdens daluren of als ervoor gezord moet worden dat de EV volledig opgeladen is en klaar om te vertrekken op een specifiek tijdstip.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Laden toestaan</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Laden toestaan</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Lader scherm vergrendelen</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Lader scherm vergrendelen</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Bron adres</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Bron adres</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Instellingen</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Instellingen</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Regel instance #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Regel instance #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Net instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Net instance</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Lader instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Lader instance</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Omvormer instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Omvormer instance</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC bron #%1 instantie</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC bron #%1 instantie</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>DC bron instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>DC bron instance</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC-bron #%1 prioriteit</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC-bron #%1 prioriteit</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>DC bron prioriteit</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>DC bron prioriteit</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Tank instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Tank instance</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>RV-C apparaten</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>RV-C apparaten</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Visualisatie framerate inschakelen</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Visualisatie framerate inschakelen</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Niet ondersteund</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Niet ondersteund</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Verwijder niet verbonden apparaten</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Verwijder niet verbonden apparaten</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Niet ondersteund apparaat gevonden</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Niet ondersteund apparaat gevonden</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Relaisfunctie</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Relaisfunctie</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Start/stop lader of aggregaat</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Start/stop lader of aggregaat</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Handmatige bediening</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Zekering doorgebrand</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Handmatige bediening</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Handmatige bediening</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Altijd open (het relais niet gebruiken)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Altijd open (het relais niet gebruiken)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Let op dat het wijzigen van de instelling voor de lage laadtoestand ook de instelling voor de ontlaadtijd onder in het accumenu verandert.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Let op dat het wijzigen van de instelling voor de lage laadtoestand ook de instelling voor de ontlaadtijd onder in het accumenu verandert.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Zekering doorgebrand</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Zekering doorgebrand</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Status LED's</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Status LED&apos;s</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Geen</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Hoofdschakelaar</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Hoofdschakelaar</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Verwarming</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Verwarming</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Interne Ventilator</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Interne Ventilator</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Waarschuwingsvlaggen</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Waarschuwingsvlaggen</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Alarmvlaggen</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Alarmvlaggen</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Schakelaar</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Schakelaar</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Initialiseren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Initialiseren</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Afsluiten</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Afsluiten</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Bijwerken</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Bijwerken</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Gaat draaien</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Gaat draaien</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Vooraf opladen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Vooraf opladen</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Magneetschakelaar check</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Magneetschakelaar check</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Gezondheidstoestand</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Gezondheidstoestand</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Accu temperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Accu temperatuur</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Luchttemperatuur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Luchttemperatuur</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Startaccu spanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Startaccu spanning</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Busspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Busspanning</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Spanning bovenste deel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Spanning bovenste deel</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Communicatiefout</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Gezondheidstoestand</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Busspanning</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Spanning onderste deel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Spanning onderste deel</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Middelpuntsafwijking</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Middelpuntsafwijking</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Verbruikte Ah</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Verbruikte Ah</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Resterende tijd</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Resterende tijd</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Details</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Details</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarmen op moduleniveau</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarmen op moduleniveau</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnose</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnose</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Zekeringen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Zekeringen</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>Systeem</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>Systeem</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parameters</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parameters</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Accu opnieuw detecteren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Accu opnieuw detecteren</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Drukken om te detecteren</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Drukken om te detecteren</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Drukken om te detecteren</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Het opnieuw detecteren van de accu kan 60 seconden duren. De naam van de accu kan ook onjuist zijn.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Het opnieuw detecteren van de accu kan 60 seconden duren. De naam van de accu kan ook onjuist zijn.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Hoge laadstroom</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Hoge laadstroom</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Hoge ontladingsstroom</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Hoge ontladingsstroom</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Lage laadstatus</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Lage laadstatus</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Hoge accuspanning</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Lage laadstatus</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Lage startaccu spanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Lage startaccu spanning</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Hoge startaccu spanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Hoge startaccu spanning</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Accutemperatuursensor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Accutemperatuursensor</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Middelpuntspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Middelpuntspanning</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Zekering doorgebrand</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Hoge interne temperatuur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Hoge interne temperatuur</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Lage laadtemperatuur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Lage laadtemperatuur</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Hoge laadtemperatuur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Hoge laadtemperatuur</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Interne storing</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Interne storing</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Zekeringautomaat geactiveerd</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Zekeringautomaat geactiveerd</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Onbalans cel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Onbalans cel</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Lage celspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Lage celspanning</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Laagste celspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Laagste celspanning</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Hoogste celspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Hoogste celspanning</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Minimale celtemperatuur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Minimale celtemperatuur</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Maximale celtemperatuur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Maximale celtemperatuur</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Accumodules</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Accumodules</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Aantal modules die lading/ontlading blokkeren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Aantal modules die lading/ontlading blokkeren</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Geïnstalleerde/Beschikbare capaciteit</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Geïnstalleerde/Beschikbare capaciteit</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Diepste ontlading</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Diepste ontlading</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Laatste ontlading</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Laatste ontlading</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Gemiddelde ontlading</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Gemiddelde ontlading</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Totaal aantal laadcycli</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Totaal aantal laadcycli</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Aantal volledige ontladingen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Aantal volledige ontladingen</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Cumulatieve onttrokken Ah</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Cumulatieve onttrokken Ah</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Minimale celspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Minimale celspanning</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Maximale celspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Maximale celspanning</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Tijd sinds laatste volledige oplading</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Tijd sinds laatste volledige oplading</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Synchronisatietelling</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Synchronisatietelling</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarm bij lage startaccuspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarm bij lage startaccuspanning</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Minimumspanning startaccu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Minimumspanning startaccu</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Maximale spanning startaccu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Maximale spanning startaccu</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Ontladen energie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Ontladen energie</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Geladen energie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Geladen energie</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Laadspanningslimiet (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Laadspanningslimiet (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Laadstroomlimiet (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Laadstroomlimiet (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Ontlaadstroomlimiet (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Ontlaadstroomlimiet (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Lage Spanning Ontkoppelen (altijd genegeerd)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Lage Spanning Ontkoppelen (altijd genegeerd)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Accubank</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Accubank</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relais (op accumonitor)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relais (op accumonitor)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Fabrieksinstellingen herstellen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Fabrieksinstellingen herstellen</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Klik om te herstellen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Klik om te herstellen</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Fabrieksinstellingen herstellen?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Fabrieksinstellingen herstellen?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth ingeschakeld</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth ingeschakeld</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Nominale spanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Nominale spanning</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Capaciteit</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Capaciteit</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capaciteit</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Geladen spanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Geladen spanning</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Staartstroom</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Staartstroom</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Geladen detectietijd</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Geladen detectietijd</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Peukert exponent</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Peukert exponent</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Laadefficiëntiefactor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Laadefficiëntiefactor</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Stroomdrempel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Stroomdrempel</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Gemiddelde resterende tijd</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Gemiddelde resterende tijd</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Resterende tijd ontladingsniveau</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Resterende tijd ontladingsniveau</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Stroomafwijking</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Stroomafwijking</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Laadstatus naar 100% synchroniseren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Laadstatus naar 100% synchroniseren</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Klikken</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Klikken</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Nulstroom kalibreren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Nulstroom kalibreren</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Klikken om 0 in te stellen</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Klikken om 0 in te stellen</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Verdeler %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Verdeler %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Geen spanning op verdeelrail</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Geen spanning op verdeelrail</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Verbinding onderbroken</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n zekering(en) doorgebrand</numerusform>
-        <numerusform>%n zekering(en) doorgebrand</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n zekering(en) doorgebrand</numerusform>
+            <numerusform>%n zekering(en) doorgebrand</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Geen informatie beschikbaar, zie voorgaande pagina voor de Distributor status</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Geen informatie beschikbaar, zie voorgaande pagina voor de Distributor status</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Zekering %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Zekering %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Niet in gebruik</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Niet in gebruik</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Doorgebrand</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Doorgebrand</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Stopgezet door storing</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Stopgezet door storing</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Laatste fout</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">1 na laatste fout</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">2 na laatste fout</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">3 na laatste fout</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Systeemschakelaar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Systeemschakelaar</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Extern relais</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Extern relais</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Programmeerbaar contact</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Programmeerbaar contact</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Accu's</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Accu&apos;s</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capaciteit</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Accu&apos;s</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Parallel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Parallel</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>In serie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>In serie</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Min/max. celspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Min/max. celspanning</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Min/max. celtemperatuur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Min/max. celtemperatuur</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Balanceren</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Balanceren</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Balanceren</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Onbekend</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Uitgang</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Uitgang</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Veld aansturing</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Veld aansturing</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Motor toerental</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Motor toerental</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Aux spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Aux spanning</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Geen alarmmeldingen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Geen alarmmeldingen</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Lage spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Lage spanning</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Hoge spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Hoge spanning</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Lage Aux spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Lage Aux spanning</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Hoge Aux spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Hoge Aux spanning</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Alarm lage Aux spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Alarm lage Aux spanning</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Alarm hoge Aux spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Alarm hoge Aux spanning</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Min. Aux spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Min. Aux spanning</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Max. Aux spanning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Max. Aux spanning</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Energie opgewekt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Energie opgewekt</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Energie verbruikt</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Energie verbruikt</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Alarm inschakelen</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Alarm inschakelen</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Actief niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Actief niveau</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Herstel niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Herstel niveau</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Vertraging</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Vertraging</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Niveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Niveau</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Resterend</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Resterend</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Accu sensor</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Accu sensor</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Accu sensor</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Sensor type</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Sensor type</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Standaard</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Standaard</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Europees (0 tot 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Europees (0 tot 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>VS (240 tot 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>VS (240 tot 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Aangepast</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Aangepast</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Aangepast</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Sensor waarde als leeg</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Sensor waarde als leeg</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Vloeistoftype</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Vloeistoftype</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Butaan verhouding</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Butaan verhouding</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Aangepaste vorm</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Aangepaste vorm</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Gemiddelde tijd</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Gemiddelde tijd</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Sensor waarde</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Sensor waarde</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Geen aangepaste vorm gedefinieerd. Er kan een gedefinieerd worden met maximaal tien punten. Let op dat 0% en 100% geïmpliceerd zijn.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Geen aangepaste vorm gedefinieerd. Er kan een gedefinieerd worden met maximaal tien punten. Let op dat 0% en 100% geïmpliceerd zijn.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punt %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Punt toevoegen</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Punt toevoegen</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Sensorniveau</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Sensorniveau</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Volume</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Dubbele sensorniveauwaarden zijn niet toegestaan.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Dubbele sensorniveauwaarden zijn niet toegestaan.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>De volumewaarden moeten toenemen.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>De volumewaarden moeten toenemen.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Open (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Open (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Open (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Open (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Open (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Open (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Op slot</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Op slot</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Faseconfiguratie</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Faseconfiguratie</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Stand schakelaar</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Stand schakelaar</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">1-Fase</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2-Fasen</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2-Fasen</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3-Fasen</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3-Fasen</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Apparaten</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Snelheid</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Belasting</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Koelmiddel temperatuur</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Koelmiddel temperatuur</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Uitlaat temperatuur</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Uitlaat temperatuur</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Temperatuur wikkeling</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Temperatuur wikkeling</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Startaccu spanning</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Startaccu spanning</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Aantal starts</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Aantal starts</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS-besturing</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Keuze schakelaar vergrendeld (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Keuze schakelaar vergrendeld (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Geen fout (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Geen fout (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC totalen</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC totalen</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energie L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energie L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Fasevolgorde</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Fasevolgorde</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Data manager versie</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Data manager versie</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Geen</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Knipperende LED duidt deze CT aan</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Knipperende LED duidt deze CT aan</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Smappee bus apparaten</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Smappee bus apparaten</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>PV acculader</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>PV acculader</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Deze instelling is uitgeschakeld als een Digital Multi Control is aangesloten.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Deze instelling is uitgeschakeld als een Digital Multi Control is aangesloten.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Deze instelling is uitgeschakeld als een VE.Bus BMS is aangesloten.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Deze instelling is uitgeschakeld als een VE.Bus BMS is aangesloten.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC In %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC In %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Omgekeerd</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Omgekeerd</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Alarm inschakelen</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Omgekeerd</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Alarm logica omkeren</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Alarm logica omkeren</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Instraling</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Instraling</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Celtemperatuur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Celtemperatuur</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Externe temperatuur (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Externe temperatuur (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Externe temperatuur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Externe temperatuur</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Externe temperatuur (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Externe temperatuur (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Windsnelheid</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Windsnelheid</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Auto-detectie</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Auto-detectie</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Windsnelheidsensor</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Windsnelheidsensor</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Externe temperatuur sensor</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Externe temperatuur sensor</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Opgeteld</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Opgeteld</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Vermenigvuldigen</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Vermenigvuldigen</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Teller resetten</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Teller resetten</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Kortsluiting</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Omgekeerde polariteit</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Sensor accu lage spanning</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Sensor accu lage spanning</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Vochtigheid</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Vochtigheid</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Druk</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Druk</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Laag</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Offset</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Schaal</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Schaal</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Spanningssensor</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Spanningssensor</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Totaal PV energie</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Totaal PV energie</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Product pagina</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Product pagina</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>AC sensor %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>AC sensor %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Er is een nieuwe MK3-versie beschikbaar.
+        <translation>Er is een nieuwe MK3-versie beschikbaar.
 OPMERKING: Het bijwerken kan het systeem tijdelijk stoppen.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>De MK3 bijwerken</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>De MK3 bijwerken</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Druk om bij te werken</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Druk om bij te werken</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>MK3 bijwerken, de waarden zullen na het bijwerken terug komen.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>MK3 bijwerken, de waarden zullen na het bijwerken terug komen.</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">De accu opladen tot 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>De accu opladen tot 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>De accu opladen tot 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Geavanceerd</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>Bezig</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>Bezig</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Klik om te stoppen</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Klik om te stoppen</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Klik om te starten</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Klik om te starten</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Laad de accu op tot 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Laad de accu op tot 100%</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Het systeem keert terug naar de normale werking en geeft prioriteit aan hernieuwbare energie.
+        <translation>Het systeem keert terug naar de normale werking en geeft prioriteit aan hernieuwbare energie.
 Doorgaan?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Als er walstroom beschikbaar is zal dat gebruikt worden en de zon- en windprioriteit wordt genegeerd. Doorgaan?</translation>
+        <translation>Als er walstroom beschikbaar is zal dat gebruikt worden en de zon- en windprioriteit wordt genegeerd. Doorgaan?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Voor één keer de accu's volledig laden wordt walstroom gebruikt. Als het laden gereed is zal het systeem terugkeren naar normaal bedrijf, met de prioriteit voor zon- en windenergie. Doorgaan?</translation>
+        <translation>Voor één keer de accu&apos;s volledig laden wordt walstroom gebruikt. Als het laden gereed is zal het systeem terugkeren naar normaal bedrijf, met de prioriteit voor zon- en windenergie. Doorgaan?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>DC spanning</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>DC spanning</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>DC stroom</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>DC stroom</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Geavanceerd</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Geavanceerd</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Alarm instellingen</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Alarm instellingen</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>Een VE.Bus BMS schakelt indien nodig automatisch het systeem uit om de accu te beschermen. Besturing van het systeem vanuit de Color Control is daarom niet mogelijk.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>Een VE.Bus BMS schakelt indien nodig automatisch het systeem uit om de accu te beschermen. Besturing van het systeem vanuit de Color Control is daarom niet mogelijk.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Een BMS-assistent is geïnstalleerd die ingesteld is voor een VE.Bus BMS, maar de VE.Bus BMS wordt niet gevonden!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Een BMS-assistent is geïnstalleerd die ingesteld is voor een VE.Bus BMS, maar de VE.Bus BMS wordt niet gevonden!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Waarschuwing: Egalisatie aanzetten in ESS een systeem met zonneladers kan het laden van de accu met te hoge spanning en met te hoge stroom veroorzaken.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Waarschuwing: Egalisatie aanzetten in ESS een systeem met zonneladers kan het laden van de accu met te hoge spanning en met te hoge stroom veroorzaken.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Het systeem schakelt automatisch over naar druppel als de egalisatie lading is voltooid.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Het systeem schakelt automatisch over naar druppel als de egalisatie lading is voltooid.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Egalisatie onderbreken</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Egalisatie onderbreken</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Egalisatie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Egalisatie</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Onderbreken...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Onderbreken...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Starten...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Starten...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Starten...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Drukken om te onderbreken</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Drukken om te onderbreken</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Onderbreken en herstarten van absorptie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Onderbreken en herstarten van absorptie</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Onderbreken en ga naar druppel</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Onderbreken en ga naar druppel</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Onderbreken</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Onderbreken</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Niet onderbreken</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Niet onderbreken</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>VE.Bus systeem opnieuw zoeken.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>VE.Bus systeem opnieuw zoeken.</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Opnieuw detecteren...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Opnieuw detecteren...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Herstart VE.Bus systeem</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Herstart VE.Bus systeem</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Herstarten...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Herstarten...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Druk voor herstarten</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Druk voor herstarten</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>AC ingang 1 genegeerd</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>AC ingang 1 genegeerd</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>AC ingang 2 genegeerd</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>AC ingang 2 genegeerd</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>ESS relais test</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>ESS relais test</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Voltooid</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">In behandeling...</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Voltooid</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Voltooid</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>In behandeling...</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>In behandeling...</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>VE.Bus diagnostiek</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>VE.Bus diagnostiek</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Netwerkkwaliteitsteller Fase L%1, apparaat %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Netwerkkwaliteitsteller Fase L%1, apparaat %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.Busfout 8 / 11 rapport</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.Busfout 8 / 11 rapport</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Alleen alarm</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Alleen alarm</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarmen en meldingen</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarmen en meldingen</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>BMS storing</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>BMS storing</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Serienummers</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Serienummers</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Laatste VE.Bus Fout 11 rapport #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Laatste VE.Bus Fout 11 rapport #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>BF veiligheidstest bezig</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>BF veiligheidstest bezig</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>BF veiligheidstest OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>BF veiligheidstest OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>AC0 /AC1 wanverhouding</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>AC0 /AC1 wanverhouding</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Communicatiefout</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Communicatiefout</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>Aardrelais fout</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>Aardrelais fout</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Netspanning komt niet overeen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Netspanning komt niet overeen</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Netfrequentie komt niet overeen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Netfrequentie komt niet overeen</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Fout in aandrijving van BF-relais</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Fout in aandrijving van BF-relais</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Fout: PE2 open</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Fout: PE2 open</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Fout: PE2 gesloten</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Fout: PE2 gesloten</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Mislukte stap: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Mislukte stap: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Fase L%1, apparaat %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Fase L%1, apparaat %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>VE.Bus Storing 11 rapportage vereist minimaal VE.Bus firmware versie 454.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>VE.Bus Storing 11 rapportage vereist minimaal VE.Bus firmware versie 454.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus eigenaardigheden</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus eigenaardigheden</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energie</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energie</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Vermogen</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Vermogen</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Spanning</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Spanning</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Stroom</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Stroom</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Locatie</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Locatie</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Fase</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Actieve AC ingang</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Actieve AC ingang</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Hoge DC rimpel</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Hoge DC rimpel</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Hoge DC spanning</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Hoge DC spanning</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Hoge DC stroom</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Hoge DC stroom</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Storing temperatuursensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Storing temperatuursensor</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Storing spanningssensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Storing spanningssensor</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Overbelasting</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Overbelasting</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>DC rimpel</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>DC rimpel</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Spanningssensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Spanningssensor</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Faserotatie</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Faserotatie</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Faserotatie</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>VE.Bus versie</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>VE.Bus versie</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2 apparaat</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2 apparaat</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>MK2 versie</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>MK2 versie</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Multi Control versie</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Multi Control versie</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>VE.Bus BMS versie</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>VE.Bus BMS versie</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Tenzij het net uitvalt</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Tenzij het net uitvalt</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>AC In</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>AC In</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC Ingang</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC Ingang</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>AC Ingang 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>AC Ingang 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>AC Ingang 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>AC Ingang 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Rol</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC Belasting</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC Belasting</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>AC-Uit</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>AC-Uit</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>AC Uitgang</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>AC Uitgang</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC fase L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC fase L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>AC sensor %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>AC sensor %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>AC sensoren</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>AC sensoren</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Actief</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Actief</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Overbelasting</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Alarmstatus</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Alarmstatus</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarmen</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarmen</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Opladen toestaan</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Opladen toestaan</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Ontladen toestaan</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Ontladen toestaan</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Automatisch zoeken</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Automatisch zoeken</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Accu</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Accu</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Accustroom</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Accustroom</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Accuspanning</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Accuspanning</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Laadstroom</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Laadstroom</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Opladen</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Opladen</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Storing wissen</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Storing wissen</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Gesloten</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Gesloten</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Verbonden</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Verbonden</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Stroom</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Stroom</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Stroomtransformatoren</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Stroomtransformatoren</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Aangepaste naam</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Aangepaste naam</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Debuggen</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Debuggen</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Apparaat</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Apparaat</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Uitgeschakeld</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Ontladen</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Ontladen</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Losgekoppeld</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Losgekoppeld</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Inschakelen</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Inschakelen</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Ingeschakeld</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Ingeschakeld</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energie</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energie</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Fout</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Fout</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Fout:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Fout:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Storingscode</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Storingscode</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Firmware versie</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Firmware versie</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Aggregaat</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Aggregaat</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Hoge accutemperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Hoge accutemperatuur</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Alarm hoog niveau</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Alarm hoog niveau</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Hoge startaccuspanning</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Hoge startaccuspanning</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Hoge temperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Hoge temperatuur</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Alarmen hoge spanning</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Alarmen hoge spanning</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Geschiedenis</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Geschiedenis</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Uur(en)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Uur(en)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Inactief</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Inactief</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inactief</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inactief</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Omvormer / Lader</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP adres</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP adres</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Lage accutemperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Lage accutemperatuur</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Alarm laag niveau</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Alarm laag niveau</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Lage startaccuspanning</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Lage startaccuspanning</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Lage laadstatus</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Lage laadstatus</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Lage temperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Lage temperatuur</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Alarmen lage spanning</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Alarmen lage spanning</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Producent</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Producent</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Maximumtemperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Maximumtemperatuur</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Maximumspanning</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Maximumspanning</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Minimumtemperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Minimumtemperatuur</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Minimumspanning</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Minimumspanning</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Modus</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Modus</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Modelnaam</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Modelnaam</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Nee</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Nee</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Geen fout</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Geen fout</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Niet beschikbaar</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Niet beschikbaar</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Niet aangesloten</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Niet aangesloten</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Offline</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Offline</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>OK</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>OK</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Aan</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Aan</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Geopend</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Geopend</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Wachtwoord</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Wachtwoord</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Fase</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Fase</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Klikken om te wissen</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Klikken om te wissen</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Klik om te resetten</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Klik om te resetten</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Klikken om te zoeken</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Klikken om te zoeken</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>PV omvormer</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>PV omvormer</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>PV stroom</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>PV stroom</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Rustige uren</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Rustige uren</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relais</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relais</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Herstart</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Herstart</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Verwijderen</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Verwijderen</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>Loopt</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>Loopt</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Zoeken %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Zoeken %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Serienummer</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Serienummer</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Instellingen</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Instellingen</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Instellingen</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Instellingen</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Signaalsterkte</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Signaalsterkte</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Stand-by</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Stand-by</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Start nadat de voorwaarde is bereikt voor</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Start nadat de voorwaarde is bereikt voor</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Starttijd</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Starttijd</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Startwaarde tijdens rustige uren</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Startwaarde tijdens rustige uren</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Starten als melding actief is gedurende</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Starten als melding actief is gedurende</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Laadstatus</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Laadstatus</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Status</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Status</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Opstarten (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Opstarten (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Stopwaarde tijdens rustige uren</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Stopwaarde tijdens rustige uren</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Stop nadat de voorwaarde is bereikt voor</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Stop nadat de voorwaarde is bereikt voor</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Gestopt</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Gestopt</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatuur</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatuur</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Temperatuursensor</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Temperatuursensor</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Vandaag</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Vandaag</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Totaal</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Totaal</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Tracker</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Tracker</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Type</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Type</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Uniek Identity nummer</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Uniek Identity nummer</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Onbekend</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Onbekend</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>VE.Bus fout</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>VE.Bus fout</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Spanning</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Spanning</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>VRM instance</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>VRM instance</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Als melding is gewist, dan stoppen na</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Als melding is gewist, dan stoppen na</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Ja</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Ja</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Gisteren</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Gisteren</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Opbrengst</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Opbrengst</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Vermogenslimiet voor niet terugleveren</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Vermogenslimiet voor niet terugleveren</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Datum instellen</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Datum instellen</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Start nu</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Start nu</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Actief volgens planning</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Actief volgens planning</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Nu stoppen</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Nu stoppen</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Totale bedrijfstijd</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Totale bedrijfstijd</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Tijd %1 instellen</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Tijd %1 instellen</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>De aggregaat blijft draaien als aan een autostartvoorwaarde wordt voldaan.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>De aggregaat blijft draaien als aan een autostartvoorwaarde wordt voldaan.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Omvormer / ladermodus</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Omvormer / ladermodus</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <extracomment>cid:16DC26AD-B77D-4CE5-AE47-CD15A3346E55 https://s3.eu-west-1.amazonaws.com/po-pub/i/rviuNDtDwogzXx5UjT3Xq3Nk.png 
-
-It is used here.</extracomment>
-      <translation>Instellen</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Instellen</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Annuleren</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Sluiten</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Sluiten</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Tijd instellen</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Tijd instellen</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Al in gebruik</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Al in gebruik</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Fout met omruilen</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Fout met omruilen</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Omruilen voltooid</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Omruilen voltooid</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Device instances verwisselen...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Device instances verwisselen...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Device instance %1 wordt al gebruikt door '%3'. Device instance verwisselen en toewijzen aan %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Device instance %1 wordt al gebruikt door &apos;%3&apos;. Device instance verwisselen en toewijzen aan %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Device instance %1 wordt al gebruikt door een ander apparaat van hetzelfde type. Device instance verwisselen en toewijzen aan %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Device instance %1 wordt al gebruikt door een ander apparaat van hetzelfde type. Device instance verwisselen en toewijzen aan %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Kan device instances niet verwisselen: bewerking is afgebroken.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Kan device instances niet verwisselen: bewerking is afgebroken.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Nieuwe device instances zullen actief zijn bij het herstarten.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Nieuwe device instances zullen actief zijn bij het herstarten.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Omruil</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Omruil</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Fout bij het controleren op firmware-updates</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Fout bij het controleren op firmware-updates</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Downloading en installeren firmware %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Downloading en installeren firmware %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Firmware wordt geïnstalleerd...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Firmware wordt geïnstalleerd...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Fout tijdens installatie firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Fout tijdens installatie firmware</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Geen nieuwere versie beschikbaar</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Geen nieuwere versie beschikbaar</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Geen firmware gevonden</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Geen firmware gevonden</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Brandstof</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Brandstof</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Vers water</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Vers water</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Afvalwater</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Afvalwater</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Bronwater</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Bronwater</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Olie</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Olie</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Vuilwater</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Vuilwater</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzine</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzine</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diesel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diesel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Hydraulische olie</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Hydraulische olie</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Vuil water</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Vuil water</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Vergrendeld instellen voor toegangsniveau</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Vergrendeld instellen voor toegangsniveau</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Wachtwoord verkeerd</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Wachtwoord verkeerd</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Kort</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Kort</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Overzicht</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Overzicht</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Niveaus</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Niveaus</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Berichten</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Berichten</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Nu</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Nu</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1m geleden</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1m geleden</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1h %2m geleden</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1h %2m geleden</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Elke dag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Elke dag</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Weekdagen</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Weekdagen</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Weekends</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Weekends</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Maandag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Maandag</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Dinsdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Dinsdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Woensdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Woensdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Donderdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Donderdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Vrijdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Vrijdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Zaterdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Zaterdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Zondag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Zondag</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 of %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 of %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Schema %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Schema %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Dag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Dag</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Niet ingesteld</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Niet ingesteld</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Laadtoestand limiet</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Laadtoestand limiet</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Eigen verbruik boven limiet</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Eigen verbruik boven limiet</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">Zonnepaneel</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>Zonnepaneel</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>Zonnepaneel</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>Zonnepaneel &amp; Accu</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>Zonnepaneel &amp; Accu</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Controleren...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Controleren...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Alarmtoestand</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Alarmtoestand</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Geschiedenis wissen</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Geschiedenis wissen</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Wordt gewist</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Wordt gewist</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Geforceerd ingeschakeld</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Geforceerd ingeschakeld</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Geforceerd uitgeschakeld</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Geforceerd uitgeschakeld</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Relaistoestand</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Relaistoestand</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Geschiedenis resetten op de monitor zelf</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Geschiedenis resetten op de monitor zelf</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Klik om uit te werpen</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Klik om uit te werpen</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Bezig met uitwerpen, even geduld</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Bezig met uitwerpen, even geduld</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Geen opslag gevonden</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Geen opslag gevonden</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 temperatuursensor</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 temperatuursensor</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 temperatuursensor (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 temperatuursensor (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Temperatuursensor (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Temperatuursensor (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Geen acties</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Geen acties</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Waarschuwing: De activerings- en deactiveringstemperaturen zijn ingesteld op dezelfde waarde. Hierdoor wordt de voorwaarde genegeerd.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Waarschuwing: De activerings- en deactiveringstemperaturen zijn ingesteld op dezelfde waarde. Hierdoor wordt de voorwaarde genegeerd.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Voorwaarde %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Voorwaarde %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Functie uitgeschakeld</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Functie uitgeschakeld</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Geen (Uit)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Geen (Uit)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relais 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relais 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relais 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relais 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Waarschuwing: Het bovenstaande relais is niet voor temperatuur ingesteld, de  toestand wordt genegeerd.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Waarschuwing: Het bovenstaande relais is niet voor temperatuur ingesteld, de  toestand wordt genegeerd.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Inschakel waarde</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Inschakel waarde</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Volume eenheid</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Volume eenheid</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Kubieke meter</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Kubieke meter</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Liters (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Liters (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Gallons (VS)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Gallons (VS)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Gallons (Imperiaal)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Gallons (Imperiaal)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Min. Spanning</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Min. Spanning</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Max. Spanning</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Max. Spanning</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Max. Spanning</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Max. stroom</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Max. stroom</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Oplaadtijd</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Oplaadtijd</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Druppellading</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">uur</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Druppellading</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Druppellading</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <extracomment>It is used in the date/time spinner for "hour"  https://s3.eu-west-1.amazonaws.com/po-pub/i/lDKid3lHJDnbYNVzEvmFvCuW.jpg</extracomment>
-      <translation>uur</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>uur</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 fout(en) opgetreden</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 fout(en) opgetreden</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Laatste</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Laatste</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>1 na laatste</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>1 na laatste</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>2 na laatste</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>2 na laatste</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>3 na laatste</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>3 na laatste</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Maximaal vermogen</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Maximaal vermogen</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Niet mogelijk verbinding te maken</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Niet mogelijk verbinding te maken</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Verbinding verbroken, probeert opnieuw verbinding te maken</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Verbinding verbroken, probeert opnieuw verbinding te maken</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Verbinding wordt gemaakt</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Verbinding wordt gemaakt</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Verbinding wordt gemaakt</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Verbonden, in afwachting van brokerberichten</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Verbonden, in afwachting van brokerberichten</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Verbonden, ontvangt brokerberichten</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Verbonden, ontvangt brokerberichten</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Aangesloten, gebruikersinterface laden</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Aangesloten, gebruikersinterface laden</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Ongeldige protocolversie</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Ongeldige protocolversie</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Klant ID afgewezen</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Klant ID afgewezen</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Broker service niet beschikbaar</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Broker service niet beschikbaar</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Slechte gebruikersnaam of wachtwoord</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Slechte gebruikersnaam of wachtwoord</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Gebruiker niet geautoriseerd</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Gebruiker niet geautoriseerd</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Fout transportverbinding</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Fout transportverbinding</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Protocol fout</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Protocol fout</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>MQTT protocol niveau 5 fout</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>MQTT protocol niveau 5 fout</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Alarm uitschakelen</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Alarm uitschakelen</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Totaal vermogen</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Totaal vermogen</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1h %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1h %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Fout</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Fout</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Bezig IP adres te ontvangen</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Bezig IP adres te ontvangen</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbonden</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Verbinding verbreken</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Verbinding verbreken</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Losgekoppeld</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC Belastingen</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC Belastingen</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>DC Belastingen</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>DC Belastingen</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Wind</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Wind</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Walstroom</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Walstroom</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Netstroombegrenzing</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Netstroombegrenzing</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Stroomlimiet aggregaat</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Stroomlimiet aggregaat</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Walstroomlimiet</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Walstroomlimiet</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Stoppen</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Stoppen</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Stoppen</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 te gaan</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 te gaan</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 tank (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 tank (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>AC lader</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>AC lader</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Dynamo</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Dynamo</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>DC lader</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>DC lader</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>DC aggregaat</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>DC aggregaat</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC Systeem</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC Systeem</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Brandstofcel</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Brandstofcel</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>As Generator</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>As Generator</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Water Generator</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Water Generator</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Wind Lader</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Wind Lader</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Laag</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Laag</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Hoog</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Hoog</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Houd de accu's opgeladen</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Houd de accu&apos;s opgeladen</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Geoptimaliseerd voor de levensduur van de accu</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Geoptimaliseerd voor de levensduur van de accu</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Geoptimaliseerd zonder BatteryLife</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Geoptimaliseerd zonder BatteryLife</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Externe besturing</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Geladen</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Geladen</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Wacht op zon</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Wacht op zon</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Wacht op RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Wacht op RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Wacht op start</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Wacht op start</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Fout aardingstest</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Fout aardingstest</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Fout bij testen CP ingang</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Fout bij testen CP ingang</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Lekstroom gedetecteerd</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Lekstroom gedetecteerd</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Te lage spanning gedetecteerd</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Te lage spanning gedetecteerd</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Te hoge spanning gedetecteerd</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Te hoge spanning gedetecteerd</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Oververhitting gedetecteerd</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Oververhitting gedetecteerd</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Laad limiet</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Laad limiet</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Start laden</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Start laden</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Geplanned</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Geplanned</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Geplanned</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Opwarmen</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Opwarmen</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Afkoelen</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Afkoelen</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Testbedrijf</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Testbedrijf</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Handmatig gestart</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Handmatig gestart</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Opstarten</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Opstarten</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>In bedrijf (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>In bedrijf (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>In bedrijf (snelheid verlaagd)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>In bedrijf (snelheid verlaagd)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relais %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relais %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Fout</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Fout</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorptie</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorptie</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Opslag</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Opslag</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Egaliseren</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Egaliseren</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Externe besturing</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>AES modus</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>AES modus</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Foutconditie</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Foutconditie</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Bulk laden</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Bulk laden</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Absorptie laden</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Absorptie laden</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Druppel laden</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Druppel laden</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Opslag modus</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Opslag modus</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Egalisatie laden</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Egalisatie laden</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Doorvoer</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Doorvoer</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Omvormen</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Omvormen</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Assisteren</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Assisteren</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Voeding modus</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Voeding modus</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Onderhouden</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Wakker worden</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Wakker worden</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Herhaalde absorptie</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Herhaalde absorptie</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Automatisch egaliseren</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Automatisch egaliseren</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>BatterySafe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>BatterySafe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Belasting detectie</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Belasting detectie</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Geblokkeerd</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Geblokkeerd</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamic ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dynamic ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dynamic ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Groep Master</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Groep Master</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Instance Master</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Instance Master</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Group &amp; Instance Master</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Group &amp; Instance Master</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Stand-alone &amp; Groep Master</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Stand-alone &amp; Groep Master</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Alleen lader</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Alleen lader</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Alleen omvormer</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Alleen omvormer</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Alarm lage accuspanning</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Alarm hoge accuspanning</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Alarm kortsluiting</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Alarm kortsluiting</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>AP uitzetten</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>AP uitzetten</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>DC ingang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>DC ingang</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Voor lithiumaccu's wordt een lading van minder dan 10% afgeraden. Raadpleeg voor andere accutypen het gegevensblad voor het minimumniveau dat door de fabrikant wordt aanbevolen.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Voor lithiumaccu&apos;s wordt een lading van minder dan 10% afgeraden. Raadpleeg voor andere accutypen het gegevensblad voor het minimumniveau dat door de fabrikant wordt aanbevolen.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Autostart uitschakelen?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Autostart uitschakelen?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Omvormer/lader (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Omvormer/lader (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>CPU-gebruik weergeven</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>CPU-gebruik weergeven</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Toepassing beëindigen</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Toepassing beëindigen</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Stoppen met</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Stoppen met</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Applicatie versie</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Applicatie versie</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Olietemperatuur</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Olietemperatuur</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Let op dat het wijzigen van de instelling voor de Tijd tot ontladingsvloer ook de instelling voor de Lage laadstatus in het relaismenu verandert.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Let op dat het wijzigen van de instelling voor de Tijd tot ontladingsvloer ook de instelling voor de Lage laadstatus in het relaismenu verandert.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Bedrijfstijd</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Bedrijfstijd</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Ah opgeladen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Ah opgeladen</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Cycli begonnen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Cycli begonnen</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Cycli voltooid</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Cycli voltooid</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Aantal inschakelingen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Aantal inschakelingen</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Aantal diepe ontladingen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Aantal diepe ontladingen</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Geschiedenis laadcyclus</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Geschiedenis laadcyclus</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Sensor waarde als vol</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Sensor waarde als vol</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Tijd tot onderhoud</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Tijd tot onderhoud</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Autostart-functionaliteit</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Autostart-functionaliteit</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Zorg ervoor dat het aggregaat niet is aangesloten op AC-ingang %1 als deze optie gebruikt wordt.</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Zorg ervoor dat het aggregaat niet is aangesloten op AC-ingang %1 als deze optie gebruikt wordt.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>De servicetimer is teruggezet</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>De servicetimer is teruggezet</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Continu zoeken kan de WiFi functie verstoren.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Continu zoeken kan de WiFi functie verstoren.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Minimaal en maximaal meterbereik</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Minimaal en maximaal meterbereik</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Startpagina</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Applicatie opnieuw starten...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Applicatie opnieuw starten...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Niet gelukt om taal te wijzigen!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Niet gelukt om taal te wijzigen!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Nooit</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Even geduld terwijl de taal wordt gewijzigd.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Even geduld terwijl de taal wordt gewijzigd.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Kort overzicht eenheid</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Kort overzicht eenheid</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Geen labels</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Geen labels</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Tankvolumes tonen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Tankvolumes tonen</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Percentages tonen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Percentages tonen</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Opmerking: Als stroom niet kan worden weergegeven (bijvoorbeeld bij een totaal voor gecombineerde AC- en DC-bronnen), dan wordt in plaats daarvan vermogen weergegeven.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Opmerking: Als stroom niet kan worden weergegeven (bijvoorbeeld bij een totaal voor gecombineerde AC- en DC-bronnen), dan wordt in plaats daarvan vermogen weergegeven.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Laadstroomlimieten</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Laadstroomlimieten</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Officiële release</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Officiële release</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Bèta versie</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Bèta versie</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Testen (Victron intern)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Testen (Victron intern)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Ontwikkelen (Victron intern)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Ontwikkelen (Victron intern)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Opnieuw opstarten...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Opnieuw opstarten...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Status LED's inschakelen</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Status LED&apos;s inschakelen</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Opwarmen en afkoelen</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Opwarmen en afkoelen</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Aggregaat stoptijd</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Aggregaat stoptijd</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarm als aggregaat niet in autostartmodus staat</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarm als aggregaat niet in autostartmodus staat</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Er gaat een alarm af als de autostartfunctie meer dan 10 minuten uitgeschakeld blijft.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Er gaat een alarm af als de autostartfunctie meer dan 10 minuten uitgeschakeld blijft.</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Zelfontlading van accu</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Zelfontlading van accu</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Alle systeembelastingen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Alle systeembelastingen</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Alleen kritieke belastingen</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Alleen kritieke belastingen</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Minimale laadtoestand (tenzij net uitvalt)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Levensduur accu</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Levensduur accu</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Toegang tot Signaal K op http://venus.local:3000 en via VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Toegang tot Signaal K op http://venus.local:3000 en via VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Toegang tot Node-RED op https://venus.local:1881 en via VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Toegang tot Node-RED op https://venus.local:1881 en via VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Accumetingen</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Accumetingen</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Systeemstatus</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Systeemstatus</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Apparaten lijst</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Apparaten lijst</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>VRM apparaatinstanties</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>VRM apparaatinstanties</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Alarm hoge temperatuur</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Alarm hoge temperatuur</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>BMS gestuurd</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>BMS gestuurd</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarmen en fouten</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarmen en fouten</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Voor deze functie is firmwareversie 400 of hoger vereist. Neem contact op met de installateur om de Multi/Quattro bij te werken.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Voor deze functie is firmwareversie 400 of hoger vereist. Neem contact op met de installateur om de Multi/Quattro bij te werken.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Lader niet gereed, egalisatie kan niet worden gestart</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Lader niet gereed, egalisatie kan niet worden gestart</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Egalisatie kan niet worden geactiveerd tijdens bulklaadstatus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Egalisatie kan niet worden geactiveerd tijdens bulklaadstatus</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Maximale stroom</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Maximale stroom</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Maximaal vermogen</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Maximaal vermogen</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Minimale stroom</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Minimale stroom</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Geen</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Niet beschikbaar</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Uit</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Complete geschiedenis</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Complete geschiedenis</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Instellingen</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Onbekend</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Opbrengst vandaag</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Opbrengst vandaag</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware geïnstalleerd, apparaat start opnieuw op</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware geïnstalleerd, apparaat start opnieuw op</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Aanraakscherm besturing</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Aanraakscherm besturing</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Testfout vastgesmolten contacten (kortgesloten)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Testfout vastgesmolten contacten (kortgesloten)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Overschakelen naar 3 fasen</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Overschakelen naar 3 fasen</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Overschakelen naar 1 fase</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Overschakelen naar 1 fase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Stop met opladen</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Stop met opladen</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Gereserveerd</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Gereserveerd</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Omvormermodus</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Omvormermodus</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC OUT L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC OUT L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Ingang</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Ingang</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Doorvoer</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Doorvoer</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>De pagina wordt na tien seconden automatisch herladen om de nieuwste versie te laden.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>De pagina wordt na tien seconden automatisch herladen om de nieuwste versie te laden.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Omvormer (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Omvormer (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Omvormer/Acculaders</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Omvormer/Acculaders</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Geen energiemeters gevonden
+        <translation>Geen energiemeters gevonden
 
 Let op: dit menu toont alleen Carlo Gavazzi meters die zijn aangesloten via RS485. Voor elke andere meter, inclusief Carlo Gavazzi meters die via ethernet zijn aangesloten, raadpleeg het menu Modbus TCP/UDP apparaten.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Automatisch bereik</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Automatisch bereik</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Indien ingeschakeld, worden de minima en maxima van meters en grafieken automatisch aangepast op basis van waarden uit het verleden.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Indien ingeschakeld, worden de minima en maxima van meters en grafieken automatisch aangepast op basis van waarden uit het verleden.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Alle bereikwaarden op nul zetten</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Alle bereikwaarden op nul zetten</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Bereikwaarden resetten</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Bereikwaarden resetten</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Weet je zeker dat je alle waarden op nul wilt zetten?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Weet je zeker dat je alle waarden op nul wilt zetten?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Maximale stroom: AC IN 1 aangesloten</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Maximale stroom: AC IN 1 aangesloten</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Maximale stroom: AC IN 2 aangesloten</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Maximale stroom: AC IN 2 aangesloten</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Maximale stroom: geen AC-ingangen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Maximale stroom: geen AC-ingangen</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>DC-uitgang</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>DC-uitgang</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Zon</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Zon</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>TPM motor</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>TPM motor</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Temperatuur motor</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Temperatuur motor</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Temperatuur besturing</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Temperatuur besturing</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Actieve cyclus</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Actieve cyclus</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Cyclus %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Cyclus %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>DC niet verbonden</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>DC niet verbonden</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Uitgeschakeld</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Uitgeschakeld</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Functie wijzigen</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Functie wijzigen</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Firmware update</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Firmware update</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Software resetten</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Software resetten</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Onvolledig</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Onvolledig</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Verstreken tijd</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Verstreken tijd</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Opladen/onderhouden (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Opladen/onderhouden (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Accu (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;einde&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Accu (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;einde&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Lage AC OUT spanning</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Lage AC OUT spanning</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Hoge AC OUT spanning</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Hoge AC OUT spanning</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Totaal opbrengst</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Totaal opbrengst</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Systeem opbrengst</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Systeem opbrengst</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Dagelijkse geschiedenis</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Dagelijkse geschiedenis</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Geen alarmen om in te stellen</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Geen alarmen om in te stellen</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Maximale PV spanning</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Maximale PV spanning</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Maximale accuspannning</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Maximale accuspannning</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Minimale accuspanning</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Minimale accuspanning</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Fout accubank</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Fout accubank</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Accuspanning niet ondersteund</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Accuspanning niet ondersteund</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Onjuist aantal accu's</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Onjuist aantal accu&apos;s</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Ongeldige accu configuratie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Ongeldige accu configuratie</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Balancer status</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Balancer status</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Gebalanceerd</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Gebalanceerd</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Onbalans</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Onbalans</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Gebruik deze optie bij systemen die geen piek afvlakking doen.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Gebruik deze optie bij systemen die geen piek afvlakking doen.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Gebruik deze optie voor piekafvlakken.</translation>
+        <translation>Gebruik deze optie voor piekafvlakken.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>De drempel voor piekafvlakken wordt ingesteld met de instelling voor de AC ingangsstroomlimiet. Zie documentatie voor meer informatie.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>De drempel voor piekafvlakken wordt ingesteld met de instelling voor de AC ingangsstroomlimiet. Zie documentatie voor meer informatie.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>De piekdrempels voor importeren en exporteren kunnen op dit scherm worden gewijzigd. Zie de documentatie voor meer informatie.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>De piekdrempels voor importeren en exporteren kunnen op dit scherm worden gewijzigd. Zie de documentatie voor meer informatie.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Systeem AC invoerstroom beperken</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Systeem AC invoerstroom beperken</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Om deze functie te gebruiken, moet net metingen ingesteld zijn op Externe meter en moet er een bijgewerkte ESS assistant geïnstalleerd zijn.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Om deze functie te gebruiken, moet net metingen ingesteld zijn op Externe meter en moet er een bijgewerkte ESS assistant geïnstalleerd zijn.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Maximale systeeminvoerstroom (per fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Maximale systeeminvoerstroom (per fase)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Netmeting moet zijn ingesteld op Externe meter om deze functie te kunnen gebruiken.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Netmeting moet zijn ingesteld op Externe meter om deze functie te kunnen gebruiken.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Maximale systeemexportstroom (per fase)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Maximale systeemexportstroom (per fase)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Bedraad</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Bedraad</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Kort</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Hoge systeembelasting, sluit het zijpaneel om CPU belasting te verminderen</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Hoge systeembelasting, sluit het zijpaneel om CPU belasting te verminderen</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Ingangsstroomlimiet</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Ingangsstroomlimiet</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Kortsluiting</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Kortsluiting</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Kopen</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Kopen</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Verkopen</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Verkopen</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Doel laadtoestand</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Doel laadtoestand</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC uit %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC uit %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Trackers</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Trackers</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>RS apparaten</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>RS apparaten</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Elektronanimaties pauzeren</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Elektronanimaties pauzeren</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Totale capaciteit</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Totale capaciteit</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Aantal BMS-en</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Aantal BMS-en</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>AC terugleverstroom van systeem beperken</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>AC terugleverstroom van systeem beperken</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Modbus TCP/UDP-apparaten</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Modbus TCP/UDP-apparaten</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Apparaat toevoegen</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Apparaat toevoegen</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Zoek apparaten</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Zoek apparaten</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Opgeslagen apparaten</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Opgeslagen apparaten</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Ontdekte apparaten</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Ontdekte apparaten</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Modbus TCP/UDP-apparaat toevoegen</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Modbus TCP/UDP-apparaat toevoegen</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protocol</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protocol</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Poort</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Poort</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Eenheid</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Eenheid</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Geen Modbus apparaten opgeslagen</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Geen Modbus apparaten opgeslagen</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Apparaat %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Apparaat %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Modbus apparaat verwijderen?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Modbus apparaat verwijderen?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Geen Modbus apparaten gevonden</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Geen Modbus apparaten gevonden</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Accu %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Accu %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation> AC stroom</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation> AC stroom</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Aggregaat start/stop uitgeschakeld</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Aggregaat start/stop uitgeschakeld</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>De afstandsstartfunctie is uitgeschakeld op het aggregaat. De GX kan het aggregaat nu niet starten of stoppen. Schakel deze functie in op het bedieningspaneel van het aggregaat.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>De afstandsstartfunctie is uitgeschakeld op het aggregaat. De GX kan het aggregaat nu niet starten of stoppen. Schakel deze functie in op het bedieningspaneel van het aggregaat.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Automatische startfunctie</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Automatische startfunctie</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Huidige looptijd</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Besturingsstatus</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Besturingsstatus</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Aggregaat status</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Aggregaat status</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Modus starten op afstand</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Modus starten op afstand</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Oliedruk</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Oliedruk</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Geplande laad niveau's</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Geplande laad niveau&apos;s</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Actief (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Actief (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Handmatig stoppen</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Handmatig stoppen</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Open circuit</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Open circuit</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>
 %1 (niet beschikbaar)
 </translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Aanraakscherm aan</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Aanraakscherm aan</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Aanraakscherm uit</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Aanraakscherm uit</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Aanraakscherm uitgeschakeld</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Aanraakscherm uitgeschakeld</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Waarschuwingen bevestigen</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Waarschuwingen bevestigen</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Foutcode besturing</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Foutcode besturing</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Gebruik dit menu om de accugegevens te definiëren die worden weergegeven als er op het pictogram Accu wordt geklikt op de pagina Overzicht. Dezelfde selectie is ook zichtbaar op het VRM Portal.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Gebruik dit menu om de accugegevens te definiëren die worden weergegeven als er op het pictogram Accu wordt geklikt op de pagina Overzicht. Dezelfde selectie is ook zichtbaar op het VRM Portal.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Systeemspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Systeemspanning</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Verbindingsinformatie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Verbindingsinformatie</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Selecteer...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Selecteer...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Beveiligd</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Beveiligd</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Wachtwoordbeveiliging en netwerkcommunicatie is versleuteld</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Wachtwoordbeveiliging en netwerkcommunicatie is versleuteld</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Zwak</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Zwak</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Wachtwoordbeveiliging, maar de netwerkcommunicatie is niet versleuteld</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Wachtwoordbeveiliging, maar de netwerkcommunicatie is niet versleuteld</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Niet beveiligd</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Niet beveiligd</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Geen wachtwoord en de netwerkcommunicatie is niet versleuteld</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Geen wachtwoord en de netwerkcommunicatie is niet versleuteld</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Wachtwoord moet minstens 8 tekens lang zijn</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Geef wachtwoord</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Wachtwoord moet minstens 8 tekens lang zijn</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Wachtwoord moet minstens 8 tekens lang zijn</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Profiel 'Beveiligd' selecteren?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Profiel &apos;Beveiligd&apos; selecteren?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Selecteer 'Zwak' profiel?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Selecteer &apos;Zwak&apos; profiel?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Selecteer 'Niet beveiligd' profiel?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Selecteer &apos;Niet beveiligd&apos; profiel?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Lokale netwerkdiensten zijn beveiligd met een wachtwoord
+        <translation>- Lokale netwerkdiensten zijn beveiligd met een wachtwoord
 - De netwerkcommunicatie is versleuteld
 - Er is een beveiligde verbinding met VRM
 - Onveilige instellingen kunnen niet worden ingeschakeld</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokale netwerkdiensten zijn beveiligd met een wachtwoord
+        <translation>- Lokale netwerkdiensten zijn beveiligd met een wachtwoord
 - Onversleutelde toegang tot lokale websites is ook ingeschakeld (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokale netwerkdiensten hebben geen wachtwoord nodig
+        <translation>- Lokale netwerkdiensten hebben geen wachtwoord nodig
 - Onversleutelde toegang tot lokale websites is ook ingeschakeld (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Wachtwoord root</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Wachtwoord root</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Uitloggen</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Uitloggen</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Nu uitloggen</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Nu uitloggen</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Uitloggen?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Uitloggen?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Hierdoor worden alle lokale netwerkverbindingen verbroken.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Hierdoor worden alle lokale netwerkverbindingen verbroken.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Uitloggen</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Uitloggen</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Alleen-lezen</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Alleen-lezen</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Volledig</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Volledig</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Weet je het zeker?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Weet je het zeker?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Als je deze instelling wijzigt naar Alleen-lezen of Uit, word je geblokkeerd.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Als je deze instelling wijzigt naar Alleen-lezen of Uit, word je geblokkeerd.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>MQTT toegang</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>MQTT toegang</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' is geen getal.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; is geen getal.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Bevestigen</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Bevestigen</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Gebruik een getal met %1 cijfers of minder.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Gebruik een getal met %1 cijfers of minder.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' is geen geldig IP-adres.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; is geen geldig IP-adres.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' is geen geldig poortnummer. Gebruik een getal tussen 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; is geen geldig poortnummer. Gebruik een getal tussen 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 is geen geldig eenheidsnummer. Gebruik een getal tussen 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 is geen geldig eenheidsnummer. Gebruik een getal tussen 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Huidige looptijd</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Huidige looptijd</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Foutcodes aggregaat</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Foutcodes aggregaat</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Koellichaamtemperatuur</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Koellichaamtemperatuur</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Laadspanning</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>De laadspanning wordt momenteel geregeld door het BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>De laadspanning wordt momenteel geregeld door het BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Laadstroom limiet</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Laadstroom limiet</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>BMS gestuurd</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>BMS gestuurd</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation> BMS besturing wordt automatisch ingeschakeld als er een  BMS aanwezig is. Reset het als de systeemconfiguratie wijzigde of als er geen BMS aanwezig is.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation> BMS besturing wordt automatisch ingeschakeld als er een  BMS aanwezig is. Reset het als de systeemconfiguratie wijzigde of als er geen BMS aanwezig is.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Servicetimer uitgeschakeld.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Servicetimer uitgeschakeld.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>VRM Portal</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>VRM Portal</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (VPN-toegang op afstand)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (VPN-toegang op afstand)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>Laadtoestand %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>Laadtoestand %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Er moet een beveiligingsprofiel worden ingesteld voordat de netwerkdiensten kunnen worden ingeschakeld, zie Instellingen - Algemeen</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Er moet een beveiligingsprofiel worden ingesteld voordat de netwerkdiensten kunnen worden ingeschakeld, zie Instellingen - Algemeen</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' is vervangen door '%2' omdat het ongeldige tekens bevatte.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; is vervangen door &apos;%2&apos; omdat het ongeldige tekens bevatte.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Initialiseren...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Initialiseren...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Backend opstarten...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Backend opstarten...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend gestopt.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend gestopt.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Verbinding mislukt.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Verbinding mislukt.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Dit GX-apparaat is afgemeld bij Tailscale.
+        <translation>Dit GX-apparaat is afgemeld bij Tailscale.
 
 Wacht even of controleer de internetverbinding.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Wachten op een reactie van Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Wachten op een reactie van Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Verbind dit GX apparaat met de Tailscale gebruiker door deze link te openen:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Verbind dit GX apparaat met de Tailscale gebruiker door deze link te openen:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Wacht even of controleer de internetverbinding.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Wacht even of controleer de internetverbinding.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Onbekende status: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Onbekende status: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Fout: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Fout: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>WiFi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>WiFi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Schakel Tailscale uit om deze instellingen te bewerken.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Schakel Tailscale uit om deze instellingen te bewerken.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Tailscale inschakelen</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Tailscale inschakelen</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Naam machine</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Naam machine</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Afmelden Tailscale gebruiker</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Afmelden Tailscale gebruiker</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Toegang tot lokaal netwerk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Toegang tot lokaal netwerk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Toegang tot lokaal ethernetnetwerk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Toegang tot lokaal ethernetnetwerk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Toegang tot lokaal WiFi netwerk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Toegang tot lokaal WiFi netwerk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Aangepast(e) netwerk(en)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Aangepast(e) netwerk(en)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Voorbeeld: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Voorbeeld: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>er Uitleg:
+        <translation>er Uitleg:
 
 Deze functie, die door Tailscale subnet routes wordt genoemd, maakt het mogelijk om op afstand toegang te krijgen tot andere apparaten in het (de) lokale netwerk(en).
 
-Het veld Aangepaste netwerken accepteert een door komma's gescheiden lijst met subnetten in de CIDR-notatie.
+Het veld Aangepaste netwerken accepteert een door komma&apos;s gescheiden lijst met subnetten in de CIDR-notatie.
 
 Nadat er een nieuw netwerk is toegevoegd/ingeschakeld, moet het eenmalig goedgekeurd worden in de Tailscale beheerconsole.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Aangepaste "tailscale up" argumenten</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Aangepaste &quot;tailscale up&quot; argumenten</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Aangepaste server-URL (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Aangepaste server-URL (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Deze aggregaat besturing heeft een hulprelais nodig om aangestuurd te worden, maar het hulprelais is niet ingesteld. Stel relais 1 in onder Instellingen → Relais naar "Aangesloten aggregaat hulprelais".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Deze aggregaat besturing heeft een hulprelais nodig om aangestuurd te worden, maar het hulprelais is niet ingesteld. Stel relais 1 in onder Instellingen → Relais naar &quot;Aangesloten aggregaat hulprelais&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarm bij hoge startaccuspanning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarm bij hoge startaccuspanning</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Opwarmen van aggregaat overslaan</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Opwarmen van aggregaat overslaan</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>In bedrijf, maar geen diensten (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>In bedrijf, maar geen diensten (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Rootwachtwoord gewijzigd in %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Rootwachtwoord gewijzigd in %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Aangesloten hulprelais aggregaat</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Aangesloten hulprelais aggregaat</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Positie van AC-belastingen</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Positie van AC-belastingen</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>AC-ingang &amp; uitgang</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>AC-ingang &amp; uitgang</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Gebruik deze optie als er AC-belastingen aanwezig zijn op de ingang van de omvormer/lader. Gebruik deze optie als je het niet zeker weet.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Gebruik deze optie als er AC-belastingen aanwezig zijn op de ingang van de omvormer/lader. Gebruik deze optie als je het niet zeker weet.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Alleen AC-uitgang</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Alleen AC-uitgang</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Gebruik deze optie als het systeem een netmeter gebruikt, maar alle AC-belastingen op de uitgang van de omvormer/lader staan.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Gebruik deze optie als het systeem een netmeter gebruikt, maar alle AC-belastingen op de uitgang van de omvormer/lader staan.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Maandelijks</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Maandelijks</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>EV Charger</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>EV Charger</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Warmtepomp</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Warmtepomp</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Essentiële belastingen</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Essentiële belastingen</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>De generator starten en stoppen op basis van de geconfigureerde autostartvoorwaarden.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>De generator starten en stoppen op basis van de geconfigureerde autostartvoorwaarden.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Instellingen DC aggregaat</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Instellingen DC aggregaat</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Temperatuur dynamo</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Temperatuur dynamo</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Temperatuur motor</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Temperatuur motor</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Totale bedrijfstijd</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Totale bedrijfstijd</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Netwerkbeveiligingsprofiel</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Netwerkbeveiligingsprofiel</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Laatste %1 dagen</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Laatste %1 dagen</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>AggregaatGenerator zal stoppen over %1 tenzij autostart condities zijn ingeschakeld die het draaiende houden.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>AggregaatGenerator zal stoppen over %1 tenzij autostart condities zijn ingeschakeld die het draaiende houden.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Het aggregaat draait totdat het handmatig wordt gestopt, tenzij er automatische opstartcondities zijn ingeschakeld die het aggregaat aan de gang houden.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Het aggregaat draait totdat het handmatig wordt gestopt, tenzij er automatische opstartcondities zijn ingeschakeld die het aggregaat aan de gang houden.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Klassieke UI</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Klassieke UI</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Nieuwe UI</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Nieuwe UI</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Taal succesvol gewijzigd!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Vermogensbegrenzing</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Taal succesvol gewijzigd!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Voor Multi-RS en HS19-apparaten zijn de ESS-instellingen beschikbaar op de productpagina van het RS-systeem.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Voor Multi-RS en HS19-apparaten zijn de ESS-instellingen beschikbaar op de productpagina van het RS-systeem.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Start/stop aggregaat</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Start/stop aggregaat</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>De firmwareversie kan niet worden gewijzigd als "Netwerkbeveiligingsprofiel" in "Instellingen / Algemeen" niet is geselecteerd.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>De firmwareversie kan niet worden gewijzigd als &quot;Netwerkbeveiligingsprofiel&quot; in &quot;Instellingen / Algemeen&quot; niet is geselecteerd.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Duur</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Duur</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Systeemalarmen</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Systeemalarmen</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Geen systeemalarmen</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Geen systeemalarmen</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Terug</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Terug</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Wat is er nieuw</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Wat is er nieuw</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>Overslaan</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>Overslaan</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Welkom!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Welkom!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>We zijn verheugd om een volledig opnieuw ontworpen interface te introduceren die zowel de gebruiksvriendelijkheid als de esthetiek van de GX verbetert.
+        <translation>We zijn verheugd om een volledig opnieuw ontworpen interface te introduceren die zowel de gebruiksvriendelijkheid als de esthetiek van de GX verbetert.
 
 Met een gestroomlijnde navigatie en een frisse look is alles waar je van houdt nu nog gemakkelijker toegankelijk en visueel aantrekkelijker.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Donker - lichte modus</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Donker - lichte modus</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Verschillende omgevingen vragen om verschillende scherminstellingen. De donker- en lichtmodi zorgen voor de beste kijkervaring, waar je ook bent.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Verschillende omgevingen vragen om verschillende scherminstellingen. De donker- en lichtmodi zorgen voor de beste kijkervaring, waar je ook bent.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Alle belangrijke informatie die je nodig hebt, gepresenteerd in een schone en eenvoudige lay-out. Het middelpunt is een aanpasbare widget met ringen, waardoor je in één oogopslag snel toegang hebt tot je systeeminzichten.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Alle belangrijke informatie die je nodig hebt, gepresenteerd in een schone en eenvoudige lay-out. Het middelpunt is een aanpasbare widget met ringen, waardoor je in één oogopslag snel toegang hebt tot je systeeminzichten.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Krijg meer controle met ons bijgewerkte overzichtspaneel, met realtime systeemgegevens - alles op één plek voor eenvoudige bewaking.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Krijg meer controle met ons bijgewerkte overzichtspaneel, met realtime systeemgegevens - alles op één plek voor eenvoudige bewaking.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Besturingen</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Besturingen</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Alle dagelijkse besturingselementen zijn nu samengevoegd in het nieuwe deelvenster Besturingselementen. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Alle dagelijkse besturingselementen zijn nu samengevoegd in het nieuwe deelvenster Besturingselementen. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watts en ampères</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watts en ampères</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Er kan nu gekozen worden tussen Watts en Ampères. Kies de eenheid die het beste bij je voorkeur past.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Er kan nu gekozen worden tussen Watts en Ampères. Kies de eenheid die het beste bij je voorkeur past.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Lees meer</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Lees meer</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Ga naar de onderstaande link voor meer informatie over de vernieuwde UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Ga naar de onderstaande link voor meer informatie over de vernieuwde UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Scan de QR-code voor meer informatie over de Renewed UI.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Scan de QR-code voor meer informatie over de Renewed UI.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Klaar</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Klaar</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Volgende</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Volgende</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Fout: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Fout: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Actieve fout</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Actieve fout</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Totale looptijd aggregaat (uur)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Totale looptijd aggregaat (uur)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Startpagina</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Startpagina</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Gebruikersinterface</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Gebruikersinterface</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Gebruikersinterface (Console op afstand)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Gebruikersinterface (Console op afstand)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 bijgewerkt</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 bijgewerkt</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>De gebruikersinterface schakelt over naar %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>De gebruikersinterface schakelt over naar %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 is ingesteld op %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Deze PV-omvormer ondersteunt vermogensbegrenzing. Schakel deze instelling uit als deze de normale werking verstoort.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 is ingesteld op %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Druk op 'OK' om opnieuw op te starten</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Druk op &apos;OK&apos; om opnieuw op te starten</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Node-RED fabrieksreset</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Node-RED fabrieksreset</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Weet je zeker dat je Node-RED wilt resetten naar de fabrieksinstellingen? Hierdoor worden al je flows gewist.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Weet je zeker dat je Node-RED wilt resetten naar de fabrieksinstellingen? Hierdoor worden al je flows gewist.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Verbindingsstatus</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Verbindingsstatus</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Verbindingsstatus (HTTPS-kanaal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Verbindingsstatus (HTTPS-kanaal)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Verbindingsstatus (HTTP-kanaal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Verbindingsstatus (HTTP-kanaal)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Verbindingsstatus (MQTT Real-time kanaal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Verbindingsstatus (MQTT Real-time kanaal)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Verbindingsstatus (MQTT RPC-kanaal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Verbindingsstatus (MQTT RPC-kanaal)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Automatisch gestart - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Automatisch gestart - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Uitschakel waarde</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Uitschakel waarde</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Niet actief</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Niet actief</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Verlies van communicatie</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Verlies van communicatie</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>Laadtoestand voorwaarde</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>Laadtoestand voorwaarde</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>AC belastingsconditie</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>AC belastingsconditie</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Huidige accu conditie</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Huidige accu conditie</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Accu spanning</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Accu spanning</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Omvormer overbelast</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Omvormer overbelast</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Laden/ontladen uitgeschakeld</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Laden/ontladen uitgeschakeld</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Lading uitgeschakeld</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Lading uitgeschakeld</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Ontlading uitgeschakeld</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Ontlading uitgeschakeld</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Kort</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Brief (zijpaneel open)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Brief (zijpaneel open)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Overzicht</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Niveaus (Tanks)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Niveaus (Tanks)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Niveaus (Omgeving)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Niveaus (Omgeving)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Accu lijst</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Accu lijst</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>GX-apparaat is bijgewerkt</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>GX-apparaat is bijgewerkt</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Na %n minuut</numerusform>
-        <numerusform>Na %n minuten</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Na %n minuut</numerusform>
+            <numerusform>Na %n minuten</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Ga naar deze pagina wanneer de toepassing start.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Ga naar deze pagina wanneer de toepassing start.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Time-out</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Time-out</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Terugkeren naar de startpagina wanneer de toepassing inactief is.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Terugkeren naar de startpagina wanneer de toepassing inactief is.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Na één minuut inactiviteit wordt de huidige pagina als startpagina geselecteerd, als deze in deze lijst staat.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Na één minuut inactiviteit wordt de huidige pagina als startpagina geselecteerd, als deze in deze lijst staat.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Deze stroomgrens ligt vast in de systeemconfiguratie. Hij kan niet worden aangepast.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Deze stroomgrens ligt vast in de systeemconfiguratie. Hij kan niet worden aangepast.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>De modus staat vast in de systeemconfiguratie. Deze kan niet worden aangepast.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>De modus staat vast in de systeemconfiguratie. Deze kan niet worden aangepast.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Generator start/stop-functie is niet ingeschakeld, ga naar relaisinstellingen en stel functie in op "Genset start/stop".</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Standaardtijd Marokko</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Standaardtijd West-Centraal-Afrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Standaardtijd Zuid-Afrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Standaardtijd Namibië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Standaardtijd Egypte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standaardtijd Oost-Afrika</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Standaardtijd Argentinië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Amerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Standaardtijd Groenland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Standaardtijd Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Standaardtijd Newfoundland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Amerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantische standaardtijd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Standaardtijd Centraal-Brazilië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standaardtijd Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Standaardttijd Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standaardtijd SA Western</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Standaardtijd Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Standaardtijd Eastern</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Standaardtijd SA Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Standaardtijd US Eastern</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Standaardtijd Centraal-Canada</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Standaardtijd Centraal-Amerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Standaardtijd Centraal-Mexico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Standaardtijd Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Standaardtijd Mountain (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Standaardtijd Mountain</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Standaardtijd US Mountain</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Standaardtijd Pacific (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Standaardtijd Stille Oceaan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Standaardtijd Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Standaardtijd Hawaii-Aleutian</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standaardtijd Nieuw-Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standaardtijd Central Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standaardtijd West Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standaardtijd West-Australië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standaardtijd Centraal-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standaardtijd West-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standaardtijd Oost-Afrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standaardtijd Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standaardtijd SA Western</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standaardtijd West Europa</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Standaardtijd Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Standaardtijd Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Standaardtijd Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Standaardtijd Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Standaardtijd Tokio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Standaardtijd Korea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Standaardtijd Singapur</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Standaardtijd Ulaanbaatar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Standaardtijd Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Standaardtijd Noordoost-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Standaardtijd China</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Standaardtijd Noord-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Standaardtijd Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Standaardtijd Noord-Centraal-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standaardtijd Centraal-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Standaardtijd Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Standaardtijd Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Standaardtijd Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Standaardtijd India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standaardtijd West-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Standaardtijd Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Standaardtijd Jekaterinaburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Standaardtijd Georgië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Standaardtijd Kaukasus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Standaardtijd Azerbeidzjan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Standaardtijd Arabië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Standaardtijd Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Standaardtijd Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Standaardtijd Arabië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Standaardtijd Arabië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Standaardtijd Syrië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Standaardtijd Midden-Oosten</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Standaardtijd Jordanië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Standaardtijd Israël</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Standaardtijd Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Standaardtijd Azoren</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Standaardtijd Kaapverdië</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Standaardtijd Tasmanië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Standaardtijd Oost-Australië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Standaardtijd AUS Oost</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Standaardtijd Centraal-Australië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Standaardtijd AUS Centraal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standaardtijd West-Australië</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT </translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Standaardtijd Midden Atalantisch</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Datumgrens standaardtijd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Standaardtijd GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Standaardtijd Centraal-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Standaardtijd Midden-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Standaardtijd Midden-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standaardtijd West-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Standaardtijd Oost-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Standaardtijd FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Standaardtijd GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Standaardtijd Wit-Rusland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Standaardtijd Rusland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Standaardtijd Turkije</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Standaardtijd Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Standaardtijd Christmas Island</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Standaardtijd Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Standaardtijd Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standaardtijd Nieuw-Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standaardtijd Central Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standaardtijd West Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Standaardtijd Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Standaardtijd Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Standaardtijd Paaseiland</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Generator start/stop-functie is niet ingeschakeld, ga naar relaisinstellingen en stel functie in op &quot;Genset start/stop&quot;.</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Onbekend</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Zon opbrengst</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">DC ingang</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC Belastingen</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">DC Belastingen</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overzicht</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">Zonnepaneel</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Totaal opbrengst</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Systeem opbrengst</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Alleen alarm</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarmen en meldingen</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Waarschuwing</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Geen fout</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Geen fout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Onbekende fout: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Onbekende fout: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Geen fout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Geen fout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Accu initialisatiefout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Accu initialisatiefout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Geen accu's aangesloten</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Geen accu&apos;s aangesloten</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Onbekende accu</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Onbekende accu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Verschillende accutypes</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Verschillende accutypes</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Verkeerd aant. accu's</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Verkeerd aant. accu&apos;s</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt niet gevonden</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt niet gevonden</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Accu meetfout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Accu meetfout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Interne berekeningsfout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Interne berekeningsfout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Verkeerd aantal accu's in serie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Verkeerd aantal accu&apos;s in serie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Hardware fout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Hardware fout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Watchdog fout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Watchdog fout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Te hoge spanning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Te hoge spanning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Te lage spanning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Te lage spanning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Te hoge temperatuur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Te hoge temperatuur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Te lage temperatuur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Te lage temperatuur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Onder lading stand-by</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Onder lading stand-by</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>ADC storing</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>ADC storing</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Accu communicatiefout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Accu communicatiefout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Voorlaad storing</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Voorlaad storing</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Storing veiligheidsmagneetschakelaar</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Storing veiligheidsmagneetschakelaar</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Fout bijwerken accu</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Fout bijwerken accu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>BMS kabel fout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>BMS kabel fout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Referentiespanning fout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Referentiespanning fout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Verkeerde systeem spanning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Verkeerde systeem spanning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Time-out voorladen</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Time-out voorladen</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>ATC/ATD fout</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>ATC/ATD fout</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibratiedata verloren</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibratiedata verloren</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Instellingen ongeldig</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Instellingen ongeldig</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Interlock</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Interlock</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Noodstop</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Noodstop</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Time-out communicatie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Time-out communicatie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Veiligheidsslot</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Veiligheidsslot</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Terminal te hoge temperatuur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Terminal te hoge temperatuur</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Geen fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Temperatuur accu hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Spanning accu hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Tsensor accu verkeerd aangesloten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Tsensor accu ontbreekt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Sp.sensor accu verkeerd aangesloten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Sp.sensor accu ontbreekt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Draadverliezen accu hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Spanning accu laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Hoge DC rimpel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Lage laadtoestand accu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Accu middelpunt spannings probleem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Accu tempetatuur te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Hoge temperatuur acculader</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Te hoge laadstroom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Negatieve laadstroom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Bulktijd acculader verstreken</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Sensorstoring laadstroom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Interne Tsensor verkeerd aangesloten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Interne Tsensor ontbreekt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Ventilator acculader niet gedetecteerd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Te hoge stroom ventilator acculader</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Oververhitting aansluiting acculader</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Kortsluiting lader</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Lader vermogenstrap fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Bescherming tegen te veel laden</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Ingang hoge spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Ingang te hoge stroom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Ingang te hoog vermogen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Ingang verkeerde polariteit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Geen ingangsspanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Ingang uitschakeling (niet opnieuw proberen)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Ingang uitschakeling (opnieuw proberen)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Input interne fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>PV isolatie fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Aarding fout gedetecteerd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Overbelasting omvormer</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Omvormer te hoge temp</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Omvormer piekstroom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Omvormer intern DC niveau</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation> Omvormer foutief AC OUT niveau</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Omvormer vermogenstrap fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Omvormer verbonden met AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>ACIN1 relais test fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>ACIN2 relais test fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Apparaat verdwenen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Incompatibel apparaat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>BMS-verbinding verbroken</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Netwerk foutief ingesteld</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Faserotatie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Meerdere AC ingangen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Faseoverbelasting</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Schrijffout geheugen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>CPU temperatuur te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Communicatie verbroken</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibratie gegevens verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Incompatibele firmware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Incompatibele hardware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Instellingen ongeldig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Referentiespanning fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Tester fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Geschiedenis ongeldig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>kWh tellers ongeldig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>DC spanning fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Aardlek sensor fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>3V3 voeding fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>5 V voeding fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>12 V voeding fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>15 V voeding fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>PV Ingang afgesloten</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Zet de schakelaar in een ontgrendelde positie om de instellingen te wijzigen.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Gebruik D Bus gegevensbron: maak verbinding met het opgegeven D Bus adres.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>Adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation> Gebruik D Bus gegevensbron: maak verbinding met het standaard D Bus adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Gebruik MQTT gegevensbron: maak verbinding met het opgegeven MQTT brokeradres.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>Adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>Portal ID van MQTT gegevensbronapparaat.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>Portal ID</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>MQTT VRM webhost shard</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>scherf</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation> Gebruikersnaam van MQTT gegevensbron</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Gebruiker</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Wachtwoord voor MQTT gegevensbron</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>Wachtwoord</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>MQTT gegevensbron token</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Token code</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation> Schakel FPS teller in</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Opstartscherm overslaan</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Gebruik een testgegevensbron om te testen.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Apparaat uitgeschakeld</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Gemengde oude/nieuwe MK2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Fout verwachte apparaten</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Geen ander apparaat gedetecteerd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Te hoge spanning op AC uit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Fout DDC programma</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS zonder assistent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Aardrelais test mislukt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Systeemtijd sync fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Elektriciteitsnetwerk relais test fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Configuratie verschil met 2de mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Apparaat verzend fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Wacht op configuratie of mist dongle</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Phase master ontbreekt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Er is te hoge spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Slaaf heeft geen AC ingang!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Apparaat kan geen slaaf zijn</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Systeembescherming begonnen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Firmware-incompatibiliteit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Interne fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Relais test mislukt, verbinden niet mogelijk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>VE.Bus fout</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Onbekende fout:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Interne fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Geen fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Temperatuur accu hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Spanning accu hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Spanning accu laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Accuspanning boven het ingestelde maximum</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Dynamo hoge temperatuur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Dynamo hoge draaisnelheid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>FET van veld aansturing hoge temperatuur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Vereiste sensor niet aanwezig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Dynamo lage spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Dynamo hoge spanning drempel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Dynamo spanning hoger dan het ingestelde maximum</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Hoge spanning dynamo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Accu losgekoppeld</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Accu losgekoppeld hoge spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Accu buiten bereik</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Te veel BMSen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Accu wordt bijna losgekoppeld</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Te veel apparatuur om te volgen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Accu losgekoppeld lage spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Accu losgekoppeld hoge stroom</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Acuu losgekoppeld hoge temperatuur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Accu losgekoppeld lage temperatuur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>BMS verbinding verbroken</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC uitgeschakeld</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>DC/DC converter niet gereed</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC hoge primaire spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC lage primaire spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC hoge secundaire spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC lage secundaire spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC hoge temperatuur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>DC/DC verkeerde instelling</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Temperatuursensor accu defect</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Onbekende fout:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Onbekende fout:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Geen fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Temperatuur accu hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Spanning accu hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Tsensor accu verkeerd aangesloten</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Tsensor accu ontbreekt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Sp.sensor accu verkeerd aangesloten</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Sp.sensor accu ontbreekt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Draadverliezen accu hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Spanning accu laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Hoge DC rimpel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Lage laadtoestand accu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Accu middelpunt spannings probleem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Accu tempetatuur te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Hoge temperatuur acculader</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Te hoge laadstroom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Negatieve laadstroom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Bulktijd acculader verstreken</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Sensorstoring laadstroom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Interne Tsensor verkeerd aangesloten</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Interne Tsensor ontbreekt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Ventilator acculader niet gedetecteerd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Te hoge stroom ventilator acculader</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Oververhitting aansluiting acculader</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Kortsluiting lader</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Lader vermogenstrap fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Bescherming tegen te veel laden</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Ingang hoge spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Ingang te hoge stroom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Ingang te hoog vermogen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Ingang verkeerde polariteit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Geen ingangsspanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Ingang uitschakeling (niet opnieuw proberen)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Ingang uitschakeling (opnieuw proberen)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Input interne fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>PV isolatie fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Aarding fout gedetecteerd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Overbelasting omvormer</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Omvormer te hoge temp</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Omvormer piekstroom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Omvormer intern DC niveau</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation> Omvormer foutief AC OUT niveau</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Omvormer vermogenstrap fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Omvormer verbonden met AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>ACIN1 relais test fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>ACIN2 relais test fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Apparaat verdwenen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Incompatibel apparaat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>BMS-verbinding verbroken</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Netwerk foutief ingesteld</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Faserotatie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Meerdere AC ingangen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Faseoverbelasting</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Schrijffout geheugen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>CPU temperatuur te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Communicatie verbroken</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibratie gegevens verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Incompatibele firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Incompatibele hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Instellingen ongeldig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Referentiespanning fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Tester fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Geschiedenis ongeldig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>kWh tellers ongeldig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>DC spanning fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Aardlek sensor fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>3V3 voeding fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>5 V voeding fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>12 V voeding fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>15 V voeding fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>PV Ingang afgesloten</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Onbekende fout:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Onbekende fout:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Onbekende fout:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Onbekende fout:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Geen fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>AC spanning L1 te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>AC spanning te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>AC spanning L1 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>AC spanning te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>AC frequentie L1 te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>AC frequentie te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>AC frequentie L1 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>AC frequentie te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC stroom L1 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>AC stroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>AC vermogen L1 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>AC vermogen te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Noodstop</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Servo stroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Oliedruk te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Oliedruk te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Motortemperatuur te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Motortemperatuur te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Temperatuur wikkeling te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Temperatuur wikkeling te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Temperatuur uitlaat te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Temperatuur uitlaat te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Elektronica temperatuur laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Elektronica temperatuur hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Startspanning te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Startstroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Gloedspanning te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Gloeistroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Koude-Start-Aid spanning te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Cold-Start-Aid stroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Spanning brandstofhoudmagneet te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Stroom brandstofhoudmagneet te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Spanning spoel stopmagneet te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Stop-magneetspoel stroom te hoog </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Stop-magneetspoel spanning te laag </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Stop-magneet trek spoel stroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Spanning ventilator/waterpomp te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Stroom ventilator/waterpomp te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Spanning stroomsensor laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Stroomsensor stroom hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Boost-uitgangsspanning te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Boost uitgangsstroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Voedingsspanning bus te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Voedingsstroom bus te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Startaccuspanning te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Startaccuspanning te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Rotatie te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Rotatie te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Onverwachte stop/probleem met brandstoftoevoer</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Spanning netmagneetschakelaar te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Stroom netmagneetschakelaar te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>AC spanning L2 te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>AC spanning L2 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>AC frequentie L2 te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>AC frequentie L2 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>AC stroom L2 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>AC vermogen L2 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>AC spanning L3 te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>AC spanning L3 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>AC frequentie L3 te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>AC frequentie L3 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC stroom L3 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>AC vermogen L3 te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Spanning Omvormeruitgang te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Stroom Omvormeruitgang te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Spanning universele uitgang (1A) te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Universele uitgang (1A) stroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Spanning universele uitgang (5A) te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Universele uitgang (5A) stroom te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT DC spanning 1 laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>AGT DC spanning 1 hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT DC stroom 1 laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT DC stroom 1 hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>AGT DC spanning 2 laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>AGT DC spanning 2 hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT DC stroom 2 laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT DC stroom 2 hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 koeler laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 koeler hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 rail (-) laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 rail (-) hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 rail (+) laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 rail (+) hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Brandstoftemperatuur te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Brandstoftemperatuur te hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Brandstofpeil te laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Besturingseenheid verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Paneel verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Onderhoud vereist</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>3-fasemodule verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>AGT-module verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Synchronisatiestoring</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Externe ECU verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Inlaat luchtfilter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Diagnosebericht (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Sync. module verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Belastingsegalisatie mislukt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Sync-modus gedeactiveerd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Rood stoplicht (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Oranje waarschuwingslamp (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Storingslampje (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Lamp beschermen (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Draaiveld onjuist</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Brandstofpeilsensor verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Starten zonder omvormer</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Bus #1 defect</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Startverzoek afgewezen</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Starten op afstand geweigerd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Geforceerde uitschakeling belastingsrelais</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Synchronisatiemodule is offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>BMS verloren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Omvormer DC Link Voltage laag/omgekeerd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Omvormer DC Link stroom laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Omvormer DC voorlaadspanning laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Omvormer DC voorlaadspanning hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Omvormer IGBT/MOSFET-stuurprogramma fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Fout in omvormer regelkring</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Omvormer AC Frequentiedetectie </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Omvormer storing besturingswaarde</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Fabrieksinstelling gewijzigd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parameter gewijzigd in beheerdermodus</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Handmatig ingrijpen (ext. systeem)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Initialisatie mislukt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Temperatuur omvormer hoog L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Temperatuur omvormer hoog L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Temperatuur omvormer hoog L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Temperatuur omvormer hoog DC link</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Overbelasting omvormer</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Communicatie omvormer verbroken</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>DC overbelasting</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>DC te hoge spanning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Geen verbinding</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Geen fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Onbekende fout: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Onbekende fout:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Oliedruk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Te hoge temperatuur cilinderkop</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Besturing laden</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Snelheid hoger dan verwacht</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Te hoge snelheid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Olietemperatuur hoger dan verwacht</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Oiltemperatuur open circuit / kortsluiting naar voeding</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Oiltemperatuur kortsluiting naar aarde</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analoog instelpunt hoog / kortsluiting naar voeding</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analoog instelpunt laag / kortsluiting naar aarde</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Time-out ontvangst TSC1-bericht</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Time-out ontvangst CM1 bericht</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Accuspanning hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Accuspanning laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Snelheidssignaal vervormd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Interne 5V sensorvoeding hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Interne 5V sensorvoeding laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Barometerdruk hoog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Barometerdruk laag</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Uitgang brandstofpomp kortsluiting naar voeding</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Uitgang brandstofpomp kortsluiting naar massa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Uitgang gloeibougie kortsluiting naar voeding</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Uitgang gloeibougie kortsluiting naar massa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Verstuiver open circuit/onderzijde kortsluiting naar massa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Interne kortsluiting verstuiverspoel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Verstuiver lage kant kortsluiting naar voeding</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Service-uren verstreken</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Processor storing</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Onbekende fout:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Accu</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Accu</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Koelkast</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Koelkast</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Algemeen</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Algemeen</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Kamer</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Kamer</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Buiten</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Buiten</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Boiler</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Boiler</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Diepvries</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Diepvries</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Onbekende fout:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Geen fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>AC spanning L1 te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>AC spanning te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>AC spanning L1 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>AC spanning te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>AC frequentie L1 te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>AC frequentie te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>AC frequentie L1 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>AC frequentie te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC stroom L1 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>AC stroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>AC vermogen L1 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>AC vermogen te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Noodstop</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Servo stroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Oliedruk te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Oliedruk te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Motortemperatuur te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Motortemperatuur te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Temperatuur wikkeling te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Temperatuur wikkeling te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Temperatuur uitlaat te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Temperatuur uitlaat te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Elektronica temperatuur laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Elektronica temperatuur hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Startspanning te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Startstroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Gloedspanning te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Gloeistroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Koude-Start-Aid spanning te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Cold-Start-Aid stroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Spanning brandstofhoudmagneet te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Stroom brandstofhoudmagneet te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Spanning spoel stopmagneet te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Stop-magneetspoel stroom te hoog </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Stop-magneetspoel spanning te laag </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Stop-magneet trek spoel stroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Spanning ventilator/waterpomp te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Stroom ventilator/waterpomp te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Spanning stroomsensor laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Stroomsensor stroom hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Boost-uitgangsspanning te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Boost uitgangsstroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Voedingsspanning bus te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Voedingsstroom bus te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Startaccuspanning te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Startaccuspanning te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Rotatie te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Rotatie te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Onverwachte stop/probleem met brandstoftoevoer</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Spanning netmagneetschakelaar te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Stroom netmagneetschakelaar te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>AC spanning L2 te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>AC spanning L2 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>AC frequentie L2 te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>AC frequentie L2 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>AC stroom L2 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>AC vermogen L2 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>AC spanning L3 te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>AC spanning L3 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>AC frequentie L3 te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>AC frequentie L3 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC stroom L3 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>AC vermogen L3 te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Spanning Omvormeruitgang te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Stroom Omvormeruitgang te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Spanning universele uitgang (1A) te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Universele uitgang (1A) stroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Spanning universele uitgang (5A) te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Universele uitgang (5A) stroom te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT DC spanning 1 laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>AGT DC spanning 1 hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT DC stroom 1 laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT DC stroom 1 hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>AGT DC spanning 2 laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>AGT DC spanning 2 hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT DC stroom 2 laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT DC stroom 2 hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 koeler laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 koeler hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 rail (-) laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 rail (-) hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 rail (+) laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 rail (+) hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Brandstoftemperatuur te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Brandstoftemperatuur te hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Brandstofpeil te laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Besturingseenheid verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Paneel verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Onderhoud vereist</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>3-fasemodule verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>AGT-module verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Synchronisatiestoring</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Externe ECU verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Inlaat luchtfilter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Diagnosebericht (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Sync. module verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Belastingsegalisatie mislukt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Sync-modus gedeactiveerd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Rood stoplicht (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Oranje waarschuwingslamp (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Storingslampje (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Lamp beschermen (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Draaiveld onjuist</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Brandstofpeilsensor verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Starten zonder omvormer</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Bus #1 defect</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Startverzoek afgewezen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Starten op afstand geweigerd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Geforceerde uitschakeling belastingsrelais</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Synchronisatiemodule is offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>BMS verloren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Omvormer DC Link Voltage laag/omgekeerd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Omvormer DC Link stroom laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Omvormer DC voorlaadspanning laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Omvormer DC voorlaadspanning hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Omvormer IGBT/MOSFET-stuurprogramma fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Fout in omvormer regelkring</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Omvormer AC Frequentiedetectie </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Omvormer storing besturingswaarde</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Fabrieksinstelling gewijzigd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parameter gewijzigd in beheerdermodus</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Handmatig ingrijpen (ext. systeem)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Initialisatie mislukt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Temperatuur omvormer hoog L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Temperatuur omvormer hoog L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Temperatuur omvormer hoog L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Temperatuur omvormer hoog DC link</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Overbelasting omvormer</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Communicatie omvormer verbroken</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>DC overbelasting</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>DC te hoge spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Geen verbinding</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Geen fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Onbekende fout: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Onbekende fout:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Oliedruk</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Te hoge temperatuur cilinderkop</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Besturing laden</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Snelheid hoger dan verwacht</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Te hoge snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Olietemperatuur hoger dan verwacht</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Oiltemperatuur open circuit / kortsluiting naar voeding</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Oiltemperatuur kortsluiting naar aarde</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Analoog instelpunt hoog / kortsluiting naar voeding</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Analoog instelpunt laag / kortsluiting naar aarde</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Time-out ontvangst TSC1-bericht</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Time-out ontvangst CM1 bericht</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Accuspanning hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Accuspanning laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Snelheidssignaal vervormd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Interne 5V sensorvoeding hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Interne 5V sensorvoeding laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Barometerdruk hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Barometerdruk laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Uitgang brandstofpomp kortsluiting naar voeding</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Uitgang brandstofpomp kortsluiting naar massa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Uitgang gloeibougie kortsluiting naar voeding</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Uitgang gloeibougie kortsluiting naar massa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Verstuiver open circuit/onderzijde kortsluiting naar massa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Interne kortsluiting verstuiverspoel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Verstuiver lage kant kortsluiting naar voeding</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Service-uren verstreken</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Processor storing</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Zet de schakelaar in een ontgrendelde positie om de instellingen te wijzigen.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Gebruik D Bus gegevensbron: maak verbinding met het opgegeven D Bus adres.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>Adres</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation> Gebruik D Bus gegevensbron: maak verbinding met het standaard D Bus adres</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Gebruik MQTT gegevensbron: maak verbinding met het opgegeven MQTT brokeradres.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>Adres</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>Portal ID van MQTT gegevensbronapparaat.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>Portal ID</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>MQTT VRM webhost shard</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>scherf</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation> Gebruikersnaam van MQTT gegevensbron</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Gebruiker</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Wachtwoord voor MQTT gegevensbron</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>Wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>MQTT gegevensbron token</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Token code</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation> Schakel FPS teller in</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Opstartscherm overslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Gebruik een testgegevensbron om te testen.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Standaardtijd Marokko</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Standaardtijd West-Centraal-Afrika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Standaardtijd Zuid-Afrika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Standaardtijd Namibië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Standaardtijd Egypte</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Standaardtijd Oost-Afrika</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Standaardtijd Argentinië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Standaardtijd Zuidoost-Amerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Standaardtijd Groenland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Standaardtijd Montevideo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Standaardtijd Newfoundland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Standaardtijd Zuidoost-Amerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Atlantische standaardtijd</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Standaardtijd Centraal-Brazilië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Standaardtijd Pacific SA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Standaardttijd Paraguay</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Standaardtijd SA Western</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Standaardtijd Venezuela</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Standaardtijd Eastern</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Standaardtijd SA Pacific</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Standaardtijd US Eastern</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Standaardtijd Centraal-Canada</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Standaardtijd Centraal-Amerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Standaardtijd Centraal-Mexico</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Standaardtijd Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Standaardtijd Mountain (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Standaardtijd Mountain</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Standaardtijd US Mountain</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Standaardtijd Pacific (Mexico)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Standaardtijd Stille Oceaan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Standaardtijd Alaska</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Standaardtijd Hawaii-Aleutian</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Standaardtijd Nieuw-Zeeland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Standaardtijd Central Pacific</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Standaardtijd West Pacific</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Standaardtijd West-Australië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Standaardtijd Zuidoost-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Standaardtijd Centraal-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Standaardtijd West-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Standaardtijd Oost-Afrika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Standaardtijd Pacific SA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Standaardtijd SA Western</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Standaardtijd West Europa</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Standaardtijd Kamchatka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Standaardtijd Magadan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Standaardtijd Vladivostok</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Standaardtijd Yakutsk</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Standaardtijd Tokio</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Standaardtijd Korea</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Standaardtijd Singapur</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Standaardtijd Ulaanbaatar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Standaardtijd Taipei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Standaardtijd Noordoost-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Standaardtijd China</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Standaardtijd Zuidoost-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Standaardtijd Noord-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Standaardtijd Myanmar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Standaardtijd Noord-Centraal-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Standaardtijd Centraal-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Standaardtijd Bangladesh</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Standaardtijd Nepal</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Standaardtijd Sri Lanka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Standaardtijd India</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Standaardtijd West-Azië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Standaardtijd Pakistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Standaardtijd Jekaterinaburg</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Standaardtijd Georgië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Standaardtijd Kaukasus</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Standaardtijd Azerbeidzjan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Standaardtijd Arabië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Standaardtijd Afghanistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Standaardtijd Iran</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Standaardtijd Arabië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Standaardtijd Arabië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Standaardtijd Syrië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Standaardtijd Midden-Oosten</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Standaardtijd Jordanië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Standaardtijd Israël</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Standaardtijd Greenwich</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Standaardtijd Azoren</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Standaardtijd Kaapverdië</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Standaardtijd Tasmanië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Standaardtijd Oost-Australië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Standaardtijd AUS Oost</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Standaardtijd Centraal-Australië</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Standaardtijd AUS Centraal</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Standaardtijd West-Australië</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT </translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Standaardtijd Midden Atalantisch</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Datumgrens standaardtijd</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>Standaardtijd GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Standaardtijd Centraal-Europa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Standaardtijd Midden-Europa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Standaardtijd Midden-Europa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Standaardtijd West-Europa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Standaardtijd Oost-Europa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Standaardtijd FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Standaardtijd GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Standaardtijd Wit-Rusland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Standaardtijd Rusland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Standaardtijd Turkije</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Standaardtijd Mauritius</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Standaardtijd Christmas Island</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Standaardtijd Tonga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Standaardtijd Fiji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Standaardtijd Nieuw-Zeeland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Standaardtijd Central Pacific</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Standaardtijd West Pacific</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Standaardtijd Samoa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Standaardtijd Hawaii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Standaardtijd Paaseiland</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Interne fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Onbekende fout:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Interne fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Geen fout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Temperatuur accu hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Spanning accu hoog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Spanning accu laag</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Accuspanning boven het ingestelde maximum</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Dynamo hoge temperatuur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Dynamo hoge draaisnelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>FET van veld aansturing hoge temperatuur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Vereiste sensor niet aanwezig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Dynamo lage spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Dynamo hoge spanning drempel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Dynamo spanning hoger dan het ingestelde maximum</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Hoge spanning dynamo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Accu losgekoppeld</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Accu losgekoppeld hoge spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Accu buiten bereik</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Te veel BMSen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Accu wordt bijna losgekoppeld</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Te veel apparatuur om te volgen</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Accu losgekoppeld lage spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Accu losgekoppeld hoge stroom</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Acuu losgekoppeld hoge temperatuur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Accu losgekoppeld lage temperatuur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>BMS verbinding verbroken</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC uitgeschakeld</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>DC/DC converter niet gereed</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC hoge primaire spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC lage primaire spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC hoge secundaire spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC lage secundaire spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC hoge temperatuur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>DC/DC verkeerde instelling</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Temperatuursensor accu defect</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_pl.ts
+++ b/i18n/venus-gui-v2_pl.ts
@@ -1,7384 +1,8025 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="pl">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Wyłączone</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Wyłączone</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Przeciążenie inwertera</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Przeciążenie inwertera</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Moc</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Moc</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Wył.</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Wył.</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Auto</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Podłączony</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Odłączone</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generator</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Wysokie napięcie akumulatora</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Wysokie napięcie akumulatora</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Inwerter / Ładowarka</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Inwerter / Ładowarka</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Niskie napięcie akumulatora</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Niskie napięcie akumulatora</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Ręcznie</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Ręcznie</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Brak</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Brak</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Pozycja</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Pozycja</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Prędkość</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Prędkość</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Stan</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Stan</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instalowanie %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instalowanie %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Nieznany błąd</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Nieznany błąd</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Minimalny SOC</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Minimalny SOC</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznany</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Wprowadź hasło</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Wprowadź hasło</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Naciśnij, aby sprawdzić</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Naciśnij, aby sprawdzić</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Sieć</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Sieć</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Uzysk solarny</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Uzysk solarny</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Sterowanie zewnętrzne</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Sterowanie zewnętrzne</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Zbiorniki</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Zbiorniki</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Środowisko</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Środowisko</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Brak aktualnych alertów</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Brak aktualnych alertów</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Ogólne</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Ogólne</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Data i godzina</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Data i godzina</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Konfiguracja systemu</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Konfiguracja systemu</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Wyświetlacz i język</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Wyświetlacz i język</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>Portal VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>Portal VRM</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Liczniki energii</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Liczniki energii</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>Inwertery PV</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>Inwertery PV</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>Modem GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>Modem GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Start/stop generatora</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Start/stop generatora</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Pompa zbiornika</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Pompa zbiornika</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Usługi</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Usługi</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Funkcje Venus OS Large</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Funkcje Venus OS Large</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Limit żywotności akumulatora: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Limit żywotności akumulatora: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Autostart zostanie wyłączony, a generator nie uruchomi się automatycznie w oparciu o skonfigurowane warunki.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Autostart zostanie wyłączony, a generator nie uruchomi się automatycznie w oparciu o skonfigurowane warunki.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Ręczne Zatrzymanie</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Ręczne Zatrzymanie</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Ręczny Start</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Ręczny Start</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Pozycja</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Autostart</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Autostart</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Przełączniki</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Przełączniki</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Poziom dostępu</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Poziom dostępu</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Użytkownik</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Użytkownik</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Użytkownik i instalator</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Użytkownik i instalator</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superuser</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superuser</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Serwis</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Serwis</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Upewnij się, aby po wyłączeniu DVCC zresetować także system VE.Bus</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Upewnij się, aby po wyłączeniu DVCC zresetować także system VE.Bus</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Limit prądu ładowania</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Limit prądu ładowania</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Maksymalny prąd ładowania</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Maksymalny prąd ładowania</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Użyj wartości %1 do uruchomienia/zatrzymania</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Użyj wartości %1 do uruchomienia/zatrzymania</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Rozpocznij, gdy %1 jest wyższy niż</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Rozpocznij, gdy %1 jest wyższy niż</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Rozpocznij, gdy %1 jest niższy niż</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Rozpocznij, gdy %1 jest niższy niż</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Zatrzymaj, gdy %1 jest wyższy niż</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Zatrzymaj, gdy %1 jest wyższy niż</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Zatrzymaj, gdy %1 jest niższy niż</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Zatrzymaj, gdy %1 jest niższy niż</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Usunąć adres IP?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Usunąć adres IP?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Połączenie</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Połączenie</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Produkt</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Produkt</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Nazwa</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Nazwa</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Nazwa</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>Produkt ID</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>Produkt ID</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Wersja sprzętowa</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Wersja sprzętowa</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Nazwa urządzenia</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Nazwa urządzenia</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Zdalne sterowanie przełącznikiem wyłączone</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Zdalne sterowanie przełącznikiem wyłączone</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Generator uszkodzony</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Generator uszkodzony</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Generator nie jest wykrywany na wejściu AC</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Generator nie jest wykrywany na wejściu AC</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Łączny czas pracy od ostatniego przebiegu testowego</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Łączny czas pracy od ostatniego przebiegu testowego</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Czas do następnego przebiegu testowego</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Czas do następnego przebiegu testowego</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Pracuje</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Pracuje</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Start ręczny</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Start ręczny</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Uruchom generator</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Uruchom generator</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Dzienny czas pracy</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Dzienny czas pracy</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Wartość musi być większa niż wartość zatrzymania</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Wartość musi być większa niż wartość zatrzymania</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Wartość musi być niższa niż wartość uruchomienia</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Wartość musi być niższa niż wartość uruchomienia</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>Wyjście AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>Wyjście AC</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">Wyjście AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Użyj obciążenia AC do uruchomienia/zatrzymania</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Użyj obciążenia AC do uruchomienia/zatrzymania</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Pomiar</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Pomiar</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Zużycie ogółem</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Zużycie ogółem</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Suma AC Out przetwornicy</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Suma AC Out przetwornicy</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Inwerter AC poza najwyższą fazą</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Inwerter AC poza najwyższą fazą</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Uruchom, gdy moc jest wyższa niż</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Uruchom, gdy moc jest wyższa niż</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Zatrzymaj, gdy moc jest niższa niż</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Zatrzymaj, gdy moc jest niższa niż</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Monitor akumulatora</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Monitor akumulatora</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Niedostępny monitor, ustaw inny</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Niedostępny monitor, ustaw inny</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Monitor akumulatora</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Niedostępny monitor, ustaw inny</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>O utracie łączności</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>O utracie łączności</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Zatrzymaj generator</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Zatrzymaj generator</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Utrzymaj pracę generatora</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Utrzymaj pracę generatora</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Zatrzymaj generator, gdy dostępne jest wejście AC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Zatrzymaj generator, gdy dostępne jest wejście AC</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>SOC akumulatora</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>SOC akumulatora</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Wysoka temperatura inwertera</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Wysoka temperatura inwertera</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Wysoka temperatura inwertera</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Start przy ostrzeżeniu o wysokiej temperaturze</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Start przy ostrzeżeniu o wysokiej temperaturze</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Start przy ostrzeżeniu o przeciążeniu</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Start przy ostrzeżeniu o przeciążeniu</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Przebieg okresowy</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Przebieg okresowy</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Interwał przebiegu</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Interwał przebiegu</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 dni(dzień)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 dni(dzień)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Pomiń przebieg, jeśli był uruchomiony przez</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Pomiń przebieg, jeśli był uruchomiony przez</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Zacznij zawsze</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Zacznij zawsze</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Data startu przebiegów interwałowych</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Data startu przebiegów interwałowych</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Czas trwania przebiegu (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Czas trwania przebiegu (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Pracuj do momentu pełnego naładowania akumulatora</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Pracuj do momentu pełnego naładowania akumulatora</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (stały)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (stały)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS podłączony, ale brak stałej pozycji GPS</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS podłączony, ale brak stałej pozycji GPS</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Brak podłączonego GPS</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Brak podłączonego GPS</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Szerokość geograficzna</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Szerokość geograficzna</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Długość geograficzna</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Długość geograficzna</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Kurs</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Kurs</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Wysokość</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Wysokość</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Liczba satelitów</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Liczba satelitów</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Wartość zadana sieci</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Wartość zadana sieci</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Wartość zadana AC-In</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Wartość zadana AC-In</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Prąd: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Prąd: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Napięcie: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Napięcie: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Limity (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Limity (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Ładowanie: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Ładowanie: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Rozładowanie: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Rozładowanie: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Limity (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Limity (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Widoczne</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Widoczne</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Ukryte</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Ukryte</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Pomiar pomocniczy)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Pomiar pomocniczy)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Wyjście %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Wyjście %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Aktywny monitor akumulatora</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Aktywny monitor akumulatora</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Nazwa</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Wprowadź nazwę</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Wprowadź nazwę</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Wprowadź nazwę</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Skanowanie ciągłe</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Skanowanie ciągłe</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Adaptery Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Adaptery Bluetooth</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Kod PIN</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Kod PIN</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Przed połączeniem może być konieczne usunięcie istniejących informacji o parowaniu.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Przed połączeniem może być konieczne usunięcie istniejących informacji o parowaniu.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Rodzaj fazy</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Rodzaj fazy</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Jednofazowy</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Jednofazowy</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Wielofazowy</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Wielofazowy</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>Inwerter PV na fazie 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>Inwerter PV na fazie 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>Falownik PV na fazie 2 Pozycja</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>Falownik PV na fazie 2 Pozycja</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>Profil CAN-bus</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>Profil CAN-bus</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Wyłączone</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Działa, ale brak usług (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Działa, ale brak usług (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Urządzenia</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Urządzenia</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>Wyjście NMEA2000</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>Wyjście NMEA2000</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Selektor unikalnego numeru identyfikacyjnego</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Selektor unikalnego numeru identyfikacyjnego</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Proszę czekać, zmiana i sprawdzenie unikalnego numeru zajmuje chwilę</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Proszę czekać, zmiana i sprawdzenie unikalnego numeru zajmuje chwilę</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Powyższy selektor określa, który blok unikalnych numerów identyfikacyjnych ma być używany dla unikalnych numerów identyfikacyjnych NAME w polu PGN 60928 NAME. Zmieniaj tylko w przypadku korzystania z wielu urządzeń GX w jednej sieci VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Powyższy selektor określa, który blok unikalnych numerów identyfikacyjnych ma być używany dla unikalnych numerów identyfikacyjnych NAME w polu PGN 60928 NAME. Zmieniaj tylko w przypadku korzystania z wielu urządzeń GX w jednej sieci VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Powyższy selektor określa, który blok unikalnych numerów identyfikacyjnych ma być używany dla numeru seryjnego w polu DGN 60928 ADDRESS_CLAIM. Zmień tylko w przypadku korzystania z wielu urządzeń GX w jednej sieci RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Powyższy selektor określa, który blok unikalnych numerów identyfikacyjnych ma być używany dla numeru seryjnego w polu DGN 60928 ADDRESS_CLAIM. Zmień tylko w przypadku korzystania z wielu urządzeń GX w jednej sieci RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Sprawdź Unikalne numery identyfikacyjne</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Sprawdź Unikalne numery identyfikacyjne</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Naciśnij, aby sprawdzić</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Istnieje inne urządzenie połączone z tym unikalnym numerem, wybierz nowy numer.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Istnieje inne urządzenie połączone z tym unikalnym numerem, wybierz nowy numer.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: Żadne inne urządzenie nie jest połączone z tym unikalnym numerem.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: Żadne inne urządzenie nie jest połączone z tym unikalnym numerem.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Status sieci</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Status sieci</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Adaptacyjna jasność</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Adaptacyjna jasność</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Jasność</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Jasność</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Czas wyłączenia wyświetlacza</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Czas wyłączenia wyświetlacza</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 s</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 s</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 s</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Nigdy</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Nigdy</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Tryb wyświetlania</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Tryb wyświetlania</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Ciemny</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Ciemny</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Jasny</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Jasny</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Poziomy szybkiego podglądu</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Poziomy szybkiego podglądu</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Język</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Język</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Zmiana języka</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Zmiana języka</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Wyświetlacz zasilania elektrycznego</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Wyświetlacz zasilania elektrycznego</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Moc (Wat)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Moc (Wat)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Prąd (A)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Prąd (A)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Jednostki</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Jednostki</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Poziom %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Poziom %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsjusz</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsjusz</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;UWAGA:&lt;/b&gt; Przeczytaj instrukcję przed dopasowaniem.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;UWAGA:&lt;/b&gt; Przeczytaj instrukcję przed dopasowaniem.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Limit zarządzanego napięcia ładowania akumulatora</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Limit zarządzanego napięcia ładowania akumulatora</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Maksymalne napięcie ładowania</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Maksymalne napięcie ładowania</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Współdzielony czujnik napięcia</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Współdzielony czujnik napięcia</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Współdzielony czujnik temperatury</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Współdzielony czujnik temperatury</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Czujnik niedostępny, ustaw inny</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Czujnik niedostępny, ustaw inny</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Czujnik niedostępny, ustaw inny</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Używany czujnik</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Używany czujnik</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Współdzielony czujnik prądu</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Współdzielony czujnik prądu</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Status SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Status SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Wyłączone (sterowanie zewnętrzne)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Wyłączone (sterowanie zewnętrzne)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Wyłączone (brak ładowarek)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Wyłączone (brak ładowarek)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Wyłączone (brak monitorowania aku.)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Wyłączone (brak monitorowania aku.)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Wybór automatyczny</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Wybór automatyczny</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Brak kontroli BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Brak kontroli BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Sterowanie BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Sterowanie BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Niedostępny, ustaw inny</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Niedostępny, ustaw inny</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Wybór automatyczny</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Wybór automatyczny</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Brak</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Data/czas utworzenia</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Data/czas utworzenia</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Aktualizacje online</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Aktualizacje online</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Zainstaluj oprogramowanie z SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Zainstaluj oprogramowanie z SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Zapisany zapasowy firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Zapisany zapasowy firmware</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Sprawdź aktualizacje na karcie SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Sprawdź aktualizacje na karcie SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Znaleziono oprogramowanie</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Znaleziono oprogramowanie</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instalacja %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instalacja %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Naciśnij, aby zaktualizować do %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Naciśnij, aby zaktualizować do %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Naciśnij, aby zaktualizować do %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Data/czas utworzenia oprogramowania</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Data/czas utworzenia oprogramowania</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Automatyczna aktualizacja</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Automatyczna aktualizacja</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Tylko sprawdzenie</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Tylko sprawdzenie</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Tylko sprawdzenie i pobranie</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Tylko sprawdzenie i pobranie</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Sprawdź i zaktualizuj</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Sprawdź i zaktualizuj</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Aktualizacja kanału</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Aktualizacja kanału</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Typ obrazu</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Typ obrazu</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normalna</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normalna</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Duża</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Duża</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Sprawdź aktualizacje</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Sprawdź aktualizacje</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Dostępna aktualizacja</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Dostępna aktualizacja</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Instalacja %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Instalacja %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Instalowanie %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Data/czas stworzenia aktualizacji</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Data/czas stworzenia aktualizacji</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Inwertery</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Inwertery</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Znajdź inwertery PV</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Znajdź inwertery PV</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Wykryte adresy IP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Wykryte adresy IP</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Dodaj adres IP ręcznie</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Dodaj adres IP ręcznie</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>Port TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>Port TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Wielofazowy</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Wielofazowy</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Split-phase (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Split-phase (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Pokaż</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Pokaż</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Ponowne skanowanie adresów IP?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Ponowne skanowanie adresów IP?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Ponowne skanowanie</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Ponowne skanowanie</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH w sieci LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH w sieci LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Wsparcie zdalne</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Wsparcie zdalne</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Tunel zdalnego wsparcia</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Tunel zdalnego wsparcia</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>IP i port zdalnego wsparcia</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>IP i port zdalnego wsparcia</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Wyloguj się teraz</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Uruchom ponownie teraz</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Uruchom ponownie teraz</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Urządzenie zostało ponownie uruchomione.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Alarm dźwiękowy</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Alarm dźwiękowy</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Tryb demonstracyjny</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Tryb demonstracyjny</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>Demo ESS</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>Demo ESS</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Demo Łodzie/Kampery 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Demo Łodzie/Kampery 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Demo Łodzie/Kampery 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Demo Łodzie/Kampery 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Uruchomienie trybu demo spowoduje zmianę niektórych ustawień, a interfejs użytkownika będzie przez chwilę nieaktywny.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Uruchomienie trybu demo spowoduje zmianę niektórych ustawień, a interfejs użytkownika będzie przez chwilę nieaktywny.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Warunki</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Warunki</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Minimalny czas pracy</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Minimalny czas pracy</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Czas nagrzewania</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Czas nagrzewania</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Czas schładzania</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Czas schładzania</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Wykryj generator na wejściu AC</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Wykryj generator na wejściu AC</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Żadne z wejść AC nie jest ustawione na generator. Przejdź do strony konfiguracji systemu i ustaw właściwe wejście AC na generator, aby włączyć tę funkcjonalność.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Żadne z wejść AC nie jest ustawione na generator. Przejdź do strony konfiguracji systemu i ustaw właściwe wejście AC na generator, aby włączyć tę funkcjonalność.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Alarm zostanie uruchomiony, gdy na wejściu AC inwertera nie zostanie wykryte zasilanie z generatora. Upewnij się, że prawidłowe wejście AC jest ustawione na generator na stronie konfiguracji systemu.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Alarm zostanie uruchomiony, gdy na wejściu AC inwertera nie zostanie wykryte zasilanie z generatora. Upewnij się, że prawidłowe wejście AC jest ustawione na generator na stronie konfiguracji systemu.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Czas rozpoczęcia godzin ciszy</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Czas rozpoczęcia godzin ciszy</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Czas zakończenia godzin ciszy</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Czas zakończenia godzin ciszy</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Czas pracy i obsługa</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Czas pracy i obsługa</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Resetowanie liczników dziennego czasu pracy</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Resetowanie liczników dziennego czasu pracy</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Licznik dziennego czasu pracy został zresetowany</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Licznik dziennego czasu pracy został zresetowany</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Nie można modyfikować liczników podczas pracy generatora</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Nie można modyfikować liczników podczas pracy generatora</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Częstotliwość serwisowania generatora (godziny)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Częstotliwość serwisowania generatora (godziny)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Serwisowy interwał czasowy ustawiony na %1 h. Użyj przycisku "Resetuj zegar serwisowy", aby zresetować serwisowy licznik czasu.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Serwisowy interwał czasowy ustawiony na %1 h. Użyj przycisku &quot;Resetuj zegar serwisowy&quot;, aby zresetować serwisowy licznik czasu.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Resetowanie zegara serwisowego</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Resetowanie zegara serwisowego</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Ustawienia GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Ustawienia GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Format</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Format</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Jednostka prędkości</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Jednostka prędkości</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilometry na godzinę</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilometry na godzinę</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Metry na sekundę</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Metry na sekundę</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Mile na godzinę</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Mile na godzinę</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Węzły</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Węzły</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Brak podłączonego modemu GSM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Brak podłączonego modemu GSM</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Nośnik</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Nośnik</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Może być konieczne skonfigurowanie ustawień APN poniżej na tej stronie, skontaktuj się z operatorem w celu uzyskania szczegółów.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Może być konieczne skonfigurowanie ustawień APN poniżej na tej stronie, skontaktuj się z operatorem w celu uzyskania szczegółów.
 Jeśli to nie zadziała, sprawdź kartę sim w telefonie, aby upewnić się, że jest kredyt i/lub jest ona zarejestrowana do korzystania z danych.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Zezwól na roaming</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Zezwól na roaming</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Status SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Status SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>Nie włożono SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>Nie włożono SIM</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>Wymagany PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>Wymagany PIN</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>Wymagany PUK</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>Wymagany PUK</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Awaria SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Awaria SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM zajęty</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM zajęty</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Niewłaściwa karta SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Niewłaściwa karta SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Nieprawidłowy PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Nieprawidłowy PIN</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Gotowe</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Gotowe</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Nieznany błąd</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Domyślne</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Domyślne</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Użyj domyślnego APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Użyj domyślnego APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Nazwa APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Nazwa APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Użyj uwierzytelniania</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Użyj uwierzytelniania</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Nazwa użytkownika</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Nazwa użytkownika</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Zużycie własne</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Zużycie własne</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Nie znaleziono asystenta ESS</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Nie znaleziono asystenta ESS</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Pomiary sieciowe</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Pomiary sieciowe</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Miernik zewnętrzny</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Miernik zewnętrzny</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Inwerter/Ładowarka</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Inwerter/Ładowarka</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Wyjście AC inwertera w użyciu</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Wyjście AC inwertera w użyciu</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Regulacja wielofazowa</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Regulacja wielofazowa</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Suma wszystkich faz</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Suma wszystkich faz</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Faza indywidualna</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Faza indywidualna</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Każda faza jest regulowana w celu indywidualnego osiągnięcia wartości zadanej sieci (wydajność systemu spada).
+        <translation>Każda faza jest regulowana w celu indywidualnego osiągnięcia wartości zadanej sieci (wydajność systemu spada).
 
 UWAGA: Używać tylko wtedy, gdy jest to wymagane przez dostawcę mediów.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Suma wszystkich faz jest inteligentnie regulowana w celu osiągnięcia wartości zadanej sieci (wydajność systemu jest zoptymalizowana).
+        <translation>Suma wszystkich faz jest inteligentnie regulowana w celu osiągnięcia wartości zadanej sieci (wydajność systemu jest zoptymalizowana).
 
 Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Nieaktywny</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamiczny ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Minimalny SOC (o ile nie nastąpi awaria sieci)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Minimalny SOC (o ile nie nastąpi awaria sieci)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Aktywny limit SOC</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Aktywny limit SOC</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Podtrzymanie</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Ładowanie ponowne</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Równanie wartości szczytowych</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Równanie wartości szczytowych</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Tylko powyżej minimalnego SOC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Tylko powyżej minimalnego SOC</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Zawsze</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Zawsze</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Rozładowanie wyłączone</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Rozładowanie wyłączone</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Powolne ładowanie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Powolne ładowanie</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Podtrzymanie</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Podtrzymanie</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Ładowanie ponowne</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Ładowanie ponowne</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Limit mocy ładowania</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Limit mocy ładowania</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Maksymalna moc ładowania</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Maksymalna moc ładowania</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Limit mocy inwertera</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Limit mocy inwertera</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Maksymalna moc inwertera</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Maksymalna moc inwertera</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Wartość zadana sieci</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Wartość zadana sieci</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Zasilanie z sieci</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Zasilanie z sieci</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>PV sprzężone z AC - zasilanie w nadmiarze</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>PV sprzężone z AC - zasilanie w nadmiarze</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>PV sprzężone z DC - zasilanie w nadmiarze</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>PV sprzężone z DC - zasilanie w nadmiarze</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Limit zasilania systemu</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Limit zasilania systemu</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Maksymalne zasilanie</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Maksymalne zasilanie</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Ograniczenie dopływu zasilania aktywne</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Ograniczenie dopływu zasilania aktywne</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Wejścia analogowe</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Wejścia analogowe</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Wejścia cyfrowe</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Wejścia cyfrowe</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Wejście cyfrowe %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Wejście cyfrowe %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Pulsometr</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Pulsometr</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Alarm drzwiowy</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Alarm drzwiowy</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Pompa zęzowa</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Pompa zęzowa</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Alarm zęzowy</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Alarm zęzowy</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Alarm przeciwwłamaniowy</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Alarm przeciwwłamaniowy</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Alarm dymu</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Alarm dymu</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Alarm pożarowy</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Alarm pożarowy</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>Alarm CO2</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>Alarm CO2</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Czujniki Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Czujniki Bluetooth</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Pamiętaj, że te funkcje nie są oficjalnie wspierane przez firmę Victron. Pytania kieruj na stronę community.victronenergy.com.
+        <translation>Pamiętaj, że te funkcje nie są oficjalnie wspierane przez firmę Victron. Pytania kieruj na stronę community.victronenergy.com.
 
 Dokumentacja na https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Sygnał K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Sygnał K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Włączone (tryb bezpieczny)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Włączone (tryb bezpieczny)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Odroczone o %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Odroczone o %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID Portalu VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID Portalu VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Interwał logów</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Interwał logów</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 godz.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 godz.</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 godz.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 godz.</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 godz.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 godz.</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 godz.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 godz.</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 dzień</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 dzień</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Użyj bezpiecznego połączenia (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Użyj bezpiecznego połączenia (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Ostatni kontakt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Ostatni kontakt</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Nieoczekiwany tekst odpowiedzi</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Nieoczekiwany tekst odpowiedzi</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Nieoczekiwana odpowiedź HTTP</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Nieoczekiwana odpowiedź HTTP</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Limit czasu połączenia</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Limit czasu połączenia</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Błąd połączenia</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Błąd połączenia</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Błąd DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Błąd DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Błąd routingu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Błąd routingu</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM niedostępny</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM niedostępny</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Nieznany błąd</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Nieznany błąd</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Komunikat o błędzie:
+        <translation>Komunikat o błędzie:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Ponowne uruchomienie urządzenia w przypadku braku kontaktu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Ponowne uruchomienie urządzenia w przypadku braku kontaktu</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Brak kontaktu, resetuj opóźnienie (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Brak kontaktu, resetuj opóźnienie (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Miejsce zapisu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Miejsce zapisu</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Brak aktywnego bufora</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Brak aktywnego bufora</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Pamięć wewnętrzna</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Pamięć wewnętrzna</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Transferowanie</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Transferowanie</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Pamięć zewnętrzna</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Pamięć zewnętrzna</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Nieznany błąd</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Brak błędu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Brak błędu</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Brak miejsca na dysku</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Brak miejsca na dysku</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Błąd IO</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Błąd IO</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Błąd montażu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Błąd montażu</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Zawiera obraz firmware. Nie do użytku.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Zawiera obraz firmware. Nie do użytku.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>Brak możliwości zapisu na karcie SD / pamięci USB</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>Brak możliwości zapisu na karcie SD / pamięci USB</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Wolne miejsce na dysku</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Wolne miejsce na dysku</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>bajt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>bajt</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bajty</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bajty</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Przechowywane zapisy</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Przechowywane zapisy</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 zapisów</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 zapisów</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Wiek najstarszego zapisu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Wiek najstarszego zapisu</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Włącz Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Włącz Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Nie zgłoszono błędów</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Nie zgłoszono błędów</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Czas ostatniego błędu</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Czas ostatniego błędu</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Dostępne usługi</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Dostępne usługi</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>ID jednostki: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>ID jednostki: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Funkcja (Przekaźnik 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Funkcja (Przekaźnik 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Funkcja</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Funkcja</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Przekaźnik alarmowy</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Przekaźnik alarmowy</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Pompa zbiornika</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Ręcznie</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polaryzacja przekaźnika alarmowego</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polaryzacja przekaźnika alarmowego</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normalnie otwarty</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normalnie otwarty</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normalnie zamknięty</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normalnie zamknięty</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Przekaźnik 1 wł.</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Przekaźnik 1 wł.</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Przekaźnik wł.</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Przekaźnik wł.</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Funkcja (Przekaźnik 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Funkcja (Przekaźnik 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Przekaźnik 2 wł.</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Przekaźnik 2 wł.</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Zasady kontroli temperatury</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Zasady kontroli temperatury</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Aktywacja przekaźnika na podstawie temperatury</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Aktywacja przekaźnika na podstawie temperatury</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Żaden przekaźnik nie jest skonfigurowany do aktywacji przez temperaturę. Przejdź do strony ustawień przekaźnika znajdującej się w głównym menu ustawień i ustaw funkcję przekaźnika na "Temperatura".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Żaden przekaźnik nie jest skonfigurowany do aktywacji przez temperaturę. Przejdź do strony ustawień przekaźnika znajdującej się w głównym menu ustawień i ustaw funkcję przekaźnika na &quot;Temperatura&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Opcja ta pozwala na przełączanie się pomiędzy aktualną a poprzednią wersją oprogramowania. Nie potrzeba internetu ani karty SD.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Opcja ta pozwala na przełączanie się pomiędzy aktualną a poprzednią wersją oprogramowania. Nie potrzeba internetu ani karty SD.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Naciśnij, aby uruchomić</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Naciśnij, aby uruchomić</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Ponowne uruchamianie do %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Ponowne uruchamianie do %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Zmiana wersji oprogramowania nie jest możliwa, gdy automatyczna aktualizacja jest ustawiona na „Sprawdź i zaktualizuj”. Ustaw automatyczną aktualizację na „Wyłączone” lub „Tylko sprawdź”, aby włączyć tę opcję.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Zmiana wersji oprogramowania nie jest możliwa, gdy automatyczna aktualizacja jest ustawiona na „Sprawdź i zaktualizuj”. Ustaw automatyczną aktualizację na „Wyłączone” lub „Tylko sprawdź”, aby włączyć tę opcję.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Backup oprogramowania niedostępny</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Backup oprogramowania niedostępny</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Konsola w VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>Magistrala CAN przez TCP/IP (debugowanie)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>Magistrala CAN przez TCP/IP (debugowanie)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Energia z nadbrzeża</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Energia z nadbrzeża</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Pojazd</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Pojazd</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Łódź</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Łódź</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Nazwa systemu</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Nazwa systemu</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatycznie</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatycznie</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Sieć</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatycznie</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Zdefiniowany przez użytkownika</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Zdefiniowany przez użytkownika</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Nazwa zdefiniowana przez użytkownika</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Nazwa zdefiniowana przez użytkownika</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>Wejście AC 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>Wejście AC 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>Wejście AC 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>Wejście AC 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Awaria monitorowania sieci</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Awaria monitorowania sieci</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Monitorowanie nadbrzeża odłączone</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Monitorowanie nadbrzeża odłączone</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Wybrane automatycznie</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Wybrane automatycznie</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Posiada system DC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Posiada system DC</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Synchronizacja VE.Bus SOC z akumulatorem</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Synchronizacja VE.Bus SOC z akumulatorem</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Wykorzystanie prądu ładowarki słonecznej do poprawy SOC VE.Bus</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Wykorzystanie prądu ładowarki słonecznej do poprawy SOC VE.Bus</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Regulacja napięcia ładowarki słonecznej</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Regulacja napięcia ładowarki słonecznej</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Regulacja prądu ładowarki słonecznej</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Regulacja prądu ładowarki słonecznej</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Kontrola BMS</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>Kontrola BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>Kontrola BMS</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Funkcja uruchamiania/zatrzymywania pompy zbiornika nie jest włączona. Przejdź do ustawień przekaźnika i ustaw funkcję na "Pompa zbiornika".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Funkcja uruchamiania/zatrzymywania pompy zbiornika nie jest włączona. Przejdź do ustawień przekaźnika i ustaw funkcję na &quot;Pompa zbiornika&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Stan pompy</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Stan pompy</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Czujnik zbiornika</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Czujnik zbiornika</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Poziom początkowy</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Poziom początkowy</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Poziom końcowy</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Poziom końcowy</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Utrata połączenia</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Utrata połączenia</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Odłączone</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Odłączone</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Ukryte]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Ukryte]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Połączyć się z siecią?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Połączyć się z siecią?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Połącz</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Połącz</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Zapomnieć sieć?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Zapomnieć sieć?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Zapomnij</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Zapomnij</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Czy na pewno chcesz zapomnieć tą sieć?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Czy na pewno chcesz zapomnieć tą sieć?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>Adres MAC</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>Adres MAC</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>Konfiguracja IP</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>Konfiguracja IP</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Ręcznie</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Wył.</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Naprawiono</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Naprawiono</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Netmask</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Netmask</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Bramka</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Bramka</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>Serwer DNS</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>Serwer DNS</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Adres IP Link-local</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Adres IP Link-local</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Uwaga, w przypadku systemów ESS, jak również systemów z zarządzanym akumulatorem, instancja urządzenia CAN-bus musi pozostać skonfigurowana na 0. Więcej informacji w instrukcji GX.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Uwaga, w przypadku systemów ESS, jak również systemów z zarządzanym akumulatorem, instancja urządzenia CAN-bus musi pozostać skonfigurowana na 0. Więcej informacji w instrukcji GX.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Instancja urządzenia</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Instancja urządzenia</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Adres sieci</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Adres sieci</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Urządzenia VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Urządzenia VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Urządzenie# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Urządzenie# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Brak punktów dostępu</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Brak punktów dostępu</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Brak podłączonego adaptera Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Brak podłączonego adaptera Wi-Fi</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Utwórz punkt dostępu</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Utwórz punkt dostępu</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Sieci Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Sieci Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Czy jesteś pewien, że chcesz wyłączyć punkt dostępu?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Czy jesteś pewien, że chcesz wyłączyć punkt dostępu?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Data/godzina UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Data/godzina UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Data/czas lokalny</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Data/czas lokalny</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Strefa czasowa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Strefa czasowa</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afryka</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afryka</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Ameryka</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Ameryka</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antarktyda</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antarktyda</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Arktyka</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Arktyka</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asia</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantyk</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantyk</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australia</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indie</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indie</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pacyfik</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pacyfik</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Niepołączony %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Niepołączony %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Zrestartować teraz?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Zrestartować teraz?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Zmiany instancji VRM nie zostaną zastosowane do czasu ponownego uruchomienia urządzenia.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Zmiany instancji VRM nie zostaną zastosowane do czasu ponownego uruchomienia urządzenia.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Urządzenie jest restartowane...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Urządzenie jest restartowane...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Urządzenie zostało ponownie uruchomione.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Urządzenie zostało ponownie uruchomione.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Alarm niskiego napięcia akumulatora</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Alarm niskiego napięcia akumulatora</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Alarm wysokiego napięcia akumulatora</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Alarm wysokiego napięcia akumulatora</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Ostatni błąd</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Ostatni błąd</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2. ostatni błąd</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2. ostatni błąd</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3. ostatni błąd</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3. ostatni błąd</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4. ostatni błąd</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4. ostatni błąd</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>W sieci</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>W sieci</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Ustawienie trybu pracy</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Ustawienie trybu pracy</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Standalone</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Standalone</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Standalone</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Ładowanie</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Ładowanie</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Sterowanie zewnętrzne</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Ładowanie i HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Ładowanie i HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Ładowanie i BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Ładowanie i BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Sterowanie zewn. i BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Sterowanie zewn. i BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Ładowanie, Hub-1 i BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Ładowanie, Hub-1 i BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Ustawienie Mastera</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Ustawienie Mastera</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Slave</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Slave</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Slave</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Group Master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Group Master</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Charge master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Charge master</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Group &amp; Charge master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Group &amp; Charge master</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Napięcie ładowania</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Napięcie ładowania</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Resetuj</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Resetuj</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Kontrola BMS jest włączana automatycznie, gdy BMS jest obecny. Zresetuj, jeśli konfiguracja systemu uległa zmianie lub nie ma systemu BMS.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Kontrola BMS jest włączana automatycznie, gdy BMS jest obecny. Zresetuj, jeśli konfiguracja systemu uległa zmianie lub nie ma systemu BMS.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Moc PV ogółem</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Ładowanie</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Ładowanie</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 znaleziono</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 znaleziono</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Historia</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Historia</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Historia</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Praca w sieci</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Praca w sieci</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Widok tabeli</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Widok tabeli</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Wykres</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Wykres</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Ostrzeżenie</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Ostrzeżenie</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarm</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Objętość</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Objętość</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Zwarcie</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Zwarcie</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Odwrotna polaryzacja</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Odwrotna polaryzacja</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Stacje ładowania EV</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Stacje ładowania EV</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Sesja</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Sesja</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Godzina</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Godzina</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Tryb ładowania</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Tryb ładowania</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Samodzielne uruchamianie i zatrzymywanie procesu. Służy to do szybkiego ładowania i dokładnego monitorowania.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Samodzielne uruchamianie i zatrzymywanie procesu. Służy to do szybkiego ładowania i dokładnego monitorowania.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Uruchamia się i zatrzymuje w zależności od poziomu naładowania akumulatora. Optymalne rozwiązanie do nocnego i dłuższego ładowania w celu uniknięcia przeładowania.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Uruchamia się i zatrzymuje w zależności od poziomu naładowania akumulatora. Optymalne rozwiązanie do nocnego i dłuższego ładowania w celu uniknięcia przeładowania.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Niższe stawki za energię elektryczną poza godzinami szczytu lub jeśli chcesz mieć pewność, że Twój pojazd elektryczny jest w pełni naładowany i gotowy do jazdy o określonej godzinie.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Niższe stawki za energię elektryczną poza godzinami szczytu lub jeśli chcesz mieć pewność, że Twój pojazd elektryczny jest w pełni naładowany i gotowy do jazdy o określonej godzinie.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Włączenie ładowania</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Włączenie ładowania</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Blokada wyświetlacza ładowarki</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Blokada wyświetlacza ładowarki</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Adres Źródłowy</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Adres Źródłowy</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Ustawienie</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Ustawienie</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Instancja linii #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Instancja linii #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Instancja Linii</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Instancja Linii</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Instancja Ładowarki</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Instancja Ładowarki</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Instancja Inwertera</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Instancja Inwertera</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Instancja źródła DC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Instancja źródła DC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Instancja źródła DC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Instancja źródła DC</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Priorytet źródła DC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Priorytet źródła DC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Priorytet źródła DC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Priorytet źródła DC</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Instancja zbiornika</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Instancja zbiornika</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Urządzenia RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Urządzenia RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Włącz wizualizator liczby klatek na sekundę</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Włącz wizualizator liczby klatek na sekundę</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Nieobsługiwany</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Nieobsługiwany</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Usuń odłączone urządzenia</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Usuń odłączone urządzenia</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Znaleziono nieobsługiwane urządzenie</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Znaleziono nieobsługiwane urządzenie</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Funkcja przekaźnika</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Funkcja przekaźnika</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Ładowarka lub generator start/stop</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Ładowarka lub generator start/stop</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Sterowanie ręczne</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Przepalony bezpiecznik</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Sterowanie ręczne</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Sterowanie ręczne</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Zawsze otwarte (nie używać przekaźnika)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Zawsze otwarte (nie używać przekaźnika)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Należy pamiętać, że zmiana ustawienia niskiego stanu naładowania powoduje również zmianę ustawienia czasu do rozładowania w menu akumulatora.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Należy pamiętać, że zmiana ustawienia niskiego stanu naładowania powoduje również zmianę ustawienia czasu do rozładowania w menu akumulatora.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Przepalony bezpiecznik</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Przepalony bezpiecznik</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Diody stanu</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Diody stanu</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Brak</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Główny Wyłącznik</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Główny Wyłącznik</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Grzejnik</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Grzejnik</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Wentylator wewnętrzny</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Wentylator wewnętrzny</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Flagi Ostrzegawcze</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Flagi Ostrzegawcze</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Flagi Alarmowe</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Flagi Alarmowe</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Przełącznik</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Przełącznik</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Inicjalizacja</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Inicjalizacja</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Wyłączenie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Wyłączenie</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Aktualizacja</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Aktualizacja</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Zaraz się włączy</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Zaraz się włączy</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Ładowanie wstępne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Ładowanie wstępne</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Kontrola stycznika</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Kontrola stycznika</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Stan ogólny</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Stan ogólny</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Temperatura akumulatora</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Temperatura akumulatora</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Temperatura powietrza</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Temperatura powietrza</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Napięcie rozrusznika</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Napięcie rozrusznika</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Napięcie magistrali</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Napięcie magistrali</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Napięcie sekcji górnej</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Napięcie sekcji górnej</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Błąd komunikacji</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Stan ogólny</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Napięcie magistrali</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Napięcie sekcji dolnej</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Napięcie sekcji dolnej</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Odchylenie środkowe</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Odchylenie środkowe</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Zużyte amperogodziny</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Zużyte amperogodziny</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Czas do końca</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Czas do końca</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Szczegóły</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Szczegóły</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarmy na poziomie modułu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarmy na poziomie modułu</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnostyka</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostyka</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Bezpieczniki</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Bezpieczniki</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>System</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>System</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parametry</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parametry</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Ponowne wykrycie Akumulatora</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Ponowne wykrycie Akumulatora</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Naciśnij, aby wykryć ponownie</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Naciśnij, aby wykryć ponownie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Naciśnij, aby wykryć ponownie</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Ponowne wykrycie akumulatora może potrwać do 60 sekund. Tymczasem nazwa akumulatora może być nieprawidłowa.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Ponowne wykrycie akumulatora może potrwać do 60 sekund. Tymczasem nazwa akumulatora może być nieprawidłowa.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Wysoki prąd ładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Wysoki prąd ładowania</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Wysoki prąd rozładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Wysoki prąd rozładowania</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Niski SOC</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Niski SOC</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Wysokie napięcie akumulatora</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Niski SOC</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Niskie napięcie rozruchowe</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Niskie napięcie rozruchowe</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Wysokie napięcie rozruchowe</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Wysokie napięcie rozruchowe</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Czujnik temperatury akumulatora</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Czujnik temperatury akumulatora</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Napięcie środkowe</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Napięcie środkowe</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Przepalony bezpiecznik</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Wysoka temperatura wewnętrzna</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Wysoka temperatura wewnętrzna</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Niska temperatura ładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Niska temperatura ładowania</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Wysoka temperatura ładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Wysoka temperatura ładowania</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Uszkodzenie wewnętrzne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Uszkodzenie wewnętrzne</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Zadziałał wyłącznik automatyczny</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Zadziałał wyłącznik automatyczny</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Brak równowagi celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Brak równowagi celi</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Niskie napięcie celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Niskie napięcie celi</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Najniższe napięcie celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Najniższe napięcie celi</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Najwyższe napięcie celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Najwyższe napięcie celi</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Minimalna temperatura celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Minimalna temperatura celi</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Maksymalna temperatura celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Maksymalna temperatura celi</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Moduły baterii</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Moduły baterii</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Liczba modułów blokujących ładowanie/rozładowanie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Liczba modułów blokujących ładowanie/rozładowanie</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Pojemność zainstalowana / dostępna</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Pojemność zainstalowana / dostępna</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Najgłębsze rozładowanie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Najgłębsze rozładowanie</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Ostatnie rozładowanie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Ostatnie rozładowanie</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Średnie rozładowanie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Średnie rozładowanie</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Całkowita liczba cykli</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Całkowita liczba cykli</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Liczba pełnych wyładowań</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Liczba pełnych wyładowań</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Skumulowana ilość pobranych Ah</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Skumulowana ilość pobranych Ah</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Minimalne napięcie celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Minimalne napięcie celi</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Maksymalne napięcie celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Maksymalne napięcie celi</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Czas od ostatniego pełnego naładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Czas od ostatniego pełnego naładowania</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Licznik synchronizacji</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Licznik synchronizacji</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarmy niskiego napięcia akumulatora rozruchowego</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarmy niskiego napięcia akumulatora rozruchowego</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Minimalne napięcie akumulatora rozruchowego</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Minimalne napięcie akumulatora rozruchowego</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Maksymalne napięcie akumulatora rozruchowego</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Maksymalne napięcie akumulatora rozruchowego</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Energia rozładowana</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Energia rozładowana</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Naładowana energia</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Naładowana energia</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Limit napięcia ładowania (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Limit napięcia ładowania (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Limit prądu ładowania (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Limit prądu ładowania (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Limit prądu rozładowania (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Limit prądu rozładowania (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Odłączenie przy niskim napięciu (zawsze ignorowane)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Odłączenie przy niskim napięciu (zawsze ignorowane)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Bank akumulatorów</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Bank akumulatorów</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Przekaźnik (na monitorze akumulatora)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Przekaźnik (na monitorze akumulatora)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Przywrócenie ustawień fabrycznych</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Przywrócenie ustawień fabrycznych</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Naciśnij, aby przywrócić</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Naciśnij, aby przywrócić</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Przywrócić ustawienia fabryczne?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Przywrócić ustawienia fabryczne?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth Włączony</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth Włączony</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Napięcie Nominalne</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Napięcie Nominalne</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 V</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 V</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 V</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 V</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 V</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 V</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Pojemność</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Pojemność</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Pojemność</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Napięcie ładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Napięcie ładowania</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Prąd końcowy</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Prąd końcowy</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Czas wykrywania naładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Czas wykrywania naładowania</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Wykładnik Peukerta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Wykładnik Peukerta</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Współczynnik efektywności ładowania</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Współczynnik efektywności ładowania</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Próg prądu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Próg prądu</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Okres uśredniania pozostałego czasu prscy</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Okres uśredniania pozostałego czasu prscy</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Granica wyładowania dla pozostałego czasu pracy</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Granica wyładowania dla pozostałego czasu pracy</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Bieżący próg</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Bieżący próg</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Synchronizuj stan naładowania do 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Synchronizuj stan naładowania do 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Naciśnij, aby zsynchronizować</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Naciśnij, aby zsynchronizować</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Kalibracja prądu zerowego</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Kalibracja prądu zerowego</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Naciśnij, aby ustawić na 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Naciśnij, aby ustawić na 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Dystrybutor %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Dystrybutor %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Brak prądu na szynie zbiorczej</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Brak prądu na szynie zbiorczej</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Utrata połączenia</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>Przepalony bezpiecznik %n</numerusform>
-        <numerusform>Przepalone bezpieczniki %n</numerusform>
-        <numerusform>Przepalone bezpieczniki %n</numerusform>
-        <numerusform>Przepalony(e) bezpiecznik(i) %n</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>Przepalony bezpiecznik %n</numerusform>
+            <numerusform>Przepalone bezpieczniki %n</numerusform>
+            <numerusform>Przepalone bezpieczniki %n</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Brak informacji, status Dystrybutora znajduje się na poprzedniej stronie.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Brak informacji, status Dystrybutora znajduje się na poprzedniej stronie.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Bezpiecznik %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Bezpiecznik %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Nieużywany</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Nieużywany</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Przepalony</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Przepalony</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Wyłączenia z powodu błędu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Wyłączenia z powodu błędu</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Ostatni błąd</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">2. ostatni błąd</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">3. ostatni błąd</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">4. ostatni błąd</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Przełącznik Systemowy</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Przełącznik Systemowy</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Zewnętrzny przekaźnik</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Zewnętrzny przekaźnik</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Styk Programowalny</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Styk Programowalny</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Akumulatory</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Akumulatory</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Pojemność</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Akumulatory</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Równolegle</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Równolegle</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Szeregowo</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Szeregowo</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Min/max napięcie celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Min/max napięcie celi</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Min/max temperatura celi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Min/max temperatura celi</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Balansowanie</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Balansowanie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Balansowanie</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznany</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Wyjście</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Wyjście</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Napęd terenowy</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Napęd terenowy</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Prędkość obrotowa silnika</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Prędkość obrotowa silnika</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Napięcie Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Napięcie Aux</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Brak alarmów</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Brak alarmów</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Niskie napięcie</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Niskie napięcie</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Wysokie napięcie</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Wysokie napięcie</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Niskie napięcie Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Niskie napięcie Aux</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Wysokie napięcie Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Wysokie napięcie Aux</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Alarmy niskiego napięcia Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Alarmy niskiego napięcia Aux</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Alarmy wysokiego napięcia Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Alarmy wysokiego napięcia Aux</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Minimalne napięcie Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Minimalne napięcie Aux</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Maksymalne napięcie Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Maksymalne napięcie Aux</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Energia wytworzona</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Energia wytworzona</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Energia zużyta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Energia zużyta</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Włącz alarm</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Włącz alarm</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Poziom aktywności</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Poziom aktywności</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Poziom przywracania</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Poziom przywracania</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Opóźnienie</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Opóźnienie</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Poziom</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Poziom</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Pozostało</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Pozostało</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Akumulator czujników</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Akumulator czujników</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Akumulator czujników</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Typ czujnika</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Typ czujnika</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Standardowe</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Standardowe</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Europejski (0 do 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Europejski (0 do 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>US (240 do 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>US (240 do 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Niestandardowe</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Niestandardowe</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Niestandardowe</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Wartość czujnika w stanie pustym</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Wartość czujnika w stanie pustym</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Typ płynu</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Typ płynu</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Zawartość butanu</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Zawartość butanu</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Niestandardowy kształt</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Niestandardowy kształt</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Czas uśredniania</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Czas uśredniania</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Wartość czujnika</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Wartość czujnika</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Nie zdefiniowano niestandardowego kształtu. Można zdefiniować jeden z maksymalnie dziesięcioma punktami. Należy pamiętać, że wartości 0% i 100% są domyślne.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Nie zdefiniowano niestandardowego kształtu. Można zdefiniować jeden z maksymalnie dziesięcioma punktami. Należy pamiętać, że wartości 0% i 100% są domyślne.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punkt %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Dodaj punkt</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Dodaj punkt</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Poziom czujnika</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Poziom czujnika</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Objętość</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Zduplikowane wartości poziomu czujnika są niedozwolone.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Zduplikowane wartości poziomu czujnika są niedozwolone.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Wartości wolumenu muszą rosnąć.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Wartości wolumenu muszą rosnąć.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Odblokowano (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Odblokowano (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Odblokowano (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Odblokowano (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Odblokowano (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Odblokowano (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Zablokowany</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Zablokowany</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Konfiguracja faz</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Konfiguracja faz</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Pozycja przełącznika</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Pozycja przełącznika</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Jednofazowy</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2-fazowy</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2-fazowy</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3-fazowy</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3-fazowy</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Urządzenia</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Silnik</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Silnik</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Prędkość</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Ładowanie</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Temperatura płynu chłodzącego</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Temperatura płynu chłodzącego</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Temperatura spalin</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Temperatura spalin</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Temperatura uzwojenia</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Temperatura uzwojenia</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Napięcie akumulatora rozruchowego</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Napięcie akumulatora rozruchowego</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Liczba uruchomień</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Liczba uruchomień</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Kontrola BMS</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Blokada selektora przedniego (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Blokada selektora przedniego (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Brak błędu (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Brak błędu (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC Ogółem</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC Ogółem</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energia L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energia L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Sekwencja faz</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Sekwencja faz</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Wersja menedżera danych</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Wersja menedżera danych</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Brak</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Migająca dioda wskazuje ten transformator</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Migająca dioda wskazuje ten transformator</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Urządzenia magistrali Smappee</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Urządzenia magistrali Smappee</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>Ładowarka PV</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>Ładowarka PV</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>To ustawienie jest wyłączone, gdy podłączone jest cyfrowe urządzenie Multi Control.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>To ustawienie jest wyłączone, gdy podłączone jest cyfrowe urządzenie Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>To ustawienie jest wyłączone, gdy podłączony jest VE.Bus BMS.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>To ustawienie jest wyłączone, gdy podłączony jest VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC in %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC in %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Odwrócona</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Odwrócona</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Włącz alarm</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Odwrócona</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Odwróć logikę alarmu</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Odwróć logikę alarmu</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Nasłonecznienie</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Nasłonecznienie</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Temperatura celi</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Temperatura celi</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Temperatura zewnętrzna (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Temperatura zewnętrzna (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Temperatura zewnętrzna</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Temperatura zewnętrzna</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Temperatura zewnętrzna (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Temperatura zewnętrzna (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Prędkość wiatru</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Prędkość wiatru</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Wykrywanie autom.</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Wykrywanie autom.</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Czujnik prędkości wiatru</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Czujnik prędkości wiatru</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Zewnętrzny czujnik temperatury</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Zewnętrzny czujnik temperatury</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Agregat</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Agregat</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Mnożnik</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Mnożnik</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Wyzeruj licznik</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Wyzeruj licznik</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Zwarcie</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Odwrotna polaryzacja</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Niski poziom czujnika akumulatora</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Niski poziom czujnika akumulatora</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Wilgotność</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Wilgotność</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Ciśnienie</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Ciśnienie</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Niski</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Przesunięcie</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Przesunięcie</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Skala</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Skala</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Napięcie czujnika</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Napięcie czujnika</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Moc PV ogółem</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Moc PV ogółem</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Strona produktu</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Strona produktu</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Czujnik AC %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Czujnik AC %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Dostępna jest nowa wersja MK3.
+        <translation>Dostępna jest nowa wersja MK3.
 UWAGA: Aktualizacja może tymczasowo zatrzymać system.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Aktualizacja MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Aktualizacja MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Naciśnij, aby zaktualizować</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Naciśnij, aby zaktualizować</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Aktualizacja MK3, wartości pojawią się ponownie po jej zakończeniu</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Aktualizacja MK3, wartości pojawią się ponownie po jej zakończeniu</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Ładowanie akumulatora do 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Ładowanie akumulatora do 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Ładowanie akumulatora do 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Zaawansowane</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>W toku</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>W toku</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Naciśnij, aby zatrzymać</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Naciśnij, aby zatrzymać</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Naciśnij, aby rozpocząć</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Naciśnij, aby rozpocząć</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Naładuj akumulator do 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Naładuj akumulator do 100%</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>System powróci do normalnego działania, nadając priorytet energii odnawialnej.
+        <translation>System powróci do normalnego działania, nadając priorytet energii odnawialnej.
 Czy chcesz kontynuować?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Zasilanie z lądu zostanie użyte, gdy będzie dostępne, a opcja "Priorytet energii słonecznej i wiatrowej" zostanie zignorowana.
+        <translation>Zasilanie z lądu zostanie użyte, gdy będzie dostępne, a opcja &quot;Priorytet energii słonecznej i wiatrowej&quot; zostanie zignorowana.
 Czy chcesz kontynuować?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Zasilanie z brzegu zostanie wykorzystane do jednorazowego, pełnego naładowania akumulatora.
+        <translation>Zasilanie z brzegu zostanie wykorzystane do jednorazowego, pełnego naładowania akumulatora.
 Po zakończeniu procesu ładowania system powróci do normalnej pracy, nadając priorytet energii słonecznej i wiatrowej.
 Czy chcesz kontynuować?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Napięcie DC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Napięcie DC</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>Prąd DC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>Prąd DC</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Zaawansowane</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Zaawansowane</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Ustawienia alarmu</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Ustawienia alarmu</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>VE.Bus BMS w razie potrzeby automatycznie wyłącza system, aby chronić akumulator. Sterowanie systemem z poziomu Color Control nie jest więc możliwe.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>VE.Bus BMS w razie potrzeby automatycznie wyłącza system, aby chronić akumulator. Sterowanie systemem z poziomu Color Control nie jest więc możliwe.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Zainstalowano asystenta BMS skonfigurowanego dla VE.Bus BMS, ale VE.Bus BMS nie został znaleziony!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Zainstalowano asystenta BMS skonfigurowanego dla VE.Bus BMS, ale VE.Bus BMS nie został znaleziony!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Uwaga: Włączenie wyrównania w systemie ESS z ładowarkami solarnymi może spowodować ładowanie akumulatora wysokim napięciem i zbyt dużym prądem.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Uwaga: Włączenie wyrównania w systemie ESS z ładowarkami solarnymi może spowodować ładowanie akumulatora wysokim napięciem i zbyt dużym prądem.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>System automatycznie przełączy się na fazę Float po zakończeniu ładowania wyrównawczego.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>System automatycznie przełączy się na fazę Float po zakończeniu ładowania wyrównawczego.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Przerwij wyrównanie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Przerwij wyrównanie</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Wyrównanie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Wyrównanie</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Przerywanie...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Przerywanie...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Rozpoczynanie...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Rozpoczynanie...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Rozpoczynanie...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Naciśnij, aby przerwać</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Naciśnij, aby przerwać</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Przerwij i ponowne uruchom absorpcję</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Przerwij i ponowne uruchom absorpcję</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Przewij i przejdź do trybu float</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Przewij i przejdź do trybu float</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Przerwij</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Przerwij</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Nie przerywać</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Nie przerywać</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Wykryj ponownie system VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Wykryj ponownie system VE.Bus</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Ponowne wykrywanie...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Ponowne wykrywanie...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Zrestartuj system VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Zrestartuj system VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Restartowanie...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Restartowanie...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Naciśnij aby zrestartować</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Naciśnij aby zrestartować</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>Wejście AC 1 ignorowane</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>Wejście AC 1 ignorowane</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>Wejście AC 2 ignorowane</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>Wejście AC 2 ignorowane</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Badanie przekaźnika ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Badanie przekaźnika ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Zakończono</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">W oczekiwaniu...</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Zakończono</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Zakończono</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>W oczekiwaniu...</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>W oczekiwaniu...</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Diagnostyka VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Diagnostyka VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Licznik jakości sieci Faza L%1, urządzenie %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Licznik jakości sieci Faza L%1, urządzenie %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.Bus Błąd 8 / 11 raport</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.Bus Błąd 8 / 11 raport</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Tylko alarm</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Tylko alarm</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarmy i ostrzeżenia</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarmy i ostrzeżenia</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Błąd BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Błąd BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Numery seryjne</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Numery seryjne</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>VE.Bus ostatni Błąd 11 raport #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>VE.Bus ostatni Błąd 11 raport #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Test bezpieczeństwa BF w toku</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Test bezpieczeństwa BF w toku</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Test bezpieczeństwa BF OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Test bezpieczeństwa BF OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Niezgodność AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Niezgodność AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Błąd komunikacji</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Błąd komunikacji</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>Błąd Przekaźnika GND</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>Błąd Przekaźnika GND</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Niedopasowanie UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Niedopasowanie UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Niedopasowanie Okresu Czasu</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Niedopasowanie Okresu Czasu</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Niedopasowanie napędu przekaźnika BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Niedopasowanie napędu przekaźnika BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Błąd: PE2 otwarty</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Błąd: PE2 otwarty</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Błąd: PE2 zamknięty</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Błąd: PE2 zamknięty</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Nieudany krok: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Nieudany krok: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Faza L%1, urządzenie %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Faza L%1, urządzenie %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Raportowanie błędu 11 VE.Bus wymaga minimalnej wersji firmware VE.Bus 454.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Raportowanie błędu 11 VE.Bus wymaga minimalnej wersji firmware VE.Bus 454.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>Dziwne zachowanie VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>Dziwne zachowanie VE.Bus</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>energia</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>energia</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>moc</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>moc</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>napięcie</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>napięcie</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>prąd</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>prąd</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>lokalizacja</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>lokalizacja</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>faza</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>faza</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Aktywne wejście AC</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Aktywne wejście AC</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Wysokie tętnienia DC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Wysokie tętnienia DC</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Wysokie napięcie DC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Wysokie napięcie DC</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Wysoki prąd DC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Wysoki prąd DC</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Błąd czujnika temperatury</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Błąd czujnika temperatury</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Błąd czujnika napięcia</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Błąd czujnika napięcia</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Przeciążenie</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Przeciążenie</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>Tętnienia DC</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>Tętnienia DC</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Czujnik Napięcia</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Czujnik Napięcia</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Rotacja faz</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Rotacja faz</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Wersja VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Wersja VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>Urządzenie MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>Urządzenie MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Wersja MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Wersja MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Wersja Multi Control</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Wersja Multi Control</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Wersja VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Wersja VE.Bus BMS</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>O ile sieć nie zawiedzie</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>O ile sieć nie zawiedzie</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>AC In</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>AC In</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>Wejście AC</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>Wejście AC</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>Wejście AC 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>Wejście AC 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>Wejście AC 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>Wejście AC 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Rola</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Rola</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>Obciążenie AC</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>Obciążenie AC</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>AC Out</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>AC Out</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>Wyjście AC</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>Wyjście AC</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Faza AC L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Faza AC L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Czujnik AC %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Czujnik AC %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Czujniki AC</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Czujniki AC</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Aktywny</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Aktywny</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Przeciążenie</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Stan alarmu</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Stan alarmu</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarmy</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarmy</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Pozwól ładować</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Pozwól ładować</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Pozwól rozładować</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Pozwól rozładować</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Skanowanie automatyczne</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Skanowanie automatyczne</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Akumulator</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Akumulator</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Prąd akumulatora</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Prąd akumulatora</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Napięcie akumulatora</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Napięcie akumulatora</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Prąd ładowania</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Prąd ładowania</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Ładowanie</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Ładowanie</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Wyczyść błąd</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Wyczyść błąd</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Zamknięte</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Zamknięte</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Podłączony</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Podłączony</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Prąd</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Prąd</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Transformatory prądowe</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Transformatory prądowe</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Nazwa własna</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Nazwa własna</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Debug</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Debug</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Urządzenie</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Urządzenie</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Wyłączone</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Rozładowanie</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Rozładowanie</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Odłączone</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Odłączone</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Włącz</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Włącz</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Włączone</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Włączone</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energia</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energia</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Błąd</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Błąd</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Błąd:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Błąd:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Kod błędu</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Kod błędu</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Wersja oprogramowania</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Wersja oprogramowania</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generator</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Wysoka temperatura akumulatora</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Wysoka temperatura akumulatora</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Alarm wysokiego poziomu</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Alarm wysokiego poziomu</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Wysokie napięcie akumulatora rozruchowego</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Wysokie napięcie akumulatora rozruchowego</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Wysoka temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Wysoka temperatura</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Alarmy wysokiego napięcia</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Alarmy wysokiego napięcia</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Historia</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Historia</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Godzina(y)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Godzina(y)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Bezczynność</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Bezczynność</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Nieaktywny</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Nieaktywny</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Inwerter / Ładowarka</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>Adres IP</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>Adres IP</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Niska temperatura akumulatora</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Niska temperatura akumulatora</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Alarm niskiego poziomu</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Alarm niskiego poziomu</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Niskie napięcie akumulatora rozruchowego</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Niskie napięcie akumulatora rozruchowego</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Niski stan naładowania</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Niski stan naładowania</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Niska temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Niska temperatura</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Alarmy niskiego napięcia</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Alarmy niskiego napięcia</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Producent</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Producent</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Temperatura maksymalna</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Temperatura maksymalna</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Napięcie maksymalne</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Napięcie maksymalne</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Temperatura minimalna</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Temperatura minimalna</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Minimalne napięcie</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Minimalne napięcie</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Tryb</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Tryb</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Nazwa modelu</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Nazwa modelu</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Nie</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Nie</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Brak błędu</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Niedostępne</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Niedostępne</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Nie podłączony</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Nie podłączony</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Offline</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Offline</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>OK</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>OK</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Wł.</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Wł.</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Otwórz</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Otwórz</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Hasło</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Hasło</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Faza</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Faza</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Naciśnij, aby wyczyścić</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Naciśnij, aby wyczyścić</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Naciśnij, aby zresetować</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Naciśnij, aby zresetować</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Naciśnij, aby skanować</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Naciśnij, aby skanować</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>Inwerter PV</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>Inwerter PV</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>Moc PV</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>Moc PV</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Ciche godziny</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Ciche godziny</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Przekaźnik</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Przekaźnik</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Ponowne uruchomienie</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Ponowne uruchomienie</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Usuń</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Usuń</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>W toku</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>W toku</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Skanowanie %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Skanowanie %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Numer seryjny</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Numer seryjny</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Ustawienia</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Ustawienia</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Setup</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Setup</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Siła sygnału</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Siła sygnału</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Czuwanie</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Czuwanie</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Start po osiągnięciu warunku dla</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Start po osiągnięciu warunku dla</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Godzina rozpoczęcia</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Godzina rozpoczęcia</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Wartość startowa w godzinach ciszy</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Wartość startowa w godzinach ciszy</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Rozpocznij, gdy ostrzeżenie jest aktywne dla</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Rozpocznij, gdy ostrzeżenie jest aktywne dla</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Stan naładowania</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Stan naładowania</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Status</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Status</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Uruchomienie (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Uruchomienie (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Wartość zatrzymania w godzinach ciszy</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Wartość zatrzymania w godzinach ciszy</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Zatrzymaj po osiągnięciu warunku dla</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Zatrzymaj po osiągnięciu warunku dla</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Zatrzymany</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Zatrzymany</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatura</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Czujnik temperatury</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Czujnik temperatury</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Dzisiaj</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Dzisiaj</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Razem</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Razem</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Traker</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Traker</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Typ</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Typ</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Unikalny Numer Identyfikacyjny</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Unikalny Numer Identyfikacyjny</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Nieznany</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Nieznany</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Błąd VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Błąd VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Napięcie</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Napięcie</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Instancja VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Instancja VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Gdy ostrzeżenie zostanie skasowane, zatrzymaj po</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Gdy ostrzeżenie zostanie skasowane, zatrzymaj po</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Tak</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Tak</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Wczoraj</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Wczoraj</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Uzysk</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Uzysk</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Zerowy limit zasilania wejściowego</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Zerowy limit zasilania wejściowego</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Ustaw datę</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Ustaw datę</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Zacznij teraz</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Zacznij teraz</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Praca z pomiarem czasu</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Praca z pomiarem czasu</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Zatrzymaj Teraz</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Zatrzymaj Teraz</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Całkowity Czas Pracy</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Całkowity Czas Pracy</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Ustaw czas %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Ustaw czas %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Generator będzie kontynuował pracę, jeśli spełniony zostanie warunek autostartu.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Generator będzie kontynuował pracę, jeśli spełniony zostanie warunek autostartu.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Tryb Inwertera / Ładowarki</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Tryb Inwertera / Ładowarki</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Ustaw</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Ustaw</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Anuluj</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Zamknij</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Zamknij</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Ustaw czas</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Ustaw czas</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Już w użyciu</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Już w użyciu</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Błąd zamiany</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Błąd zamiany</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Wymiana zakończona</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Wymiana zakończona</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Zamiana instancji urządzenia...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Zamiana instancji urządzenia...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Instancja urządzenia %1 jest już używana przez "%3". Zamienić instancje urządzenia i przypisać do %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Instancja urządzenia %1 jest już używana przez &quot;%3&quot;. Zamienić instancje urządzenia i przypisać do %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Instancja urządzenia %1 jest już używana przez inne urządzenie tego samego typu. Zamienić instancje urządzenia i przypisać do %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Instancja urządzenia %1 jest już używana przez inne urządzenie tego samego typu. Zamienić instancje urządzenia i przypisać do %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Nie można zamienić instancji urządzenia: upłynął limit czasu operacji.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Nie można zamienić instancji urządzenia: upłynął limit czasu operacji.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Nowe instancje urządzenia będą aktywne po ponownym uruchomieniu.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Nowe instancje urządzenia będą aktywne po ponownym uruchomieniu.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Zamiana</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Zamiana</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Błąd podczas sprawdzania aktualizacji oprogramowania</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Błąd podczas sprawdzania aktualizacji oprogramowania</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Pobieranie i instalowanie oprogramowania %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Pobieranie i instalowanie oprogramowania %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Instalowanie oprogramowania...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Instalowanie oprogramowania...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Błąd podczas instalacji oprogramowania</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Błąd podczas instalacji oprogramowania</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Brak nowszej wersji</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Brak nowszej wersji</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Nie znaleziono oprogramowania</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Nie znaleziono oprogramowania</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Paliwo</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Paliwo</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Woda słodka</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Woda słodka</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Ścieki</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Ścieki</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Zbiornik na ryby</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Zbiornik na ryby</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Olej</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Olej</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Czarna woda</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Czarna woda</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzyna</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzyna</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diesel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diesel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Olej hydrauliczny</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Olej hydrauliczny</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Woda surowa</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Woda surowa</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Ustawienie blokady dla poziomu dostępu</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Ustawienie blokady dla poziomu dostępu</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Nieprawidłowe hasło</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Nieprawidłowe hasło</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Krótki</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Krótki</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Przegląd</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Przegląd</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Poziomy</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Poziomy</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Powiadomienia</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Powiadomienia</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>teraz</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>teraz</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1m temu</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1m temu</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1h %2m temu</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1h %2m temu</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Codziennie</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Codziennie</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Dni powszednie</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Dni powszednie</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Weekendy</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Weekendy</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Poniedziałek</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Poniedziałek</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Wtorek</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Wtorek</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Środa</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Środa</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Czwartek</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Czwartek</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Piątek</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Piątek</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Sobota</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Sobota</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Niedziela</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Niedziela</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 lub %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 lub %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Harmonogram %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Harmonogram %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Dzień</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Dzień</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Nie ustalono</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Nie ustalono</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Limit SOC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Limit SOC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Zużycie własne powyżej limitu</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Zużycie własne powyżej limitu</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>PV i Akumulator</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>PV i Akumulator</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Sprawdzanie...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Sprawdzanie...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Stan alarmów</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Stan alarmów</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Wyczyść historię</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Wyczyść historię</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Czyszczenie</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Czyszczenie</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Wymuszone wł.</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Wymuszone wł.</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Wymuszone wył.</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Wymuszone wył.</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Stan przekaźnika</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Stan przekaźnika</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Resetowanie historii na monitorze</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Resetowanie historii na monitorze</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Naciśnij, aby wysunąć</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Naciśnij, aby wysunąć</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Wysuwam, proszę czekać</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Wysuwam, proszę czekać</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Nie znaleziono dysku</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Nie znaleziono dysku</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>Czujnik temperatury %1</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>Czujnik temperatury %1</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 czujnik temperatury (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 czujnik temperatury (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Czujnik temperatury (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Czujnik temperatury (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Brak działań</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Brak działań</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Ostrzeżenie: Temperatury aktywacji i dezaktywacji są ustawione na tę samą wartość. Spowoduje to zignorowanie tego warunku.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Ostrzeżenie: Temperatury aktywacji i dezaktywacji są ustawione na tę samą wartość. Spowoduje to zignorowanie tego warunku.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Warunek %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Warunek %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Funkcja wyłączona</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Funkcja wyłączona</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Brak (Wyłącz)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Brak (Wyłącz)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Przekaźnik 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Przekaźnik 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Przekaźnik 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Przekaźnik 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Ostrzeżenie: Przekaźnik wybrany powyżej nie jest skonfigurowany dla temperatury, ten warunek zostanie zignorowany.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Ostrzeżenie: Przekaźnik wybrany powyżej nie jest skonfigurowany dla temperatury, ten warunek zostanie zignorowany.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Wartość aktywacji</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Wartość aktywacji</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Jednostka objętości</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Jednostka objętości</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Metry sześcienne</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Metry sześcienne</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Litry</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Litry</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Galony (USA)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Galony (USA)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Galony (angielskie)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Galony (angielskie)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Min. Napięcie</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Min. Napięcie</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Maks. Napięcie</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Maks. Napięcie</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Maks. Napięcie</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Maksymalny Prąd</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Maksymalny Prąd</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Czas ładowania</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Czas ładowania</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Float</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">g</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Float</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Float</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>g</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>g</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>Wystąpił(y) błąd(błędy) %1</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>Wystąpił(y) błąd(błędy) %1</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Ostatni</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Ostatni</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2. ostatni</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2. ostatni</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3. ostatni</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3. ostatni</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4. ostatni</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4. ostatni</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Maksymalna Moc</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Maksymalna Moc</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Nie można się połączyć</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Nie można się połączyć</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Rozłączono, próba ponownego połączenia</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Rozłączono, próba ponownego połączenia</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Łączenie</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Łączenie</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Łączenie</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Połączony, oczekuje na wiadomości od brokera</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Połączony, oczekuje na wiadomości od brokera</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Połączony, odbiera komunikaty brokera</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Połączony, odbiera komunikaty brokera</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Połączony, ładuję interfejs użytkownika</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Połączony, ładuję interfejs użytkownika</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Nieprawidłowa wersja protokołu</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Nieprawidłowa wersja protokołu</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Identyfikator klienta odrzucony</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Identyfikator klienta odrzucony</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Usługa brokerska niedostępna</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Usługa brokerska niedostępna</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Zła nazwa użytkownika lub hasło</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Zła nazwa użytkownika lub hasło</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Nieautoryzowany klient</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Nieautoryzowany klient</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Błąd połączenia transportowego</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Błąd połączenia transportowego</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Błąd naruszenia protokołu</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Błąd naruszenia protokołu</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Błąd poziomu 5 protokołu MQTT</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Błąd poziomu 5 protokołu MQTT</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Wyciszenie alarmu</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Wyciszenie alarmu</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Moc Ogółem</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Moc Ogółem</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>min.</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>min.</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2g</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2g</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1g %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1g %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Porażka</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Porażka</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Pobieranie adresu IP</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Pobieranie adresu IP</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Podłączony</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Odłącz</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Odłącz</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Odłączone</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>Obciążenia AC</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>Obciążenia AC</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>Obciążenia DC</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>Obciążenia DC</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Wiatr</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Wiatr</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Brzeg</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Brzeg</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Ograniczenie prądu sieci</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Ograniczenie prądu sieci</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Ograniczenie prądu generatora</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Ograniczenie prądu generatora</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Ograniczenie prądu brzegowego</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Ograniczenie prądu brzegowego</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Zatrzymywanie</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Zatrzymywanie</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Zatrzymywanie</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 do końca</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 do końca</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 zbiornik (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 zbiornik (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>Ładowarka AC</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>Ładowarka AC</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Alternator</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Alternator</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>Ładowarka DC</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>Ładowarka DC</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Generator DC</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Generator DC</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>System DC</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>System DC</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Ogniwo paliwowe</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Ogniwo paliwowe</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Generator wału</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Generator wału</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Generator wody</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Generator wody</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Ładowarka wiatrowa</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Ładowarka wiatrowa</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Niski</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Niski</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>High</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>High</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Utrzymuj akumulatory naładowane</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Utrzymuj akumulatory naładowane</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Zoptymalizowany pod kątem żywotności akumualtora</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Zoptymalizowany pod kątem żywotności akumualtora</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Zoptymalizowane nie uwzględniając żywotności akumulatora</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Zoptymalizowane nie uwzględniając żywotności akumulatora</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Sterowanie zewnętrzne</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Naładowany</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Naładowany</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Czekam na słońce</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Czekam na słońce</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>W oczekiwaniu na RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>W oczekiwaniu na RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Oczekiwanie na start</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Oczekiwanie na start</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Błąd testu uziemienia</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Błąd testu uziemienia</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Błąd testu wejścia CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Błąd testu wejścia CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Wykryto prąd szczątkowy</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Wykryto prąd szczątkowy</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Wykryto zbyt niskie napięcie</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Wykryto zbyt niskie napięcie</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Wykryto przepięcie</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Wykryto przepięcie</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Wykryto przegrzanie</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Wykryto przegrzanie</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Limit ładowania</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Limit ładowania</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Rozpocznij ładowanie</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Rozpocznij ładowanie</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Zaplanowane</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Zaplanowane</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Zaplanowane</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Nagrzewanie</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Nagrzewanie</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Chłodzenie</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Chłodzenie</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Przebieg testowy</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Przebieg testowy</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Uruchomiono ręczne</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Uruchomiono ręczne</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Ładowanie rozruchu</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Ładowanie rozruchu</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>Praca (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>Praca (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>Praca (Zdławiona)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>Praca (Zdławiona)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Przekaźnik %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Przekaźnik %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Usterka</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Usterka</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorpcja</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorpcja</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Przechowywanie</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Przechowywanie</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Wyrównaj</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Wyrównaj</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Sterowanie zewnętrzne</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Tryb AES</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Tryb AES</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Stan błędu</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Stan błędu</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Ładowanie Bulk</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Ładowanie Bulk</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Ładowanie absorpcyjne</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Ładowanie absorpcyjne</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Ładowanie Float</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Ładowanie Float</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Tryb przechowywania</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Tryb przechowywania</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Ładowanie wyrównawcze</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Ładowanie wyrównawcze</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Przepuszczanie</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Przepuszczanie</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Transformuje</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Transformuje</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Asystuje</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Asystuje</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Tryb zasilania</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Tryb zasilania</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Podtrzymanie</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Obudź się</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Obudź się</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Powtórzona absorbcja</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Powtórzona absorbcja</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Automatyczne wyrównanie</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Automatyczne wyrównanie</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>BatterySafe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>BatterySafe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Wykrywanie obciążenia</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Wykrywanie obciążenia</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Zablokowany</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Zablokowany</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamiczny ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dynamiczny ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dynamiczny ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Group Master</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Group Master</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Instance Master</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Instance Master</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Group &amp; Instance Master</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Group &amp; Instance Master</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Standalone i Group Master</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Standalone i Group Master</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Tylko ładowarka</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Tylko ładowarka</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Tylko inwerter</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Tylko inwerter</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Alarm niskiego napięcia akumulatora</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Alarm wysokiego napięcia akumulatora</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Alarm zwarciowy</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Alarm zwarciowy</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Wyłączenie punktu dostępu</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Wyłączenie punktu dostępu</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Wejście DC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Wejście DC</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>W przypadku baterii litowych nie zaleca się ładowania poniżej 10%. W przypadku innych typów baterii należy sprawdzić w arkuszu danych minimalny poziom zalecany przez producenta.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>W przypadku baterii litowych nie zaleca się ładowania poniżej 10%. W przypadku innych typów baterii należy sprawdzić w arkuszu danych minimalny poziom zalecany przez producenta.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Wyłączyć autostart?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Wyłączyć autostart?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Inwerter / Ładowarka (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Inwerter / Ładowarka (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Wyświetlanie użycia CPU</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Wyświetlanie użycia CPU</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Zakończ aplikację</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Zakończ aplikację</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Wyjdź</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Wyjdź</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Wersja aplikacji</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Wersja aplikacji</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Temperatura oleju</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Temperatura oleju</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Należy pamiętać, że zmiana ustawienia czasu do rozładowania maksymalnego powoduje również zmianę ustawienia niskiego stanu naładowania w menu przekaźnika.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Należy pamiętać, że zmiana ustawienia czasu do rozładowania maksymalnego powoduje również zmianę ustawienia niskiego stanu naładowania w menu przekaźnika.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Czas działania</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Czas działania</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Naładowane Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Naładowane Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Cykle rozpoczęte</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Cykle rozpoczęte</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Cykle zakończone</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Cykle zakończone</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Liczba uruchomień</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Liczba uruchomień</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Liczba głębokich rozładowań</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Liczba głębokich rozładowań</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Historia cykli ładowania</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Historia cykli ładowania</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Wartość czujnika w stanie pełnym</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Wartość czujnika w stanie pełnym</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Czas do serwisu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Czas do serwisu</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Funkcja autostartu</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Funkcja autostartu</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Upewnij się, że generator nie jest podłączony do wejścia AC %1 podczas korzystania z tej opcji</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Upewnij się, że generator nie jest podłączony do wejścia AC %1 podczas korzystania z tej opcji</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Licznik czasu serwisowego został zresetowany</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Licznik czasu serwisowego został zresetowany</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Ciągłe skanowanie może zakłócać działanie sieci Wi-Fi.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Ciągłe skanowanie może zakłócać działanie sieci Wi-Fi.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Minimalny i maksymalny zakres pomiarowy</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Minimalny i maksymalny zakres pomiarowy</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Strona startowa</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Restart aplikacji...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Restart aplikacji...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Nie udało się zmienić języka!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Nie udało się zmienić języka!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Nigdy</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Poczekaj na zmianę języka.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Poczekaj na zmianę języka.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Szybki podgląd</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Szybki podgląd</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Brak etykiet</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Brak etykiet</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Pokaż objętości zbiornika</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Pokaż objętości zbiornika</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Pokaż wartości procentowe</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Pokaż wartości procentowe</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Uwaga: Jeśli nie można wyświetlić prądu (na przykład podczas wyświetlania sumy dla połączonych źródeł AC i DC), zamiast tego zostanie wyświetlona moc.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Uwaga: Jeśli nie można wyświetlić prądu (na przykład podczas wyświetlania sumy dla połączonych źródeł AC i DC), zamiast tego zostanie wyświetlona moc.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Limity prądu ładowania</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Limity prądu ładowania</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Wydanie oficjalne</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Wydanie oficjalne</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Wydanie beta</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Wydanie beta</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Testowanie (wewnętrzne Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Testowanie (wewnętrzne Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Rozwój (wewnętrzny Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Rozwój (wewnętrzny Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Ponowne uruchomienie...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Ponowne uruchomienie...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Włącz diody LED stanu</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Włącz diody LED stanu</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Nagrzewanie i schładzanie</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Nagrzewanie i schładzanie</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Czas zatrzymania generatora</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Czas zatrzymania generatora</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarm, gdy generator nie jest w trybie autostartu</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarm, gdy generator nie jest w trybie autostartu</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Alarm zostanie wyzwolony, gdy funkcja autostartu pozostanie wyłączona przez ponad 10 minut.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Alarm zostanie wyzwolony, gdy funkcja autostartu pozostanie wyłączona przez ponad 10 minut.</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Zużycie własne z akumulatora</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Zużycie własne z akumulatora</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Wszystkie obciążenia systemu</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Wszystkie obciążenia systemu</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Tylko obciążenia krytyczne</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Tylko obciążenia krytyczne</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Minimalny SOC (o ile nie nastąpi awaria sieci)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Stan żywotności aku.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Stan żywotności aku.</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Dostęp do Signal K na http://venus.local:3000 i przez VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Dostęp do Signal K na http://venus.local:3000 i przez VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Dostęp do Node-RED na https://venus.local:1881 i przez VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Dostęp do Node-RED na https://venus.local:1881 i przez VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Pomiary akumulatora</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Pomiary akumulatora</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Status systemu</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Status systemu</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Lista urządzeń</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Lista urządzeń</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Instancje urządzenia VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Instancje urządzenia VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Alarm wysokiej temperatury</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Alarm wysokiej temperatury</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Kontrola BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Kontrola BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarmy i błędy</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarmy i błędy</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Ta funkcja wymaga oprogramowania w wersji 400 lub wyższej. Aby zaktualizować urządzenie Multi/Quattro skontaktuj się z instalatorem.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Ta funkcja wymaga oprogramowania w wersji 400 lub wyższej. Aby zaktualizować urządzenie Multi/Quattro skontaktuj się z instalatorem.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Ładowarka nie jest gotowa, nie można uruchomić wyrównywania</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Ładowarka nie jest gotowa, nie można uruchomić wyrównywania</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Wyrównanie nie może zostać uruchomione w fazie ładowania Bulk</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Wyrównanie nie może zostać uruchomione w fazie ładowania Bulk</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Prąd maksymalny</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Prąd maksymalny</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Maksymalna moc</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Maksymalna moc</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Minimalny prąd</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Minimalny prąd</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Brak</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Niedostępne</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Wył.</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Historia ogólna</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Historia ogólna</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Ustawienia</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Nieznany</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Uzysk dziś</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Uzysk dziś</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Oprogramowanie zainstalowane, ponowne uruchomienie</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Oprogramowanie zainstalowane, ponowne uruchomienie</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Kontrola wprowadzania dotykowego</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Kontrola wprowadzania dotykowego</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Błąd testu styków spawanych (zwarcie)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Błąd testu styków spawanych (zwarcie)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Przełączanie na 3 fazy</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Przełączanie na 3 fazy</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Przełączanie na 1 fazę</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Przełączanie na 1 fazę</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Zatrzymanie ładowania</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Zatrzymanie ładowania</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Zarezerwowane</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Zarezerwowane</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Tryb inwertera</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Tryb inwertera</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Out L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Out L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Wejście</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Wejście</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Przepuszczanie</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Przepuszczanie</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Strona przeładuje się za dziesięć sekund, aby załadować najnowszą wersję.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Strona przeładuje się za dziesięć sekund, aby załadować najnowszą wersję.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Inwerter (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Inwerter (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Inwerter/Ładowarki</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Inwerter/Ładowarki</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Nie znaleziono liczników energii
+        <translation>Nie znaleziono liczników energii
 
 Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączone przez RS485. W przypadku innych liczników, w tym liczników Carlo Gavazzi podłączonych przez sieć Ethernet, należy zapoznać się z menu urządzeń Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Automatyczne przełączanie</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Automatyczne przełączanie</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Po włączeniu tej funkcji minima i maksima wskaźników i wykresów są automatycznie dostosowywane na podstawie wcześniejszych wartości.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Po włączeniu tej funkcji minima i maksima wskaźników i wykresów są automatycznie dostosowywane na podstawie wcześniejszych wartości.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Zerowanie wszystkich wartości zakresu</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Zerowanie wszystkich wartości zakresu</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Resetuj Wartości Zakresu</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Resetuj Wartości Zakresu</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Czy na pewno chcesz wyzerować wszystkie wartości?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Czy na pewno chcesz wyzerować wszystkie wartości?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Maksymalny prąd: AC w 1 podłączony</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Maksymalny prąd: AC w 1 podłączony</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Maksymalny prąd: AC w 2 podłączony</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Maksymalny prąd: AC w 2 podłączony</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Maksymalny prąd: brak wejść AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Maksymalny prąd: brak wejść AC</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>Wyjście DC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>Wyjście DC</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solar</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solar</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Obroty silnika</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Obroty silnika</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Temperatura silnika</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Temperatura silnika</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Temperatura Sterownika</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Temperatura Sterownika</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Cykl aktywny</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Cykl aktywny</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Cykl %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Cykl %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>Odłączenie DC</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>Odłączenie DC</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Wyłączony</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Wyłączony</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Zmiana funkcji</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Zmiana funkcji</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Aktualizacja oprogramowania</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Aktualizacja oprogramowania</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Reset oprogramowania</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Reset oprogramowania</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Niekompletny</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Niekompletny</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Upływający czas</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Upływający czas</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Ładowanie / podtrzymanie (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Ładowanie / podtrzymanie (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Akumulator (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;koniec&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Akumulator (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;koniec&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Niskie napięcie AC OUT</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Niskie napięcie AC OUT</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Wysokie napięcie AC OUT</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Wysokie napięcie AC OUT</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Uzysk całkowity</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Uzysk całkowity</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Uzysk systemu</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Uzysk systemu</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Historia codzienna</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Historia codzienna</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Brak alarmów do skonfigurowania</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Brak alarmów do skonfigurowania</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Maksymalne napięcie PV</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Maksymalne napięcie PV</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Maksymalne napięcie akumulatora</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Maksymalne napięcie akumulatora</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Minimalne napięcie akumulatora</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Minimalne napięcie akumulatora</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Błąd banku akumulatorów</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Błąd banku akumulatorów</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Nieobsługiwane napięcie akumulatora</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Nieobsługiwane napięcie akumulatora</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Nieprawidłowa liczba akumulatorów</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Nieprawidłowa liczba akumulatorów</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Nieprawidłowa konfiguracja akumulatorów</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Nieprawidłowa konfiguracja akumulatorów</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Status balansera</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Status balansera</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Wyrównane</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Wyrównane</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Niewyrównane</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Niewyrównane</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Używaj tej opcji w systemach, które nie przeprowadzają ograniczenie mocy szczytowych.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Używaj tej opcji w systemach, które nie przeprowadzają ograniczenie mocy szczytowych.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Ta opcja służy do ograniczenia mocy szczytowej.</translation>
+        <translation>Ta opcja służy do ograniczenia mocy szczytowej.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Próg ograniczeniu szczytowej jest ustawiany za pomocą ustawienia limitu prądu wejściowego AC. Więcej informacji w dokumentacji.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Próg ograniczeniu szczytowej jest ustawiany za pomocą ustawienia limitu prądu wejściowego AC. Więcej informacji w dokumentacji.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Na tym ekranie można zmienić progi ograniczania mocy szczytowej dla importu i eksportu. Więcej informacji w dokumentacji.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Na tym ekranie można zmienić progi ograniczania mocy szczytowej dla importu i eksportu. Więcej informacji w dokumentacji.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Ograniczenie prądu importowego AC systemu</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Ograniczenie prądu importowego AC systemu</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Aby korzystać z tej funkcji, funkcja Pomiar Sieci musi być ustawiona na Pomiar zewnętrzny i musi być zainstalowany aktualny asystent ESS.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Aby korzystać z tej funkcji, funkcja Pomiar Sieci musi być ustawiona na Pomiar zewnętrzny i musi być zainstalowany aktualny asystent ESS.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Maksymalny prąd importowy systemu (na fazę)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Maksymalny prąd importowy systemu (na fazę)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Aby korzystać z tej funkcji, pomiar sieci musi być ustawiony na licznik zewnętrzny.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Aby korzystać z tej funkcji, pomiar sieci musi być ustawiony na licznik zewnętrzny.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Maksymalny prąd eksportu systemu (na fazę)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Maksymalny prąd eksportu systemu (na fazę)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Przewodowy</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Przewodowy</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Krótki</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Wysokie obciążenie systemu, zamykam panel boczny, aby zmniejszyć obciążenie procesora</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Wysokie obciążenie systemu, zamykam panel boczny, aby zmniejszyć obciążenie procesora</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Ograniczenie prądu wejściowego</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Ograniczenie prądu wejściowego</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Zwarcie</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Zwarcie</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Kupowanie</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Kupowanie</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Sprzedaż</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Sprzedaż</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Docelowy SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Docelowy SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC out %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC out %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Trackery</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Trackery</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Urządzenia RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Urządzenia RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Wstrzymywanie animacji elektronów</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Wstrzymywanie animacji elektronów</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Całkowita pojemność</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Całkowita pojemność</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Liczba systemów BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Liczba systemów BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>Magistrala CAN BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>Magistrala CAN BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>Magistrala CAN BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>Magistrala CAN BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Ogranicz export prądu AC systemu</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Ogranicz export prądu AC systemu</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Urządzenia Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Urządzenia Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Dodaj urządzenie</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Dodaj urządzenie</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Skanuj w poszukiwaniu urządzeń</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Skanuj w poszukiwaniu urządzeń</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Zapisane urządzenia</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Zapisane urządzenia</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Odkryte urządzenia</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Odkryte urządzenia</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Dodaj urządzenie Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Dodaj urządzenie Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protokół</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protokół</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Port</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Port</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Jednostka</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Jednostka</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Nie zapisano żadnych urządzeń Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Nie zapisano żadnych urządzeń Modbus</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Urządzenie %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Urządzenie %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Usunąć urządzenie Modbus?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Usunąć urządzenie Modbus?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Nie wykryto urządzeń Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Nie wykryto urządzeń Modbus</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Akumulator %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Akumulator %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>Prąd AC</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>Prąd AC</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Dezaktywacja start/stop generatora</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Dezaktywacja start/stop generatora</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Funkcja zdalnego uruchamiania jest wyłączona w agregacie. GX nie będzie mógł teraz uruchomić ani zatrzymać agregatu. Włącz tę opcję na panelu sterowania agregatu.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Funkcja zdalnego uruchamiania jest wyłączona w agregacie. GX nie będzie mógł teraz uruchomić ani zatrzymać agregatu. Włącz tę opcję na panelu sterowania agregatu.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Funkcja automatycznego startu</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Funkcja automatycznego startu</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Bieżący czas pracy</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Status kontroli</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Status kontroli</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Status agregatu</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Status agregatu</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Tryb zdalnego uruchamiania</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Tryb zdalnego uruchamiania</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Ciśnienie oleju</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Ciśnienie oleju</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Zaplanowane poziomy ładowania</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Zaplanowane poziomy ładowania</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Aktywny (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Aktywny (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Zatrzymanie ręczne</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Zatrzymanie ręczne</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Obwód otwarty</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Obwód otwarty</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (niedostępne)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (niedostępne)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Wprowadzanie dotykowe wł.</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Wprowadzanie dotykowe wł.</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Wprowadzanie dotykowe wył.</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Wprowadzanie dotykowe wył.</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Wprowadzanie dotykowe wył.</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Wprowadzanie dotykowe wył.</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Potwierdzanie alertów</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Potwierdzanie alertów</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Kod błędu kontroli</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Kod błędu kontroli</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>To menu służy do definiowania danych akumulatora wyświetlanych po kliknięciu ikony Akumulator na stronie Przegląd. Ten sam wybór jest również widoczny w Portalu VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>To menu służy do definiowania danych akumulatora wyświetlanych po kliknięciu ikony Akumulator na stronie Przegląd. Ten sam wybór jest również widoczny w Portalu VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Napięcie instalacji [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Napięcie instalacji [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Informacje o połączeniu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Informacje o połączeniu</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Wybierz...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Wybierz...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Zabezpieczony</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Zabezpieczony</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Ochrona hasłem i szyfrowanie komunikacji sieciowej</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Ochrona hasłem i szyfrowanie komunikacji sieciowej</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Słaby</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Słaby</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Chronione hasłem, ale komunikacja sieciowa nie jest szyfrowana</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Chronione hasłem, ale komunikacja sieciowa nie jest szyfrowana</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Niezabezpieczony</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Niezabezpieczony</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Brak hasła i komunikacja sieciowa nie jest szyfrowana</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Brak hasła i komunikacja sieciowa nie jest szyfrowana</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Hasło musi składać się z co najmniej 8 znaków</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Wprowadź hasło</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Hasło musi składać się z co najmniej 8 znaków</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Hasło musi składać się z co najmniej 8 znaków</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Wybrać profil "Zabezpieczony"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Wybrać profil &quot;Zabezpieczony&quot;?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Wybrać profil "Słaby"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Wybrać profil &quot;Słaby&quot;?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Wybrać profil "Niezabezpieczony"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Wybrać profil &quot;Niezabezpieczony&quot;?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Usługi sieci lokalnej są chronione hasłem
+        <translation>- Usługi sieci lokalnej są chronione hasłem
 - Komunikacja sieciowa jest szyfrowana
 - Włączone jest bezpieczne połączenie z VRM
 - Nie można włączyć niezabezpieczonych ustawień</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokalne usługi sieciowe są chronione hasłem
+        <translation>- Lokalne usługi sieciowe są chronione hasłem
 - Włączony jest również niezaszyfrowany dostęp do lokalnych stron internetowych (HTTP/HTTPS).</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokalne usługi sieciowe nie wymagają hasła
+        <translation>- Lokalne usługi sieciowe nie wymagają hasła
 - Włączony jest również niezaszyfrowany dostęp do lokalnych stron internetowych (HTTP/HTTPS).</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Hasło główne</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Hasło główne</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Wyloguj</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Wyloguj</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Wyloguj się teraz</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Wyloguj się teraz</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Wylogować się?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Wylogować się?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Spowoduje to rozłączenie wszystkich lokalnych połączeń sieciowych.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Spowoduje to rozłączenie wszystkich lokalnych połączeń sieciowych.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>wyloguj</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>wyloguj</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Tylko do odczytu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Tylko do odczytu</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Pełny</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Pełny</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Jesteś pewien?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Jesteś pewien?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Zmiana tego ustawienia na Tylko do odczytu lub Wyłączone spowoduje zablokowanie użytkownika.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Zmiana tego ustawienia na Tylko do odczytu lub Wyłączone spowoduje zablokowanie użytkownika.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Dostęp MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Dostęp MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' nie jest liczbą.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; nie jest liczbą.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Potwierdzić</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Potwierdzić</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Użyj liczby składającej się z %1 lub mniej cyfr.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Użyj liczby składającej się z %1 lub mniej cyfr.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' nie jest prawidłowym adresem IP.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; nie jest prawidłowym adresem IP.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' nie jest prawidłowym numerem portu. Należy użyć numeru z zakresu 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; nie jest prawidłowym numerem portu. Należy użyć numeru z zakresu 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 nie jest prawidłowym numerem jednostki. Należy użyć liczby z zakresu 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 nie jest prawidłowym numerem jednostki. Należy użyć liczby z zakresu 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Bieżący czas pracy</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Bieżący czas pracy</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Kody błędów agregatu</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Kody błędów agregatu</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Temperatura radiatora</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Temperatura radiatora</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Napięcie ładowania</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Napięcie ładowania jest obecnie kontrolowane przez BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Napięcie ładowania jest obecnie kontrolowane przez BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Limit prądu ładowania</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Limit prądu ładowania</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>BMS Kontrolowane</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>BMS Kontrolowane</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Kontrola BMS jest włączana automatycznie, gdy obecny jest system BMS. Zresetuj ją, jeśli konfiguracja systemu uległa zmianie lub jeśli nie ma systemu BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Kontrola BMS jest włączana automatycznie, gdy obecny jest system BMS. Zresetuj ją, jeśli konfiguracja systemu uległa zmianie lub jeśli nie ma systemu BMS.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Zegar serwisowy wyłączony.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Zegar serwisowy wyłączony.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Portal VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Portal VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (zdalny dostęp VPN)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (zdalny dostęp VPN)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Przed włączeniem usług sieciowych należy skonfigurować profil zabezpieczeń, patrz Ustawienia - Ogólne</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Przed włączeniem usług sieciowych należy skonfigurować profil zabezpieczeń, patrz Ustawienia - Ogólne</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' zostało zastąpione przez '%2', ponieważ zawierało nieprawidłowe znaki.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; zostało zastąpione przez &apos;%2&apos;, ponieważ zawierało nieprawidłowe znaki.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Inicjalizacja...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Inicjalizacja...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Backend zaczynający się...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Backend zaczynający się...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend został zatrzymany.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend został zatrzymany.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Połączenie nie powiodło się.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Połączenie nie powiodło się.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>To urządzenie GX jest wylogowane z Tailscale.
+        <translation>To urządzenie GX jest wylogowane z Tailscale.
 
 Poczekaj lub sprawdź połączenie internetowe.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Czekam na odpowiedź od Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Czekam na odpowiedź od Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Podłącz to urządzenie GX do swojego konta Tailscale, otwierając ten link:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Podłącz to urządzenie GX do swojego konta Tailscale, otwierając ten link:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Poczekaj lub sprawdź połączenie internetowe.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Poczekaj lub sprawdź połączenie internetowe.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Nieznany stan: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Nieznany stan: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Błąd: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Błąd: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Wyłącz Tailscale, aby edytować te ustawienia.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Wyłącz Tailscale, aby edytować te ustawienia.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Włącz skalę ogonową</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Włącz skalę ogonową</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Nazwa maszyny</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Nazwa maszyny</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Wylogowanie z konta Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Wylogowanie z konta Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Dostęp do sieci lokalnej</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Dostęp do sieci lokalnej</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Dostęp do lokalnej sieci Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Dostęp do lokalnej sieci Ethernet</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Dostęp do lokalnej sieci WiFi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Dostęp do lokalnej sieci WiFi</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Sieci niestandardowe</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Sieci niestandardowe</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Przykład: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Przykład: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Wyjaśnienie:
+        <translation>Wyjaśnienie:
 
 Ta funkcja, nazywana przez Tailscale trasami podsieci, umożliwia zdalny dostęp do innych urządzeń w sieci lokalnej (sieciach lokalnych).
 
@@ -7387,2991 +8028,3058 @@ Pole sieci niestandardowych akceptuje oddzieloną przecinkami listę podsieci w 
 Po dodaniu/włączeniu nowej sieci należy ją raz zatwierdzić w konsoli administracyjnej Tailscale.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Niestandardowe argumenty "tailscale up"</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Niestandardowe argumenty &quot;tailscale up&quot;</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Niestandardowy adres URL serwera (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Niestandardowy adres URL serwera (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Ten sterownik agregatu wymaga przekaźnika pomocniczego do sterowania, ale przekaźnik pomocniczy nie jest skonfigurowany. Skonfiguruj przekaźnik 1 w Ustawienia → Przekaźnik na "Podłączony przekaźnik pomocniczy agregatu".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Ten sterownik agregatu wymaga przekaźnika pomocniczego do sterowania, ale przekaźnik pomocniczy nie jest skonfigurowany. Skonfiguruj przekaźnik 1 w Ustawienia → Przekaźnik na &quot;Podłączony przekaźnik pomocniczy agregatu&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarmy wysokiego napięcia akumulatora rozruchowego</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarmy wysokiego napięcia akumulatora rozruchowego</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Pomiń rozgrzewkę generatora</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Pomiń rozgrzewkę generatora</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>W górę, ale brak usług (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>W górę, ale brak usług (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Hasło roota zostało zmienione na %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Hasło roota zostało zmienione na %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Podłączony przekaźnik pomocniczy agregatu</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Podłączony przekaźnik pomocniczy agregatu</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Położenie obciążeń AC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Położenie obciążeń AC</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Wejście i wyjście AC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Wejście i wyjście AC</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Opcji tej należy używać, gdy na wejściu falownika/ładowarki występują obciążenia prądem przemiennym. Użyj tej opcji, jeśli nie masz pewności.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Opcji tej należy używać, gdy na wejściu falownika/ładowarki występują obciążenia prądem przemiennym. Użyj tej opcji, jeśli nie masz pewności.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Tylko wyjście AC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Tylko wyjście AC</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Użyj tej opcji, gdy system korzysta z miernika sieci, ale wszystkie obciążenia AC są na wyjściu falownika/ładowarki.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Użyj tej opcji, gdy system korzysta z miernika sieci, ale wszystkie obciążenia AC są na wyjściu falownika/ładowarki.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Miesięcznie</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Miesięcznie</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>Ładowarka solarna</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>Ładowarka solarna</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Pompa ciepła</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Pompa ciepła</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Podstawowe obciążenia</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Podstawowe obciążenia</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Uruchomienie i zatrzymanie generatora na podstawie skonfigurowanych warunków autostartu.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Uruchomienie i zatrzymanie generatora na podstawie skonfigurowanych warunków autostartu.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Ustawienia agregatu prądu stałego</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Ustawienia agregatu prądu stałego</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Temperatura alternatora</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Temperatura alternatora</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Temperatura silnika</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Temperatura silnika</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Całkowity czas pracy</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Całkowity czas pracy</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Profil bezpieczeństwa sieci</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Profil bezpieczeństwa sieci</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Ostatnie %1 dni</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Ostatnie %1 dni</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generator zatrzyma się w %1, chyba że włączone zostaną warunki autostartu, które utrzymają go w działaniu.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generator zatrzyma się w %1, chyba że włączone zostaną warunki autostartu, które utrzymają go w działaniu.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generator będzie działał do momentu ręcznego zatrzymania, chyba że włączone zostaną warunki autostartu, które utrzymają go w działaniu.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generator będzie działał do momentu ręcznego zatrzymania, chyba że włączone zostaną warunki autostartu, które utrzymają go w działaniu.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Klasyczny interfejs użytkownika</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Klasyczny interfejs użytkownika</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Nowy interfejs użytkownika</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Nowy interfejs użytkownika</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Pomyślnie zmieniono język!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Ograniczenie mocy</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Pomyślnie zmieniono język!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>W przypadku urządzeń Multi-RS i HS19 ustawienia ESS są dostępne na stronie produktu RS System.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>W przypadku urządzeń Multi-RS i HS19 ustawienia ESS są dostępne na stronie produktu RS System.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Start/stop agregatu</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Start/stop agregatu</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Zmiana wersji oprogramowania sprzętowego nie jest możliwa bez wybrania opcji "Network Security Profile" w "Settings / General".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Zmiana wersji oprogramowania sprzętowego nie jest możliwa bez wybrania opcji &quot;Network Security Profile&quot; w &quot;Settings / General&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>ostatnie {months} miesięcy</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>ostatnie {months} miesięcy</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Alarmy systemowe</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Alarmy systemowe</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Brak alarmów systemowych</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Brak alarmów systemowych</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Powrót</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Powrót</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Co nowego</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Co nowego</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>pomiń</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>pomiń</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Witamy!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Witamy!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Z przyjemnością przedstawiamy całkowicie przeprojektowany interfejs, który zwiększa zarówno użyteczność, jak i estetykę GX.
+        <translation>Z przyjemnością przedstawiamy całkowicie przeprojektowany interfejs, który zwiększa zarówno użyteczność, jak i estetykę GX.
 
 Dzięki usprawnionej nawigacji i świeżemu wyglądowi wszystko, co kochasz, jest teraz jeszcze łatwiej dostępne i bardziej atrakcyjne wizualnie.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Tryb ciemny - tryb jasny</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Tryb ciemny - tryb jasny</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Różne środowiska wymagają różnych ustawień wyświetlania. Tryby ciemny i jasny zapewniają najlepsze wrażenia z oglądania bez względu na to, gdzie się znajdujesz.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Różne środowiska wymagają różnych ustawień wyświetlania. Tryby ciemny i jasny zapewniają najlepsze wrażenia z oglądania bez względu na to, gdzie się znajdujesz.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Wszystkie kluczowe informacje, których potrzebujesz, przedstawione w przejrzystym i prostym układzie. Centralnym elementem jest konfigurowalny widżet z pierścieniami, zapewniający szybki dostęp do szczegółowych informacji o systemie.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Wszystkie kluczowe informacje, których potrzebujesz, przedstawione w przejrzystym i prostym układzie. Centralnym elementem jest konfigurowalny widżet z pierścieniami, zapewniający szybki dostęp do szczegółowych informacji o systemie.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Zyskaj większą kontrolę dzięki naszemu zaktualizowanemu panelowi Overview, zawierającemu dane systemowe w czasie rzeczywistym - wszystko w jednym miejscu dla łatwego monitorowania.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Zyskaj większą kontrolę dzięki naszemu zaktualizowanemu panelowi Overview, zawierającemu dane systemowe w czasie rzeczywistym - wszystko w jednym miejscu dla łatwego monitorowania.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Kontrole:</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Kontrole:</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Wszystkie codzienne elementy sterujące są teraz połączone w nowym panelu Controls. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Wszystkie codzienne elementy sterujące są teraz połączone w nowym panelu Controls. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Waty i ampery</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Waty i ampery</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Można teraz przełączać między watami i amperami. Wybierz jednostkę, która najlepiej odpowiada Twoim preferencjom.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Można teraz przełączać między watami i amperami. Wybierz jednostkę, która najlepiej odpowiada Twoim preferencjom.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Dowiedz się więcej</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Dowiedz się więcej</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Kliknij poniższy link, aby dowiedzieć się więcej o Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Kliknij poniższy link, aby dowiedzieć się więcej o Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;.</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Zeskanuj kod QR, aby dowiedzieć się więcej o Renewed UI.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Zeskanuj kod QR, aby dowiedzieć się więcej o Renewed UI.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Gotowe</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Gotowe</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>następnie</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>następnie</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Błąd: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Błąd: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Aktywny błąd</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Aktywny błąd</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Całkowity czas pracy generatora (godziny)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Całkowity czas pracy generatora (godziny)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Strona startowa</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Strona startowa</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Interfejs użytkownika</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Interfejs użytkownika</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Interfejs użytkownika (konsola zdalna)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Interfejs użytkownika (konsola zdalna)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 zaktualizowany</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 zaktualizowany</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>Interfejs użytkownika przełączy się na %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>Interfejs użytkownika przełączy się na %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 jest ustawione na %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Ten falownik fotowoltaiczny obsługuje ograniczanie mocy. Wyłącz to ustawienie, jeśli przeszkadza ono w normalnej pracy.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 jest ustawione na %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Naciśnij "OK", aby ponownie uruchomić komputer</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Naciśnij &quot;OK&quot;, aby ponownie uruchomić komputer</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Przywracanie ustawień fabrycznych Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Przywracanie ustawień fabrycznych Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Czy na pewno chcesz przywrócić ustawienia fabryczne Node-RED? Spowoduje to usunięcie wszystkich przepływów.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Czy na pewno chcesz przywrócić ustawienia fabryczne Node-RED? Spowoduje to usunięcie wszystkich przepływów.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Status połączenia</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Status połączenia</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Stan połączenia (kanał HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Stan połączenia (kanał HTTPS)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Status połączenia (kanał HTTP)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Status połączenia (kanał HTTP)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Status połączenia (kanał czasu rzeczywistego MQTT)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Status połączenia (kanał czasu rzeczywistego MQTT)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Status połączenia (kanał MQTT RPC)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Status połączenia (kanał MQTT RPC)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Automatyczne uruchamianie - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Automatyczne uruchamianie - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Wartość dezaktywująca</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Wartość dezaktywująca</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Nie działa</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Nie działa</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Utrata łączności</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Utrata łączności</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>Stan SOC</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>Stan SOC</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>Stan obciążenia prądem przemiennym</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>Stan obciążenia prądem przemiennym</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Stan naładowania akumulatora</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Stan naładowania akumulatora</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Stan napięcia akumulatora</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Stan napięcia akumulatora</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Stan przeciążenia falownika</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Stan przeciążenia falownika</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Ładowanie/rozładowywanie wyłączone</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Ładowanie/rozładowywanie wyłączone</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Ładowanie wyłączone</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Ładowanie wyłączone</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Wyłączone rozładowanie</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Wyłączone rozładowanie</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Krótki</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Spodenki (panel boczny otwarty)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Spodenki (panel boczny otwarty)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Przegląd</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Poziomy (zbiorniki)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Poziomy (zbiorniki)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Poziomy (Środowisko)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Poziomy (Środowisko)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Lista akumulatorów</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Lista akumulatorów</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>Urządzenie GX zostało zaktualizowane</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>Urządzenie GX zostało zaktualizowane</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Po %n minutach</numerusform>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Po %n minutach</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Przejdź do tej strony po uruchomieniu aplikacji.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Przejdź do tej strony po uruchomieniu aplikacji.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Limit czasu</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Limit czasu</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Powrót do strony startowej, gdy aplikacja jest nieaktywna.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Powrót do strony startowej, gdy aplikacja jest nieaktywna.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Po minucie bezczynności bieżąca strona zostanie wybrana jako strona początkowa, jeśli znajduje się na tej liście.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Po minucie bezczynności bieżąca strona zostanie wybrana jako strona początkowa, jeśli znajduje się na tej liście.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Ten limit prądu jest ustalony w konfiguracji systemu. Nie można go regulować.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Ten limit prądu jest ustalony w konfiguracji systemu. Nie można go regulować.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Tryb jest ustalony w konfiguracji systemu. Nie można go dostosować.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Tryb jest ustalony w konfiguracji systemu. Nie można go dostosować.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Funkcja uruchamiania/zatrzymywania agregatu nie jest włączona, przejdź do ustawień przekaźnika i ustaw funkcję na "Uruchamianie/zatrzymywanie agregatu".</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Czas Standardowy Maroko</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Czas Standardowy Zach. Afryki Centralnej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Czas Standardowy Afryki Południowej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Czas Standardowy Namibii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Czas Standardowy Egiptu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Czas Standardowy Afryki Wsch.</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Czas Standardowy Agrentyny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Czas Standardowy Wsch. Ameryki Południowej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Czas Standardowy Grenlandii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Czas Standardowy Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Czas Standardowy Nowej Fundlandii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Ameryka Pd. Czas Standardowy Wschodni</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Czas Standardowy Atlantycki</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Czas Standardowy Brazylii Centralnej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Ameryka Pd. Czas Standardowy Pacyficzny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Czas Standardowy Paragwaju</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Ameryka Pd. Czas Standardowy Zachodni</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Czas Standardowy Wenezueli</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Czas Standardowy Wschodni</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Ameryka Pd. Czas Standardowy Pacyficzny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Czas Standardowy Wschodnich USA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Czas Standardowy Kanadyjski Centralny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Czas Standardowy Ameryki Centralnej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Czas Standardowy Centralny (Meksyk)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Czas Standardowy Centralny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Czas Standardowy Górski (Meksyk)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Czas Standardowy Górski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>USA Czas Standardowy Górski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Czas Standardowy Pacyficzny (Meksyk)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Czas Standardowy Pacyficzny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Czas Standardowy Alaski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawajski Aleucki</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Czas Standardowy Nowej Zelandii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Czas Standardowy Środkowo-Pacyficzny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Czas Standardowy Zachodniego Pacyfiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Czas Standardowy Australii Zachodniej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Pd.-Zach.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Centralnej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Zachodniej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Czas Standardowy Afryki Wschodniej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Ameryka Pd. Czas Standardowy Pacyficzny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Ameryka Pd. Czas Standardowy Zachodni</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Czas Standardowy Europy Zach.</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Czas Standardowy Kamczatki</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Czas Standardowy Magadanu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Czas Standardowy Władywostoku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Czas Standardowy Jakucka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Czas Standardowy Tokio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Czas Standardowy Korei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Czas Standardowy Singapuru</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Czas Standardowy Ułanbator</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Czas Standardowy Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Pn. Azja Czas Standardowy Wschodni</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Czas Standardowy Chiński</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Pd.-Wsch.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Północnej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Czas Standardowy Birmy</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Pn.-Centr.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Centralnej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Czas Standardowy Bangladeszu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Czas Standardowy Nepalu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Czas Standardowy Sri Lanki</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Czas Standardowy Indii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Czas Standardowy Azji Zachodniej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Czas Standardowy Pakistanu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Czas Standardowy Jekaterynburga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Czas Standardowy Gruziński</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Czas Standardowy Kaukaski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Czas Standardowy Azerbejdżanu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Czas Standardowy Arabski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Czas Standardowy Afganistanu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Czas standardowy Iranu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Czas Standardowy Arabski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Czas Standardowy Arabski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Czas Standardowy Syrii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Czas Standardowy Środkowego Wsch.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Czas Standardowy Jordanii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Czas Standardowy Izraelu</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Czas Standardowy Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Czas Standardowy Azorów</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Czas Standardowy Zielonego Przylądka</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Czas Standardowy Tasmanii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Czas Standardowy Australii Wsch.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Australijski Czas Standardowy Wsch.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Czas Standardowy Australii Centr.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Australijski Czas Standardowy Centr.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Czas Standardowy Australii Zach.</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT </translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Czas Standardowy Środkowo-Atlantycki</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Czas Standardowy Linii Daty</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Czas Standardowy GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Czas Standardowy Europy Centralnej</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Czas Standardowy Środkowoeuropejski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Czas Standardowy Romance</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Czas Standardowy Europy Zach.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Czas Standardowy Europy Wsch.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Czas Standardowy FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Czas Standardowy GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Czas Standardowy Białorusi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Czas Standardowy Rosyjski</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Czas Standardowy Turecki</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Czas Standardowy Mauritiusu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Czas Standardowy Wyspy Bożego Narodzenia</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Czas Standardowy Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Czas Standardowy Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Czas Standardowy Nowej Zelandii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Czas Standardowy Środkowo-Pacyficzny</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Czas Standardowy Zachodniego Pacyfiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Czas Standardowy Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Czas Standardowy Hawajów</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Czas Standardowy Wyspy Wielkanocnej</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Funkcja uruchamiania/zatrzymywania agregatu nie jest włączona, przejdź do ustawień przekaźnika i ustaw funkcję na &quot;Uruchamianie/zatrzymywanie agregatu&quot;.</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznany</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Uzysk solarny</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Wejście DC</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">Obciążenia AC</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">Obciążenia DC</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Przegląd</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Stan</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Uzysk całkowity</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Uzysk systemu</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Tylko alarm</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarmy i ostrzeżenia</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Ostrzeżenie</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Brak błędu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Nieznany błąd: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Nieznany błąd: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Brak błędu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Błąd inicjalizacji akumualtora</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Błąd inicjalizacji akumualtora</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Brak podłączonych akumulatorów</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Brak podłączonych akumulatorów</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Nieznany akumulator</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Nieznany akumulator</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Różne rodzaje akumulatorów</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Różne rodzaje akumulatorów</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Liczba aku. nieprawdłowa</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Liczba aku. nieprawdłowa</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt nieznaleziony</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt nieznaleziony</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Błąd pomiaru aku.</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Błąd pomiaru aku.</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Wewnętrzny błąd obliczeniowy</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Wewnętrzny błąd obliczeniowy</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Liczba aku. w szeregu nieprawidłowa</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Liczba aku. w szeregu nieprawidłowa</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Błąd sprzętowy</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Błąd sprzętowy</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Błąd układu Watchdog</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Błąd układu Watchdog</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Nadmierne napięcie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Nadmierne napięcie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Za niskie napięcie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Za niskie napięcie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Nadmierna temperatura</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Nadmierna temperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Za niska temperatura</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Za niska temperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Czuwanie w stanie niedoładowania</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Czuwanie w stanie niedoładowania</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Błąd ADC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Błąd ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Błąd komunik. aku.</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Błąd komunik. aku.</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Błąd ładowania wstępnego</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Błąd ładowania wstępnego</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Błąd stycznika bezpieczeństwa</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Błąd stycznika bezpieczeństwa</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Błąd aktualizacji aku.</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Błąd aktualizacji aku.</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Błąd przewodu BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Błąd przewodu BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Awaria napięcia odniesienia</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Awaria napięcia odniesienia</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Nieprawidłowe napięcie systemowe</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Nieprawidłowe napięcie systemowe</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Limit czasu ładowania wstępnego</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Limit czasu ładowania wstępnego</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Awaria ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Awaria ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Utrata danych kalibracyjnych</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Utrata danych kalibracyjnych</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Ustawienia nieważne</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Ustawienia nieważne</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Blokada</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Blokada</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Awaryjny stop</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Awaryjny stop</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Limit czasu komunikacji</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Limit czasu komunikacji</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Blokada bezpieczeństwa</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Blokada bezpieczeństwa</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Przekroczenie temperatury terminala</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Przekroczenie temperatury terminala</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Wysoka temperatura aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Wysokie napięcie aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Tsense aku. źle podłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Brak Tsense aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Vsense aku. źle podłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Brak Vsense aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Wysokie straty w przewodach aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Niskie napięcie aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Wysokie napięcie tętniące aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Niski SOC akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Problem z napięciem środkowego punktu akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Zbyt niska temperatura aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Wysoka temperatura ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Nadmierny prąd ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Ujemny prąd ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Upłynął czas fazy Bulk ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problem z czujnikiem prądu ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Wewn. czujnik temp. źle podłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Brak wewn. czujnika temp.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Nie wykryto wentylatora ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Nadmierny prąd wentylatora ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Przegrzanie terminala ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Zwarcie w ładowarce</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Problem ze stopniem mocy ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Zabezpieczenie przed przeładowaniem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Wysokie napięcie wejściowe</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Nadmierny prąd wejściowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Nadmierna moc wejściowa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Problem z polaryzacją wejścia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Brak napięcia wejściowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Wyłączenie wejścia (bez ponawiania)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Wyłączenie wejścia (ponowienie)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Wewnętrzna awaria wejścia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Awaria izolacji PV</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Wykryto błąd uziemienia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Przeciążenie inwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Za wysoka temp. inwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Prąd szczytowy inwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Wewnętrzny poziom DC inwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Błędny poziom ACout inwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Błąd stopnia mocy inwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Inwerter podłączony do AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Błąd testu przekaźnika ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Błąd testu przekaźnika ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Urządzenie zniknęło</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Niekompatybilne urządzenie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Utrata połączenia z BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Sieć źle skonfigurowana</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Obrót fazowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Wiele wejść AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Przeciążenie fazy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Błąd zapisu w pamięci</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Zbyt wysoka temp. procesora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Utracona łączność</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Utrata danych kalibracyjnych</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Niekompatybilne oprogramowanie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Niekompatybilny sprzęt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Ustawienia nieważne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Błąd napięcia referencyjnego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Awaria testera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Historia nieważna</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Nieprawidłowe liczniki kWh</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Błąd napięcia DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Błąd sensora GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Błąd zasilania 3V3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Błąd zasilania 5V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Błąd zasilania 12V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Błąd zasilania 15V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Wyłączenie wejścia PV</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Ustaw przełącznik w pozycji odblokowanej, aby zmodyfikować ustawienia.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Użyj źródła danych D-Bus: połącz się z podanym adresem D-Bus.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Użyj źródła danych D-Bus: połącz się z domyślnym adresem D-Bus</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Użyj źródła danych MQTT: połącz się z określonym adresem brokera MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>ID portalu urządzenia źródła danych MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>ID portalu</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Fragment hosta internetowego MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>fragment</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Nazwa użytkownika źródła danych MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>użytkownik</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Hasło źródła danych MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>przejście</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Token źródła danych MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>token</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Włącz licznik FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Pomiń ekran powitalny</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Użyj próbnego źródła danych do testowania.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Urządzenie wyłączone</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Mieszane stare/nowe MK2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Oczekiwany błąd urządzeń</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Nie wykryto innego urządzenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Przepięcie na wyjściu AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Błąd programu DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS bez asystenta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Test przekaźnika uziemienia nie powiódł się</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Błąd synchronizacji czasu systemowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Błąd testu przekaźnika sieciowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Niedopasowanie konfiguracji z drugim mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Błąd transmisji urządzenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Oczekiwanie na konfigurację lub brak adaptera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Brak matrycy fazowej</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Wystąpiło przepięcie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Slave nie ma wejścia AC!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Urządzenie nie może być Slave</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Zainicjowanie ochrony systemu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Niekompatybilność oprogramowania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Błąd wewnętrzny</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Niepowodzenie testu przekaźnika uniemożliwia połączenie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Błąd VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd: </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Błąd wewnętrzny</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Wysoka temperatura aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Wysokie napięcie aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Niskie napięcie aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Napięcie aku. przekroczyło skonfigurowane maksimum</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Wysoka temperatura alternatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Wysokie obroty alternatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Wysoka temperatura napędu polowego FET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Brak wymaganego czujnika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Niskie napięcie alternatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Zakres wysokiego napięcia alternatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Napięcie alternatora przekroczyło skonfigurowane maksimum</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Wysokie napięcie alternatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Akumulator odłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Odłączenie przy wysokim napięciu aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Stan aku. poza zasięgiem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Zbyt wiele BMS-ów</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Akumulator zaraz się rozłączy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Zbyt wiele urządzeń do śledzenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Odłączenie przy niskim napięciu aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Odłączenie przy wysokim prądzie aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Odłączenie przy wysokiej temp. aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Odłączenie przy niskiej temp. aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Utrata połączenia z BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC Wyłączone</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>Konwerter DC/DC niegotowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC wysokie napięcie pierwotne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC niskie napięcie pierwotne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC wysokie napięcie wtórne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC niskie napięcie wtórne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC wysoka temperatura</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>Nieprawidłowa konfiguracja DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Uszkodzony czujnik temperatury akumulatora</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Nieznany błąd:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Brak błędu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Wysoka temperatura aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Wysokie napięcie aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Tsense aku. źle podłączony</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Brak Tsense aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Vsense aku. źle podłączony</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Brak Vsense aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Wysokie straty w przewodach aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Niskie napięcie aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Wysokie napięcie tętniące aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Niski SOC akumulatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Problem z napięciem środkowego punktu akumulatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Zbyt niska temperatura aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Wysoka temperatura ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Nadmierny prąd ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Ujemny prąd ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Upłynął czas fazy Bulk ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Problem z czujnikiem prądu ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Wewn. czujnik temp. źle podłączony</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Brak wewn. czujnika temp.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Nie wykryto wentylatora ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Nadmierny prąd wentylatora ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Przegrzanie terminala ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Zwarcie w ładowarce</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Problem ze stopniem mocy ładowarki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Zabezpieczenie przed przeładowaniem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Wysokie napięcie wejściowe</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Nadmierny prąd wejściowy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Nadmierna moc wejściowa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Problem z polaryzacją wejścia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Brak napięcia wejściowego</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Wyłączenie wejścia (bez ponawiania)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Wyłączenie wejścia (ponowienie)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Wewnętrzna awaria wejścia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Awaria izolacji PV</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Wykryto błąd uziemienia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Przeciążenie inwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Za wysoka temp. inwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Prąd szczytowy inwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Wewnętrzny poziom DC inwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Błędny poziom ACout inwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Błąd stopnia mocy inwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Inwerter podłączony do AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Błąd testu przekaźnika ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Błąd testu przekaźnika ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Urządzenie zniknęło</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Niekompatybilne urządzenie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Utrata połączenia z BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Sieć źle skonfigurowana</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Obrót fazowy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Wiele wejść AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Przeciążenie fazy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Błąd zapisu w pamięci</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Zbyt wysoka temp. procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Utracona łączność</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Utrata danych kalibracyjnych</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Niekompatybilne oprogramowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Niekompatybilny sprzęt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Ustawienia nieważne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Błąd napięcia referencyjnego</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Awaria testera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Historia nieważna</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Nieprawidłowe liczniki kWh</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Błąd napięcia DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Błąd sensora GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>Błąd zasilania 3V3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>Błąd zasilania 5V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>Błąd zasilania 12V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>Błąd zasilania 15V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Wyłączenie wejścia PV</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Nieznany błąd:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>Zbyt niskie napięcie AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>Zbyt niskie napięcie AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Zbyt wysokie napięcie AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Zbyt wysokie napięcie AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Za niska częstotliwość AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Zbyt niska częstotliwość AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Za wysoka częstotliwość AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Zbyt wysoka częstotliwość AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>Za wysoki prąd AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>Zbyt wysoki prąd AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Za wysoka moc AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>Za wysoka moc AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Wyłącznik awaryjny</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Za wysoki prąd serwomechanizmu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Zbyt niskie ciśnienie oleju</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Za wysokie ciśnienie oleju</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Za niska temperatura silnika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Za wysoka temperatura silnika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Za niska temperatura uzwojenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Zbyt wysoka temperatura uzwojenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Zbyt niska temperatura spalin</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Za wysoka temperatura spalin</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Niska temperatura elektroniki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Wysoka temperatura elektroniki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Zbyt niskie napięcie rozrusznika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Zbyt wysoki prąd rozrusznika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Zbyt niskie napięcie żarzenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Zbyt wysoki prąd żarzenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Zbyt wysokie napięcie układu Cold-Start-Aid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Zbyt wysoki prąd zimnego rozruchu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Zbyt niskie napięcie magnesu przytrzymującego paliwo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Zbyt wysoki prąd magnesu trzymającego paliwo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Zbyt niskie napięcie cewki zatrzymania elektromagnesu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Za wysoki prąd zwoju podtrzymującego cewki gaszenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Zbyt niskie napięcie cewki elektromagnesu zatrzymania </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Zbyt wysoki prąd cewki hamulcowej.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Zbyt niskie napięcie wentylatora/pompy wodnej</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Zbyt wysoki prąd wentylatora/pompy wodnej</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Niskie napięcie czujnika prądu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Wysoki prąd czujnika prądu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Zbyt niskie napięcie wyjściowe Boost</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Za wysoki prąd wyjścia doładowania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Zbyt niskie napięcie zasilania magistrali</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Zbyt wysoki prąd zasilania magistrali</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Zbyt niskie napięcie akumulatora rozruchowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Za wysokie napięcie akumulatora rozruchowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Za niskie obroty</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Za wysokie obroty</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Nieoczekiwane zatrzymanie/problem z dopływem paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Zbyt niskie napięcie stycznika zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Za wysoki prąd stycznika mocy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>Zbyt niskie napięcie AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Za wysokie napięcie AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>Za niska częstotliwość AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Częstotliwość AC L2 za wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>Za wysoki prąd AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>Zbyt wysoka moc AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Zbyt niskie napięcie AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>Za wysokie napięcie AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Za niska częstotliwość AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Za wysoka częstotliwość AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>Prąd zmienny L3 za wysoki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>Za wysoka moc AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Zbyt niskie napięcie wyjściowe falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Zbyt wysoki prąd wyjściowy falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Zbyt niskie napięcie na wyjściu uniwersalnym (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Zbyt wysoki prąd wyjścia uniwersalnego (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Zbyt niskie napięcie na wyjściu uniwersalnym (5A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Zbyt wysoki prąd wyjścia uniwersalnego (5A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Niskie napięcie AGT DC 1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Napięcie AGT DC 1 wysokie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>Prąd stały AGT 1 niski</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>Prąd stały AGT 1 wysoki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Niskie napięcie AGT DC 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Napięcie AGT DC 2 wysokie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>Prąd stały AGT 2 niski</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>Prąd stały AGT 2 wysoki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Chłodnica AGT B6 niska</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>Chłodnica AGT B6 wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>Szyna AGT B6 (-) niska</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>Szyna AGT B6 (-) wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>Szyna AGT B6 (+) niska</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>Szyna AGT B6 (+) wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Zbyt niska temperatura paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Zbyt wysoka temperatura paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Za niski poziom paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Zagubiono jednostkę sterującą</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Zagubiono panel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Potrzebny serwis</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Utracono moduł 3-fazowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Zagubiono moduł AGT</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Błąd synchronizacji</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Utrata zewnętrznego ECU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Filtr powietrza dolotowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Komunikat diagnostyczny (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Utracono moduł synchr.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Nie udało się zrównoważyć obciążenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Tryb synchronizacji wyłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Czerwone światło stopu (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Bursztynowe światło ostrzegawcze (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Lampka kontrolna awarii (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Lampa ochronna (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Nieprawidłowe pole wirujące</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Utrata czujnika poziomu paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Rozruch bez falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Autobus nr 1 nie działa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Odrzucono wniosek o rozpoczęcie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Odmowa zdalnego uruchamiania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Wymuszone wyłączenie przekaźnika obciążenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Moduł synchronizacji jest offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Utracony BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Niskie/odwrotne napięcie obwodu pośredniego konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Niski prąd obwodu pośredniego konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Niskie napięcie wstępnego ładowania DC konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Wysokie napięcie wstępnego ładowania DC konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Błąd sterownika konwertera IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Błąd przetwornika Pętla sterowania mocą</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Wykrywanie częstotliwości AC konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Błąd wartości kontrolnej konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Zmieniono ustawienie fabryczne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parametr zmieniony w trybie administratora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Interwencja ręczna (dodatkowy system)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Init failed</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Wysoka temperatura falownika L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Wysoka temperatura falownika L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Wysoka temperatura falownika L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Wysoka temperatura obwodu pośredniego falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Przeciążenie falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Utrata komunikacji z inwerterem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Przeciążenie DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Przepięcie DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Brak połączenia</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Nieznany błąd: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Ciśnienie oleju</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Nadmierna temperatura głowicy cylindrów</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Kontrola ładowania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Prędkość wyższa niż oczekiwana</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Nadmierna prędkość</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Temperatura oleju wyższa niż oczekiwano</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Obwód otwarty / zwarcie do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Zwarcie temperatury do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analogowa wartość zadana wysoka / zwarcie do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analogowa wartość zadana niska / zwarcie do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Limit czasu odbioru komunikatu TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Limit czasu odbioru wiadomości CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Wysokie napięcie baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Niskie napięcie akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Zniekształcony sygnał prędkości</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Wysokie wewnętrzne zasilanie czujnika 5V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Niski poziom zasilania wewnętrznego czujnika 5 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Wysokie ciśnienie barometryczne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Niskie ciśnienie barometryczne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Zwarcie wyjściowej pompy paliwa do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Zwarcie wyjściowej pompy paliwa do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Zwarcie wyjściowej świecy żarowej do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Zwarcie wyjściowej świecy żarowej do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Obwód otwarty wtryskiwacza/zwarcie strony dolnej do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Wewnętrzne zwarcie cewki wtryskiwacza</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Zwarcie dolnej strony wtryskiwacza do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Godziny pracy wygasły</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Awaria procesora</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Nieznany błąd:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Bateria</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Bateria</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Lodówka</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Lodówka</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Ogólne</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Ogólne</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Pokój</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Pokój</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Na zewnątrz</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Na zewnątrz</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Nagrzewnica wodna</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Nagrzewnica wodna</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Zamrażarka</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Zamrażarka</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Nieznany błąd:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Brak błędu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>Zbyt niskie napięcie AC L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>Zbyt niskie napięcie AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>Zbyt wysokie napięcie AC L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>Zbyt wysokie napięcie AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>Za niska częstotliwość AC L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>Zbyt niska częstotliwość AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>Za wysoka częstotliwość AC L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>Zbyt wysoka częstotliwość AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>Za wysoki prąd AC L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>Zbyt wysoki prąd AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>Za wysoka moc AC L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>Za wysoka moc AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Wyłącznik awaryjny</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Za wysoki prąd serwomechanizmu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Zbyt niskie ciśnienie oleju</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Za wysokie ciśnienie oleju</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Za niska temperatura silnika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Za wysoka temperatura silnika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Za niska temperatura uzwojenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Zbyt wysoka temperatura uzwojenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Zbyt niska temperatura spalin</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Za wysoka temperatura spalin</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Niska temperatura elektroniki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Wysoka temperatura elektroniki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Zbyt niskie napięcie rozrusznika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Zbyt wysoki prąd rozrusznika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Zbyt niskie napięcie żarzenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Zbyt wysoki prąd żarzenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Zbyt wysokie napięcie układu Cold-Start-Aid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Zbyt wysoki prąd zimnego rozruchu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Zbyt niskie napięcie magnesu przytrzymującego paliwo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Zbyt wysoki prąd magnesu trzymającego paliwo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Zbyt niskie napięcie cewki zatrzymania elektromagnesu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Za wysoki prąd zwoju podtrzymującego cewki gaszenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Zbyt niskie napięcie cewki elektromagnesu zatrzymania </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Zbyt wysoki prąd cewki hamulcowej.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Zbyt niskie napięcie wentylatora/pompy wodnej</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Zbyt wysoki prąd wentylatora/pompy wodnej</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Niskie napięcie czujnika prądu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Wysoki prąd czujnika prądu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Zbyt niskie napięcie wyjściowe Boost</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Za wysoki prąd wyjścia doładowania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Zbyt niskie napięcie zasilania magistrali</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Zbyt wysoki prąd zasilania magistrali</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Zbyt niskie napięcie akumulatora rozruchowego</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Za wysokie napięcie akumulatora rozruchowego</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Za niskie obroty</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Za wysokie obroty</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Nieoczekiwane zatrzymanie/problem z dopływem paliwa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Zbyt niskie napięcie stycznika zasilania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Za wysoki prąd stycznika mocy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>Zbyt niskie napięcie AC L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>Za wysokie napięcie AC L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>Za niska częstotliwość AC L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>Częstotliwość AC L2 za wysoka</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>Za wysoki prąd AC L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>Zbyt wysoka moc AC L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>Zbyt niskie napięcie AC L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>Za wysokie napięcie AC L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>Za niska częstotliwość AC L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>Za wysoka częstotliwość AC L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>Prąd zmienny L3 za wysoki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>Za wysoka moc AC L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Zbyt niskie napięcie wyjściowe falownika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Zbyt wysoki prąd wyjściowy falownika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Zbyt niskie napięcie na wyjściu uniwersalnym (1A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Zbyt wysoki prąd wyjścia uniwersalnego (1A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Zbyt niskie napięcie na wyjściu uniwersalnym (5A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Zbyt wysoki prąd wyjścia uniwersalnego (5A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>Niskie napięcie AGT DC 1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>Napięcie AGT DC 1 wysokie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>Prąd stały AGT 1 niski</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>Prąd stały AGT 1 wysoki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Niskie napięcie AGT DC 2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Napięcie AGT DC 2 wysokie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>Prąd stały AGT 2 niski</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>Prąd stały AGT 2 wysoki</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>Chłodnica AGT B6 niska</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>Chłodnica AGT B6 wysoka</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>Szyna AGT B6 (-) niska</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>Szyna AGT B6 (-) wysoka</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>Szyna AGT B6 (+) niska</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>Szyna AGT B6 (+) wysoka</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Zbyt niska temperatura paliwa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Zbyt wysoka temperatura paliwa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Za niski poziom paliwa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Zagubiono jednostkę sterującą</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Zagubiono panel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Potrzebny serwis</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Utracono moduł 3-fazowy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Zagubiono moduł AGT</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Błąd synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Utrata zewnętrznego ECU</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Filtr powietrza dolotowego</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Komunikat diagnostyczny (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Utracono moduł synchr.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Nie udało się zrównoważyć obciążenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Tryb synchronizacji wyłączony</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Czerwone światło stopu (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Bursztynowe światło ostrzegawcze (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Lampka kontrolna awarii (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Lampa ochronna (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Nieprawidłowe pole wirujące</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Utrata czujnika poziomu paliwa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Rozruch bez falownika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Autobus nr 1 nie działa</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Odrzucono wniosek o rozpoczęcie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Odmowa zdalnego uruchamiania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Wymuszone wyłączenie przekaźnika obciążenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Moduł synchronizacji jest offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>Utracony BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Niskie/odwrotne napięcie obwodu pośredniego konwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Niski prąd obwodu pośredniego konwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Niskie napięcie wstępnego ładowania DC konwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Wysokie napięcie wstępnego ładowania DC konwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Błąd sterownika konwertera IGBT/MOSFET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Błąd przetwornika Pętla sterowania mocą</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Wykrywanie częstotliwości AC konwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Błąd wartości kontrolnej konwertera</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Zmieniono ustawienie fabryczne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parametr zmieniony w trybie administratora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Interwencja ręczna (dodatkowy system)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Init failed</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Watchdog</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Wysoka temperatura falownika L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Wysoka temperatura falownika L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Wysoka temperatura falownika L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Wysoka temperatura obwodu pośredniego falownika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Przeciążenie falownika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Utrata komunikacji z inwerterem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>Przeciążenie DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>Przepięcie DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Brak połączenia</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Brak błędu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Nieznany błąd: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Nieznany błąd:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Ciśnienie oleju</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Nadmierna temperatura głowicy cylindrów</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Kontrola ładowania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Prędkość wyższa niż oczekiwana</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Nadmierna prędkość</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Temperatura oleju wyższa niż oczekiwano</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Obwód otwarty / zwarcie do zasilania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Zwarcie temperatury do masy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Analogowa wartość zadana wysoka / zwarcie do zasilania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Analogowa wartość zadana niska / zwarcie do masy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Limit czasu odbioru komunikatu TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Limit czasu odbioru wiadomości CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Wysokie napięcie baterii</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Niskie napięcie akumulatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Zniekształcony sygnał prędkości</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Wysokie wewnętrzne zasilanie czujnika 5V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Niski poziom zasilania wewnętrznego czujnika 5 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Wysokie ciśnienie barometryczne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Niskie ciśnienie barometryczne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Zwarcie wyjściowej pompy paliwa do zasilania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Zwarcie wyjściowej pompy paliwa do masy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Zwarcie wyjściowej świecy żarowej do zasilania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Zwarcie wyjściowej świecy żarowej do masy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Obwód otwarty wtryskiwacza/zwarcie strony dolnej do masy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Wewnętrzne zwarcie cewki wtryskiwacza</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Zwarcie dolnej strony wtryskiwacza do zasilania</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Godziny pracy wygasły</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Awaria procesora</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Ustaw przełącznik w pozycji odblokowanej, aby zmodyfikować ustawienia.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Użyj źródła danych D-Bus: połącz się z podanym adresem D-Bus.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>adres</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Użyj źródła danych D-Bus: połącz się z domyślnym adresem D-Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Użyj źródła danych MQTT: połącz się z określonym adresem brokera MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>adres</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>ID portalu urządzenia źródła danych MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>ID portalu</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Fragment hosta internetowego MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>fragment</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Nazwa użytkownika źródła danych MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>użytkownik</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Hasło źródła danych MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>przejście</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Token źródła danych MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>token</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Włącz licznik FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Pomiń ekran powitalny</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Użyj próbnego źródła danych do testowania.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Czas Standardowy Maroko</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Czas Standardowy Zach. Afryki Centralnej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Czas Standardowy Afryki Południowej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Czas Standardowy Namibii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Czas Standardowy Egiptu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Czas Standardowy Afryki Wsch.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Czas Standardowy Agrentyny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Czas Standardowy Wsch. Ameryki Południowej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Czas Standardowy Grenlandii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Czas Standardowy Montevideo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Czas Standardowy Nowej Fundlandii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Ameryka Pd. Czas Standardowy Wschodni</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Czas Standardowy Atlantycki</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Czas Standardowy Brazylii Centralnej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Ameryka Pd. Czas Standardowy Pacyficzny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Czas Standardowy Paragwaju</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Ameryka Pd. Czas Standardowy Zachodni</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Czas Standardowy Wenezueli</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Czas Standardowy Wschodni</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Ameryka Pd. Czas Standardowy Pacyficzny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Czas Standardowy Wschodnich USA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Czas Standardowy Kanadyjski Centralny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Czas Standardowy Ameryki Centralnej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Czas Standardowy Centralny (Meksyk)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Czas Standardowy Centralny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Czas Standardowy Górski (Meksyk)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Czas Standardowy Górski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>USA Czas Standardowy Górski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Czas Standardowy Pacyficzny (Meksyk)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Czas Standardowy Pacyficzny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Czas Standardowy Alaski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hawajski Aleucki</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Czas Standardowy Nowej Zelandii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Czas Standardowy Środkowo-Pacyficzny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Czas Standardowy Zachodniego Pacyfiku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Czas Standardowy Australii Zachodniej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Pd.-Zach.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Centralnej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Zachodniej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Czas Standardowy Afryki Wschodniej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Ameryka Pd. Czas Standardowy Pacyficzny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Ameryka Pd. Czas Standardowy Zachodni</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Czas Standardowy Europy Zach.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Czas Standardowy Kamczatki</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Czas Standardowy Magadanu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Czas Standardowy Władywostoku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Czas Standardowy Jakucka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Czas Standardowy Tokio</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Czas Standardowy Korei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Czas Standardowy Singapuru</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Czas Standardowy Ułanbator</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Czas Standardowy Taipei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Pn. Azja Czas Standardowy Wschodni</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Czas Standardowy Chiński</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Pd.-Wsch.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Północnej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Czas Standardowy Birmy</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Pn.-Centr.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Centralnej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Czas Standardowy Bangladeszu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Czas Standardowy Nepalu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Czas Standardowy Sri Lanki</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Czas Standardowy Indii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Czas Standardowy Azji Zachodniej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Czas Standardowy Pakistanu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Czas Standardowy Jekaterynburga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Czas Standardowy Gruziński</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Czas Standardowy Kaukaski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Czas Standardowy Azerbejdżanu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Czas Standardowy Arabski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Czas Standardowy Afganistanu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Czas standardowy Iranu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Czas Standardowy Arabski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Czas Standardowy Arabski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Czas Standardowy Syrii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Czas Standardowy Środkowego Wsch.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Czas Standardowy Jordanii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Czas Standardowy Izraelu</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Czas Standardowy Greenwich</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Czas Standardowy Azorów</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Czas Standardowy Zielonego Przylądka</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Czas Standardowy Tasmanii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Czas Standardowy Australii Wsch.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Australijski Czas Standardowy Wsch.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Czas Standardowy Australii Centr.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Australijski Czas Standardowy Centr.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Czas Standardowy Australii Zach.</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT </translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Czas Standardowy Środkowo-Atlantycki</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Czas Standardowy Linii Daty</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>Czas Standardowy GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Czas Standardowy Europy Centralnej</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Czas Standardowy Środkowoeuropejski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Czas Standardowy Romance</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Czas Standardowy Europy Zach.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Czas Standardowy Europy Wsch.</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Czas Standardowy FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Czas Standardowy GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Czas Standardowy Białorusi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Czas Standardowy Rosyjski</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Czas Standardowy Turecki</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Czas Standardowy Mauritiusu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Czas Standardowy Wyspy Bożego Narodzenia</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Czas Standardowy Tonga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Czas Standardowy Fiji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Czas Standardowy Nowej Zelandii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Czas Standardowy Środkowo-Pacyficzny</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Czas Standardowy Zachodniego Pacyfiku</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Czas Standardowy Samoa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Czas Standardowy Hawajów</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Czas Standardowy Wyspy Wielkanocnej</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Błąd wewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Nieznany błąd: </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Błąd wewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Brak błędu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Wysoka temperatura aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Wysokie napięcie aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Niskie napięcie aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Napięcie aku. przekroczyło skonfigurowane maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Wysoka temperatura alternatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Wysokie obroty alternatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Wysoka temperatura napędu polowego FET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Brak wymaganego czujnika</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Niskie napięcie alternatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Zakres wysokiego napięcia alternatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Napięcie alternatora przekroczyło skonfigurowane maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Wysokie napięcie alternatora</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Akumulator odłączony</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Odłączenie przy wysokim napięciu aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Stan aku. poza zasięgiem</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Zbyt wiele BMS-ów</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Akumulator zaraz się rozłączy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Zbyt wiele urządzeń do śledzenia</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Odłączenie przy niskim napięciu aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Odłączenie przy wysokim prądzie aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Odłączenie przy wysokiej temp. aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Odłączenie przy niskiej temp. aku.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Utrata połączenia z BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC Wyłączone</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>Konwerter DC/DC niegotowy</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC wysokie napięcie pierwotne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC niskie napięcie pierwotne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC wysokie napięcie wtórne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC niskie napięcie wtórne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC wysoka temperatura</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>Nieprawidłowa konfiguracja DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Uszkodzony czujnik temperatury akumulatora</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_ro.ts
+++ b/i18n/venus-gui-v2_ro.ts
@@ -1,7383 +1,8025 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ro">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Dezactivat</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Dezactivat</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Invertor supraincarcat</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Invertor supraincarcat</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Putere</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Putere</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Oprit</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Oprit</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Auto</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Baterie</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectare</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Deconectat</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generator</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Tensiune ridicata baterie</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Tensiune ridicata baterie</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Invertor/Încărcător</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Invertor/Încărcător</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Tensiune scazuta baterie</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Tensiune scazuta baterie</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manual</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manual</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Niciuna</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Niciuna</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Pozitie</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Pozitie</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Viteza</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Viteza</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Stare</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Stare</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instalare %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instalare %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Eroare necunoscuta</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Eroare necunoscuta</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>SoC minim</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>SoC minim</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Necunoscut</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Introduceți parola</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Introduceți parola</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Apasa pentru a verifica</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Apasa pentru a verifica</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Retea</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Retea</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Producția de energie solară</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Producția de energie solară</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Control extern</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Control extern</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Rezervoare</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Rezervoare</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Mediu inconjurator</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Mediu inconjurator</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Nu există alerte curente</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Nu există alerte curente</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>General</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>General</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Data si ora</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Data si ora</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Configurare sistem</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Configurare sistem</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Afisare si limba</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Afisare si limba</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>Portal online VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>Portal online VRM</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Contoare energie</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Contoare energie</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>Invertoare PV</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>Invertoare PV</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Retea locala</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Retea locala</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>Modem GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>Modem GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Start/stop generator</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Start/stop generator</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Pompa de rezervor</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Pompa de rezervor</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Serviciul clienţi</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Serviciul clienţi</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Caracteristici ale Venus OS Large</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Caracteristici ale Venus OS Large</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Limita de viață a bateriei: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Limita de viață a bateriei: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Pornire automată</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Pornirea automată va fi dezactivată și generatorul nu va porni automat pe baza condițiilor configurate.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Pornirea automată va fi dezactivată și generatorul nu va porni automat pe baza condițiilor configurate.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Oprire manuală</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Oprire manuală</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>PORNIRE MANUALA</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>PORNIRE MANUALA</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Pozitie</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Pornire automată</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Pornire automată</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Comutatoare</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Comutatoare</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Nivel acces</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Nivel acces</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Utilizator</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Utilizator</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Utilizator si instalator</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Utilizator si instalator</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Administrator</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Administrator</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Service</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Service</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Resetați sistemul VE.Bus după dezactivarea DVCC</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Resetați sistemul VE.Bus după dezactivarea DVCC</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Limiteaza intensitatea de incarcare</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Limiteaza intensitatea de incarcare</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Curent de incarcare maxim</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Curent de incarcare maxim</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Foloeste %1 valoarea pentru pornire/oprire</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Foloeste %1 valoarea pentru pornire/oprire</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Porneşte când %1 este mai mare decât</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Porneşte când %1 este mai mare decât</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Porneşte când %1 este mai mică decât</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Porneşte când %1 este mai mică decât</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Opreşte când %1 este mai mare decât</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Opreşte când %1 este mai mare decât</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Opreşte când %1 este mai mică decât</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Opreşte când %1 este mai mică decât</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Eliminați adresa IP?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Eliminați adresa IP?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Conexiuni</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Conexiuni</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Produs</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Produs</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Nume</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Nume</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Nume</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>ID produs</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>ID produs</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Versiune Hardware</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Versiune Hardware</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Enhetsnavn</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Enhetsnavn</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Control de la distanta comutator dezactivat</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Control de la distanta comutator dezactivat</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Generatorul se afla in stare de avarie</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Generatorul se afla in stare de avarie</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Generator nedetectat pe intrarea AC</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Generator nedetectat pe intrarea AC</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Timp de functionare total de la ultima pornire de test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Timp de functionare total de la ultima pornire de test</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Timp ramas pana la urmatoarea pornire de test</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Timp ramas pana la urmatoarea pornire de test</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>In functionare</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>In functionare</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>PORNIRE MANUALA</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>PORNIRE MANUALA</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Porneste generator</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Porneste generator</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Timp de functionare zilnic</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Timp de functionare zilnic</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Valoarea trebuie sa fie mai mare decat valoarea de oprire</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Valoarea trebuie sa fie mai mare decat valoarea de oprire</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Valoarea trebuie sa fie mai mica decat valoarea de pornire</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Valoarea trebuie sa fie mai mica decat valoarea de pornire</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>Iesire AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>Iesire AC</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">Iesire AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Foloeste incarcarea AC pentru pornire/oprire</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Foloeste incarcarea AC pentru pornire/oprire</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Masuratori</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Masuratori</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Consum total</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Consum total</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Total iesire AC invertor</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Total iesire AC invertor</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Cea mai ridicata faza pe iesirea AC a invertorului</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Cea mai ridicata faza pe iesirea AC a invertorului</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Porneste cand puterea este mai ridicata decat</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Porneste cand puterea este mai ridicata decat</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Opreste dupa ce puterea este mai scazuta decat</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Opreste dupa ce puterea este mai scazuta decat</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Monitor baterie</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Monitor baterie</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Monitor indisponibil, defineste altul</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Monitor indisponibil, defineste altul</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Monitor baterie</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Monitor indisponibil, defineste altul</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>La pierderea comunicatiei</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>La pierderea comunicatiei</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Opreste genertorul</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Opreste genertorul</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Mentine generatorul in functionare</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Mentine generatorul in functionare</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Opriți generatorul în momentul în care est disponibilă intrarea de curent alternativ</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Opriți generatorul în momentul în care est disponibilă intrarea de curent alternativ</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>SOC baterie</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>SOC baterie</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Temperatura ridicata invertor</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Temperatura ridicata invertor</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Temperatura ridicata invertor</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Porneste la avertizarea de temperatura ridicata</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Porneste la avertizarea de temperatura ridicata</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Porneste la avertizarea de supraincarcare</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Porneste la avertizarea de supraincarcare</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Functionare periodica</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Functionare periodica</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Interval de functionare</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Interval de functionare</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 zi (zile)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 zi (zile)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Omite pornirea daca functioneaza de</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Omite pornirea daca functioneaza de</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Porneste intotdeauna</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Porneste intotdeauna</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Data inceput pornire periodica</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Data inceput pornire periodica</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Durata functionare (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Durata functionare (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Functionare pana cand bateriile sunt complet incarcate</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Functionare pana cand bateriile sunt complet incarcate</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (localizat)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (localizat)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS conectat dar pozitie nelocalizata</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS conectat dar pozitie nelocalizata</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>GPS neconectat</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>GPS neconectat</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Latitudine</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Latitudine</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Longitudine</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Longitudine</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Curs</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Curs</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Altitudine</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Altitudine</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Numar de sateliti</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Numar de sateliti</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Valoare referinta retea</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Valoare referinta retea</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Valoare referinta intare DC</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Valoare referinta intare DC</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Curent: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Curent: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Tensiune: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Tensiune: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Limite (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Limite (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Încărcare: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Încărcare: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Descărcare: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Descărcare: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Limite (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Limite (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Vizibil</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Vizibil</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Ascuns</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Ascuns</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Masuratorii auxiliare)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Masuratorii auxiliare)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Iesire %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Iesire %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Monitor baterie activ</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Monitor baterie activ</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Nume</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Introduceți numele</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Introduceți numele</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Introduceți numele</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Scanare continuă</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Scanare continuă</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Adaptoare Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Adaptoare Bluetooth</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Cod PIN</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Cod PIN</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Este posibil sa fie necesara inlaturarea conexiunii existente inainte de conectare.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Este posibil sa fie necesara inlaturarea conexiunii existente inainte de conectare.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Tip faza</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Tip faza</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Monofazat</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Monofazat</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Multifazat</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Multifazat</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>Invertor fotovoltaic pe faza 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>Invertor fotovoltaic pe faza 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>Invertor PV pe pozitia fazei 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>Invertor PV pe pozitia fazei 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>Profil CAN-bus</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>Profil CAN-bus</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Dezactivat</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>În funcțiune, dar fără servicii (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>În funcțiune, dar fără servicii (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Dispozitiv</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Dispozitiv</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA 2000-out</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA 2000-out</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Selector numar identificare</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Selector numar identificare</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Asteptati, schimbarea si verificarea numarului unic de sipozitiv dureaza ceva timp</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Asteptati, schimbarea si verificarea numarului unic de sipozitiv dureaza ceva timp</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Selectorul de mai sus stabilește ce bloc de numere de identitate unice trebuie utilizat pentru numerele de identitate unice NAME din câmpul PGN 60928 NAME. Schimbați numai în situația în care utilizați mai multe dispozitive GX într-o singură rețea VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Selectorul de mai sus stabilește ce bloc de numere de identitate unice trebuie utilizat pentru numerele de identitate unice NAME din câmpul PGN 60928 NAME. Schimbați numai în situația în care utilizați mai multe dispozitive GX într-o singură rețea VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Selectorul de deasupra configurează blocul de numere de identitate unice care trebuie utilizate pentru numărul de serie din câmpul DGN 60928 ADDRESS_CLAIM. Schimbați numai în situația în care utilizați mai multe dispozitive GX într-o singură rețea RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Selectorul de deasupra configurează blocul de numere de identitate unice care trebuie utilizate pentru numărul de serie din câmpul DGN 60928 ADDRESS_CLAIM. Schimbați numai în situația în care utilizați mai multe dispozitive GX într-o singură rețea RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Verifica numerele de identificare</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Verifica numerele de identificare</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Apasa pentru a verifica</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Există un alt dispozitiv conectat cu acest număr unic, vă rugăm să selectați un nou număr.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Există un alt dispozitiv conectat cu acest număr unic, vă rugăm să selectați un nou număr.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: Niciun alt dispozitiv conectat cu acest numar de identificare.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: Niciun alt dispozitiv conectat cu acest numar de identificare.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Stare interconectare</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Stare interconectare</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Luminozitate adaptiva</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Luminozitate adaptiva</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Luminozitate</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Luminozitate</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Timp oprire ecran</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Timp oprire ecran</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 sec</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 sec</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 sec</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 sec</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Niciodata</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Niciodata</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Mod de afișare</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Mod de afișare</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Întunecat</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Întunecat</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Luminos</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Luminos</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Nivele de vizualizare pe scurt</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Nivele de vizualizare pe scurt</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Limba</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Limba</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Schimbare limbă</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Schimbare limbă</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Afișarea energiei electrice</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Afișarea energiei electrice</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Putere (Wați)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Putere (Wați)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Curent (Amperi)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Curent (Amperi)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Unități</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Unități</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Nivel %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Nivel %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>°F</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>°F</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;ATENŢIE:&lt;/b&gt; Citiți manualul înainte de a efectua reglajul.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;ATENŢIE:&lt;/b&gt; Citiți manualul înainte de a efectua reglajul.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Limitare tensiune incarcare baterie gestionata</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Limitare tensiune incarcare baterie gestionata</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Tensiune de incarcare maxima</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Tensiune de incarcare maxima</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Sens comun tensiune</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Sens comun tensiune</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Sens comun temperatura</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Sens comun temperatura</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Senzor indisponibil, defineste altul</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Senzor indisponibil, defineste altul</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Senzor indisponibil, defineste altul</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Senzor utilizat</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Senzor utilizat</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Sens comun intensitate</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Sens comun intensitate</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Stare SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Stare SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Dezactivat (Control extern)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Dezactivat (Control extern)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Dezactivat (fara incarcatoare)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Dezactivat (fara incarcatoare)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Dezactivat (fara monitor baterie)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Dezactivat (fara monitor baterie)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Selectare automată</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Selectare automată</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Fără cotrol BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Fără cotrol BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Control BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Control BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Indisponibil, configurați altul</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Indisponibil, configurați altul</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Selectat automat</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Selectat automat</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Niciuna</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Data/ora lansarii</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Data/ora lansarii</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Actualizari online</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Actualizari online</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Instaleaza firmware de pe card SD/stick USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Instaleaza firmware de pe card SD/stick USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Copii de rezerva firmware salvate</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Copii de rezerva firmware salvate</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Verificați dacă există actualizări pe SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Verificați dacă există actualizări pe SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Firmware gasit</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Firmware gasit</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Instalare %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Instalare %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Apasa pentru a actualiza la %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Apasa pentru a actualiza la %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Apasa pentru a actualiza la %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>ata/ora lansarii</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>ata/ora lansarii</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Actualizare automata</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Actualizare automata</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Doar verifica</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Doar verifica</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Doar verifica si descarca</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Doar verifica si descarca</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Verifica si actualizeaza</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Verifica si actualizeaza</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Tip actualizare</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Tip actualizare</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Tip image</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Tip image</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normal</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normal</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Mare</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Mare</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Verifica actualizari</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Verifica actualizari</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Actualizare disponibila</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Actualizare disponibila</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Instalare %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Instalare %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Instalare %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Varianta actualizare data/timp</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Varianta actualizare data/timp</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Invertoare</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Invertoare</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Gaseste invertoare PV</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Gaseste invertoare PV</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Adresa IP detectata</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Adresa IP detectata</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Adauga manual adresa IP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Adauga manual adresa IP</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>Port TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>Port TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Multifazică</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Multifazică</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Faza divizta (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Faza divizta (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Arata</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Arata</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Doriți să rescanați pentru adrese IP?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Doriți să rescanați pentru adrese IP?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Rescaneaza</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Rescaneaza</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH din LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH din LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Asistenta la distanta</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Asistenta la distanta</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Tunel asistenta la distanta</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Tunel asistenta la distanta</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>IP si port pentru asistenta</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>IP si port pentru asistenta</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Deconectați-vă acum</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Reporniți acum</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Reporniți acum</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Dispozitivul a fost repornit.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Alarma acustica</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Alarma acustica</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Mod demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Mod demo</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>Demo ESS</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>Demo ESS</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Demo 1 Ambarcatiune/Rulota</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Demo 1 Ambarcatiune/Rulota</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Demo 2 Ambarcatiune/Rulota</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Demo 2 Ambarcatiune/Rulota</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Pornind modul demo se vor schimba anumite configurari iar interfata cu utilizatorul va deveni inutilizabila pentru cateva momente.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Pornind modul demo se vor schimba anumite configurari iar interfata cu utilizatorul va deveni inutilizabila pentru cateva momente.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Conditii</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Conditii</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Timp de functionare minim</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Timp de functionare minim</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Timp necesar pentru încălzire</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Timp necesar pentru încălzire</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Timp de răcire</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Timp de răcire</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Detecteaza generatorul pe intrarea AC</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Detecteaza generatorul pe intrarea AC</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Nicio intrare AC nu este definita ca generator. Mergi la pagina de configurare si defineste ca generator intrarea AC corespunzatoare, pentru a activa aceasta functionalitate.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Nicio intrare AC nu este definita ca generator. Mergi la pagina de configurare si defineste ca generator intrarea AC corespunzatoare, pentru a activa aceasta functionalitate.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Se va declansa o alarma cand pe intrarea AC a invertorului nu este detectata alimentarea de la generator. Asigura-te ca in pagina de configurari a generatorului este definita intrarea AC corespunzatoare.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Se va declansa o alarma cand pe intrarea AC a invertorului nu este detectata alimentarea de la generator. Asigura-te ca in pagina de configurari a generatorului este definita intrarea AC corespunzatoare.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Inceput ore de liniste</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Inceput ore de liniste</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Sfarsit ore de liniste</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Sfarsit ore de liniste</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Timp de rulare și service</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Timp de rulare și service</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Reseteaza timpul de functionare zilnic</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Reseteaza timpul de functionare zilnic</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Timpul de functionare zilnic a fost resetat</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Timpul de functionare zilnic a fost resetat</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Este posibila modificarea contoarelor in timpul functionarii generatorului</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Este posibila modificarea contoarelor in timpul functionarii generatorului</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Intervalul de service al generatorului (ore)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Intervalul de service al generatorului (ore)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Intervalul de timp de service setat la %1h. Folosiți butonul „Resetare temporizator service” pentru a reseta temporizatorul de service.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Intervalul de timp de service setat la %1h. Folosiți butonul „Resetare temporizator service” pentru a reseta temporizatorul de service.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Resetați cronometrul de service</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Resetați cronometrul de service</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Setari GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Setari GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Format</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Format</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Unitate de viteza</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Unitate de viteza</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilometri pe oră</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilometri pe oră</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Metri pe secundă</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Metri pe secundă</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Mile pe ora</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Mile pe ora</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Noduri</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Noduri</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Niciun modem GSM conectat</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Niciun modem GSM conectat</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Operator</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Operator</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Poate fi necesara configurarea setarilor APN mai jos pe aceasta pagina, contacteaza operatorul tau pentru detalii.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Poate fi necesara configurarea setarilor APN mai jos pe aceasta pagina, contacteaza operatorul tau pentru detalii.
 Daca tot nu functioneaza, verifica cartela sim intr-un telefon pentru a te asigura ca este functionala si ca poate fi utilizata pentru transfer de date.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Permite roaming</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Permite roaming</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Stare sim</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Stare sim</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM neintrodus</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM neintrodus</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN necesar</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN necesar</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK necesar</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK necesar</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Defectiune SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Defectiune SIM</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM ocupat</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM ocupat</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>SIM gresit</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>SIM gresit</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>PIN gresit</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>PIN gresit</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Pregatit</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Pregatit</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Eroare necunoscuta</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Implicit</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Implicit</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Foloseste APN-ul implicit</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Foloseste APN-ul implicit</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Nume APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Nume APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Utilizați autentificarea</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Utilizați autentificarea</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Nume de utilizator</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Nume de utilizator</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Auto-consum</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Auto-consum</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Niciun asistent ESS gasit</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Niciun asistent ESS gasit</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Masuratori retea</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Masuratori retea</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Contor extern</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Contor extern</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Invertor/încărcător</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Invertor/încărcător</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Iesirea AC a invertorului este utilizata</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Iesirea AC a invertorului este utilizata</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Reglementari multi-faza</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Reglementari multi-faza</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Total toate fazele</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Total toate fazele</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Faza individuala</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Faza individuala</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Fiecare fază este reglată pentru a atinge individual punctul de referință al rețelei (eficiența sistemului este diminuată).
+        <translation>Fiecare fază este reglată pentru a atinge individual punctul de referință al rețelei (eficiența sistemului este diminuată).
 
 ATENȚIE: Utilizați numai dacă este solicitat de către furnizorul de utilități.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Totalul tuturor fazelor este reglat în mod inteligent pentru a atinge punctul de setare al rețelei (eficiența sistemului este optimizată).
+        <translation>Totalul tuturor fazelor este reglat în mod inteligent pentru a atinge punctul de setare al rețelei (eficiența sistemului este optimizată).
 
 Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inactiv</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">SSE dinamic</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>SOC minim (exceptand deconectarea de la retea)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>SOC minim (exceptand deconectarea de la retea)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Limitarea SOC activa</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Limitarea SOC activa</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Sustine</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Încărcare</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Reducere a consumului de energie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Reducere a consumului de energie</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Doar peste SOC minim</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Doar peste SOC minim</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Întotdeauna</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Întotdeauna</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Descarcarea dezactivata</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Descarcarea dezactivata</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Incarcare lenta</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Incarcare lenta</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Sustine</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Sustine</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Încărcare</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Încărcare</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Limiteaza puterea de incarcare</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Limiteaza puterea de incarcare</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Putere de incarcare maxima</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Putere de incarcare maxima</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Limiteaza puterea invertorului</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Limiteaza puterea invertorului</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Putere maxima invertor</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Putere maxima invertor</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Valoare referinta retea</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Valoare referinta retea</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Injectare in retea</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Injectare in retea</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>PV conectat la AC - injecteaza suplusul</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>PV conectat la AC - injecteaza suplusul</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>PV conectat la DC - injecteaza suplusul</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>PV conectat la DC - injecteaza suplusul</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Limiteaza injectarea sistemului</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Limiteaza injectarea sistemului</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Injectare maxima</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Injectare maxima</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Limita de injectare activa</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Limita de injectare activa</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Intrari analogice</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Intrari analogice</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Intrari digitale</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Intrari digitale</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Intrare digitală %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Intrare digitală %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Pulsometru</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Pulsometru</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Alarma usa</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Alarma usa</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Pompa de santina</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Pompa de santina</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Alarma santina</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Alarma santina</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Alarma efractie</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Alarma efractie</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Alarma fum</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Alarma fum</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Alarma incendiu</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Alarma incendiu</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>Alarma CO2</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>Alarma CO2</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Senzori Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Senzori Bluetooth</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Rețineți că aceste caracteristici nu sunt acceptate oficial de către Victron. Vă rugăm să accesați community.victronenergy.com pentru întrebări.
+        <translation>Rețineți că aceste caracteristici nu sunt acceptate oficial de către Victron. Vă rugăm să accesați community.victronenergy.com pentru întrebări.
 
 Documentație la https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Server de Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Server de Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Server de Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Server de Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Activat (mod sigur)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Activat (mod sigur)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Amânat de %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Amânat de %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID portal VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID portal VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Interval inregistrare parametri</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Interval inregistrare parametri</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>o ora</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>o ora</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>doua ore</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>doua ore</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 ore</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 ore</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 ore</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 ore</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>o zi</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>o zi</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Utilizeaza conexiunea securizata (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Utilizeaza conexiunea securizata (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Ultimul contact</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Ultimul contact</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Text de răspuns neașteptat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Text de răspuns neașteptat</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Răspuns HTTP neașteptat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Răspuns HTTP neașteptat</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Pauză de conectare</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Pauză de conectare</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Eroare de conexiune</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Eroare de conexiune</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Eșec DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Eșec DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Eroare de rutare</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Eroare de rutare</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM indisponibil</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM indisponibil</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Eroare necunoscută</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Eroare necunoscută</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Mesaj de eroare: 
+        <translation>Mesaj de eroare: 
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Reporneste dispozitivul in cazul lipsei de contact</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Reporneste dispozitivul in cazul lipsei de contact</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Intarziere resetare in cazul lipsei de contact (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Intarziere resetare in cazul lipsei de contact (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Locatia stocarii</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Locatia stocarii</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Nicio memorie tampon activa</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Nicio memorie tampon activa</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Stocare interna</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Stocare interna</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Transfera</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Transfera</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Stocare externa</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Stocare externa</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Eroare necunoscuta</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Nicio eroare</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Nicio eroare</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Spatiu epuizat pe dispozitivul de stocare</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Spatiu epuizat pe dispozitivul de stocare</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Eroare IO</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Eroare IO</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Eroare atasare dispozitiv</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Eroare atasare dispozitiv</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Nu poate fi utilizat, contine imagine firmware.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Nu poate fi utilizat, contine imagine firmware.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>Card SD / stick USB nu permite scrierea</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>Card SD / stick USB nu permite scrierea</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Elibereaza spatiu de stocare</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Elibereaza spatiu de stocare</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>byte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>byte</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bytes</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bytes</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Inregistrari stocate</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Inregistrari stocate</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 înregistrări</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 înregistrări</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Cea mai veche inregistrare</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Cea mai veche inregistrare</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Activeaza Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Activeaza Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Nicio eroare raportata</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Nicio eroare raportata</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Ora ultimei erori</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Ora ultimei erori</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Servicii disponibile</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Servicii disponibile</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>ID unitate: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>ID unitate: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Functie (Releu 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Functie (Releu 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Functie</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Functie</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Releu alarma</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Releu alarma</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Pompa de rezervor</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polaritate releu alarma</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polaritate releu alarma</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normal deschis</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normal deschis</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normal inchis</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normal inchis</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Releu 1 activ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Releu 1 activ</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Releu activ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Releu activ</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Functie (Releu 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Functie (Releu 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Releu 2 activ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Releu 2 activ</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Reguli de control al temperaturii</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Reguli de control al temperaturii</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Activarea releului la temperatură</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Activarea releului la temperatură</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Niciun releu nu este configurat pentru a fi activat de temperatură. Accesați pagina de setare a releului din meniul principal de setări și setați funcția releului la \”Temperatură\”.</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Niciun releu nu este configurat pentru a fi activat de temperatură. Accesați pagina de setare a releului din meniul principal de setări și setați funcția releului la \”Temperatură\”.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Aceasta optiune iti permite sa schimbi intre versiunea curenta si versiunea anterioara. Nu este necesar card SD sau conexiune la internet.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Aceasta optiune iti permite sa schimbi intre versiunea curenta si versiunea anterioara. Nu este necesar card SD sau conexiune la internet.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Firmware %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Apasa pentru a porni</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Apasa pentru a porni</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Repornind la %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Repornind la %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Schimbarea versiunii firmware nu este posibilă dacă actualizarea automată este configurată la „Verificați și actualizați”. Setați actualizarea automată la „Dezactivat” sau „Numai verificare” pentru a activa această opțiune.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Schimbarea versiunii firmware nu este posibilă dacă actualizarea automată este configurată la „Verificați și actualizați”. Setați actualizarea automată la „Dezactivat” sau „Numai verificare” pentru a activa această opțiune.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Salvarea firmware-ului este indisponibila</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Salvarea firmware-ului este indisponibila</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Consola pe VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>Magistrala CAN pe TCP/IP (Depanare)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>Magistrala CAN pe TCP/IP (Depanare)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Alimentare din rețea</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Alimentare din rețea</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Vehicul</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Vehicul</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Ambarcatiune</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Ambarcatiune</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Nume sistem</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Nume sistem</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automa</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automa</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Retea</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automa</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Definit de utilizator</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Definit de utilizator</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Nume definit de utilizator</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Nume definit de utilizator</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>Intrare 1 AC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>Intrare 1 AC</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>Intrare 2 AC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>Intrare 2 AC</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Monitor deconectarea de la retea</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Monitor deconectarea de la retea</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Monitor deconectarea de la tarm</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Monitor deconectarea de la tarm</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Auto selectat</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Auto selectat</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Are sistem DC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Are sistem DC</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Sincronizeaza SOC VE.Bus cu bateria</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Sincronizeaza SOC VE.Bus cu bateria</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Foloseste intensitatea incarcatorului solar pentru a imbunatati SOC VE.Bus</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Foloseste intensitatea incarcatorului solar pentru a imbunatati SOC VE.Bus</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Control tensiune incarcator solar</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Control tensiune incarcator solar</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Control intensitate incarcator solar</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Control intensitate incarcator solar</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Cotrol BMS</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>Cotrol BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>Cotrol BMS</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Funcția de pornire/oprire a pompei rezervorului nu este activată. Mergeți la setările releului și setați funcția la \”Pompă rezervor\”.</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Funcția de pornire/oprire a pompei rezervorului nu este activată. Mergeți la setările releului și setați funcția la \”Pompă rezervor\”.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Starea pompei</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Starea pompei</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Senzor rezervor</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Senzor rezervor</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Nivel pornire</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Nivel pornire</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Nivel oprire</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Nivel oprire</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Conexiune intrerupta</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Conexiune intrerupta</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Deconectat</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Deconectat</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Ascuns]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Ascuns]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Conectarea la retea?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Conectarea la retea?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Conectare</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Conectare</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Uita reteaua?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Uita reteaua?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Uitați</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Uitați</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Sunteți sigur că doriți să uitați această rețea?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Sunteți sigur că doriți să uitați această rețea?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>Adresa fizica MAC</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>Adresa fizica MAC</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>Configuratie IP</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>Configuratie IP</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Oprit</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Static</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Static</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>MAsca retea</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>MAsca retea</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Gateway</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Gateway</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>Server DNS</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>Server DNS</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Adresa auto-generata</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Adresa auto-generata</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Atentie, pentru sistemele ESS, precum si pentru cele cu baterie inteligenta, instanta CAN-bus a dispozitivului trebuie sa ramana configurata pe 0. Verifica manualul GX pentru mai multe informatii.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Atentie, pentru sistemele ESS, precum si pentru cele cu baterie inteligenta, instanta CAN-bus a dispozitivului trebuie sa ramana configurata pe 0. Verifica manualul GX pentru mai multe informatii.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Instanța dispozitivului</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Instanța dispozitivului</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Adresa de retea</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Adresa de retea</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Dispozitive VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Dispozitive VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Dispozitiv nr. %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Dispozitiv nr. %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Niciun punct de acces (AP)</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Niciun punct de acces (AP)</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Niciun adaptor Wi-Fi conectat</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Niciun adaptor Wi-Fi conectat</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Creaza puct acces (AP)</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Creaza puct acces (AP)</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Retele Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Retele Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Sunteți sigur că doriți să dezactivați punctul de acces?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Sunteți sigur că doriți să dezactivați punctul de acces?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Data/Ora UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Data/Ora UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Data/Ora locala</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Data/Ora locala</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Fus orar</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Fus orar</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Africa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Africa</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>America</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>America</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antartica</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antartica</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Arctica</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Arctica</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asia</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantic</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantic</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australia</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australia</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indian</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indian</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pacific</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pacific</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Neconectat %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Neconectat %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Reporniți acum?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Reporniți acum?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Modificările instanței VRM nu vor fi aplicate până când dispozitivul nu este repornit.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Modificările instanței VRM nu vor fi aplicate până când dispozitivul nu este repornit.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Dispozitivul se repornește...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Dispozitivul se repornește...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Dispozitivul a fost repornit.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Dispozitivul a fost repornit.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Alarma tensiune scazuta baterie</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Alarma tensiune scazuta baterie</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Alarma tensiune ridicata baterie</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Alarma tensiune ridicata baterie</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Ultima eroare</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Ultima eroare</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Penultima eroare</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Penultima eroare</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Ante-penultima eorare</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Ante-penultima eorare</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4 erori in urma</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4 erori in urma</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Interconectat</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Interconectat</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Configurari mod</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Configurari mod</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>De sine statator</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>De sine statator</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">De sine statator</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Incarcare</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Incarcare</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Control extern</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Incarcare si HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Incarcare si HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Incarcare si BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Incarcare si BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Control ext. si BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Control ext. si BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Incarcare, HUB-1 si BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Incarcare, HUB-1 si BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Configurari master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Configurari master</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Secundar</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Secundar</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Secundar</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Grup principal</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Grup principal</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Incarca master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Incarca master</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Grup &amp; incarcare master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Grup &amp; incarcare master</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Tensiune incarcare</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Tensiune incarcare</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Resetare</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Resetare</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Controlul BMS este activat automat în prezența unui BMS. Se resetează dacă se modifică configurația sistemului sau dacă nu este prezent BMS.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Controlul BMS este activat automat în prezența unui BMS. Se resetează dacă se modifică configurația sistemului sau dacă nu este prezent BMS.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Putere totala PV</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Incarcare</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Incarcare</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 găsit</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 găsit</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Istoric</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Istoric</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Istoric</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Functionare in retea</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Functionare in retea</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Vizualizare tabel</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Vizualizare tabel</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Grafic</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Grafic</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Avertisment</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Avertisment</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarma</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarma</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarma</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Volum</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Volum</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Scurtcircuitat</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Scurtcircuitat</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Polaritate inversata</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Polaritate inversata</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Stații de încărcare pentru vehicule electrice</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Stații de încărcare pentru vehicule electrice</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Sesiune</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Sesiune</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Timp</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Timp</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Mod încărcare</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Mod încărcare</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Porniți și opriți singur procesul. Folosiți acest lucru pentru încărcări rapide și monitorizare îndeaproape.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Porniți și opriți singur procesul. Folosiți acest lucru pentru încărcări rapide și monitorizare îndeaproape.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Pornește și se oprește în funcție de nivelul de încărcare a bateriei. Optim pentru încărcări de noapte și prelungite pentru a evita supraîncărcarea.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Pornește și se oprește în funcție de nivelul de încărcare a bateriei. Optim pentru încărcări de noapte și prelungite pentru a evita supraîncărcarea.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Tarife de energie electrică mai mici în timpul orelor de vârf sau dacă doriți să vă asigurați că vehiculul dvs. electric este complet încărcat și gata de plecare la o anumită oră.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Tarife de energie electrică mai mici în timpul orelor de vârf sau dacă doriți să vă asigurați că vehiculul dvs. electric este complet încărcat și gata de plecare la o anumită oră.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Activare incarcare</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Activare incarcare</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Blocați afișajul încărcătorului</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Blocați afișajul încărcătorului</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Adresa sursei</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Adresa sursei</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Configurare</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Configurare</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Instanță de linie #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Instanță de linie #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Instanță linie</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Instanță linie</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Instanță încărcător</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Instanță încărcător</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Instanță invertor</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Instanță invertor</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Instanță sursă de curent continuu #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Instanță sursă de curent continuu #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Instanță sursă curent continuu</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Instanță sursă curent continuu</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Prioritate sursă de curent continuu #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Prioritate sursă de curent continuu #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Prioritate sursă curent continuu</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Prioritate sursă curent continuu</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Instanță rezervor</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Instanță rezervor</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Dispozitive RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Dispozitive RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Activare vizualizator rată de cadre</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Activare vizualizator rată de cadre</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Incompatibil</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Incompatibil</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Eliminare dispozitive deconectate</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Eliminare dispozitive deconectate</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Dispozitiv incompatibil gasit</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Dispozitiv incompatibil gasit</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Functia releu</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Functia releu</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarma</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Incarcator sau generator start/stop</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Incarcator sau generator start/stop</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Control manual</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Siguranta arsa</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Control manual</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Control manual</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Intotdeauna deschis (nu folosi releul)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Intotdeauna deschis (nu folosi releul)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Retineti ca modificand „Nivelul de încărcare inferior”, de asemenea schimba și „Timpul rămas până la pragul inferior de descărcare” din meniul de configurare a bateriei.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Retineti ca modificand „Nivelul de încărcare inferior”, de asemenea schimba și „Timpul rămas până la pragul inferior de descărcare” din meniul de configurare a bateriei.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Siguranta arsa</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Siguranta arsa</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>LED status</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>LED status</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Niciuna</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Comutator principal</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Comutator principal</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Incalzitor</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Incalzitor</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Ventilator intern</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Ventilator intern</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Pictorgame de avertizare</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Pictorgame de avertizare</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Pictograme de alarma</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Pictograme de alarma</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Comutator</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Comutator</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Initializare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Initializare</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Oprire</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Oprire</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Actualizare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Actualizare</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Urmeaza sa porneasca</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Urmeaza sa porneasca</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Preincarcare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Preincarcare</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Verificare contactor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Verificare contactor</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>State of health</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>State of health</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Temperatura baterie</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Temperatura baterie</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Temperatura aerului</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Temperatura aerului</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Tensiunea demarorului</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Tensiunea demarorului</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Tensiune Bus</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Tensiune Bus</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Tensiune sectiune superioara</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Tensiune sectiune superioara</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Eroare comunicare</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">State of health</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Tensiune Bus</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Tensiune sectiune inferioara</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Tensiune sectiune inferioara</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Deviatie punct median</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Deviatie punct median</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Consum amperi ora</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Consum amperi ora</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Timp ramas</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Timp ramas</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Detalii</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Detalii</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Alarme la nivel de modul</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Alarme la nivel de modul</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnostic</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostic</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Siguranțe</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Siguranțe</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>SISTEM</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>SISTEM</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parametri</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parametri</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Redetecteaza bateria</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Redetecteaza bateria</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Apasa pentru redetectare</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Apasa pentru redetectare</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Apasa pentru redetectare</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Redetectarea bateriei poate dura pana la 60 secude. Intre timp, numele bateriei poate fi gresit.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Redetectarea bateriei poate dura pana la 60 secude. Intre timp, numele bateriei poate fi gresit.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Intensitate incarcare ridicata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Intensitate incarcare ridicata</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Intensitate descarcare ridicata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Intensitate descarcare ridicata</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>SOC scazut</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>SOC scazut</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Tensiune ridicata baterie</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">SOC scazut</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Tensiune pornire scazuta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Tensiune pornire scazuta</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Tensiune pornire ridicata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Tensiune pornire ridicata</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Senzor temperatura baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Senzor temperatura baterie</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Tensiune punct-median</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Tensiune punct-median</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Siguranta arsa</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Temeperatura interna ridicata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Temeperatura interna ridicata</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Temperatura incarcare scazuta</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Temperatura incarcare scazuta</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Temperatura de incarcare ridicata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Temperatura de incarcare ridicata</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Defectiune interna</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Defectiune interna</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Siguranta automata declansata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Siguranta automata declansata</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Celula dezechilibrata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Celula dezechilibrata</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Tensiune scazuta celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Tensiune scazuta celula</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Tensiune minima celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Tensiune minima celula</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Tensiune maxima celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Tensiune maxima celula</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Temperatura minima celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Temperatura minima celula</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Temperatura maxima celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Temperatura maxima celula</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Module baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Module baterie</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 conectat</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 conectat</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 deconectat</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 deconectat</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Numărul de module care blochează încărcarea/descărcarea</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Numărul de module care blochează încărcarea/descărcarea</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Capacitate instalata / disponibila</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Capacitate instalata / disponibila</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Descarcare maxima</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Descarcare maxima</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Ultima descarcare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Ultima descarcare</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Descare medie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Descare medie</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Numar total de incarcari</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Numar total de incarcari</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Numar de descarcari complete</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Numar de descarcari complete</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Total Ah furnizati</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Total Ah furnizati</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Tensiune minima celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Tensiune minima celula</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Tensiune maxima celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Tensiune maxima celula</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Timpul de la ultima incarcare completa</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Timpul de la ultima incarcare completa</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Numar sincronizari</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Numar sincronizari</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Alarme de tensiune scăzută a bateriei de pornire</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Alarme de tensiune scăzută a bateriei de pornire</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Tensiunea minimă a bateriei de pornire</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Tensiunea minimă a bateriei de pornire</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Tensiunea maximă a bateriei de pornire</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Tensiunea maximă a bateriei de pornire</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Energie descarcata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Energie descarcata</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>energie incarcata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>energie incarcata</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Limitare tensiune incarcare (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Limitare tensiune incarcare (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Limitare intensitate incarcare (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Limitare intensitate incarcare (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Limitare intensitate descarcare (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Limitare intensitate descarcare (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Tensiune deconectare inferioara (intotdeauna ignorata)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Tensiune deconectare inferioara (intotdeauna ignorata)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Banc baterie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Banc baterie</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Releu (pe monitor baterie)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Releu (pe monitor baterie)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Restabileste setarile de implicite</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Restabileste setarile de implicite</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Apasa pentru a restabili</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Apasa pentru a restabili</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Restabiliți setările din fabrică?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Restabiliți setările din fabrică?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth activat</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth activat</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Tensiune nominala</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Tensiune nominala</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Capacitate</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Capacitate</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacitate</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Tensiune incarcata</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Tensiune incarcata</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Curent final</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Curent final</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Timp de detectare a finalizarii incarcarii</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Timp de detectare a finalizarii incarcarii</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Exponent Peukert</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Exponent Peukert</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Factor eficienta incarcare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Factor eficienta incarcare</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Prag intensitate</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Prag intensitate</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Perioada mediere timp ramas functionare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Perioada mediere timp ramas functionare</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Timpul ramas pana la pragul inferior de descarcare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Timpul ramas pana la pragul inferior de descarcare</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Decalaj intensitate</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Decalaj intensitate</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Sincronizare nivelului de incarcare cu 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Sincronizare nivelului de incarcare cu 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Apasa pentru a sincroniza</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Apasa pentru a sincroniza</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Calibrare 0 curent</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Calibrare 0 curent</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Apasa pentru a seta la 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Apasa pentru a seta la 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Distribuitor %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Distribuitor %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Fără alimentare pe bară</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Fără alimentare pe bară</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Conexiune intrerupta</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n siguranța (siguranțele) este (sunt) arsă(e)</numerusform>
-        <numerusform>%n siguranța (siguranțele) este (sunt) arsă(e)</numerusform>
-        <numerusform>%n siguranța (siguranțele) este (sunt) arsă(e)</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n siguranța (siguranțele) este (sunt) arsă(e)</numerusform>
+            <numerusform>%n siguranța (siguranțele) este (sunt) arsă(e)</numerusform>
+            <numerusform>%n siguranța (siguranțele) este (sunt) arsă(e)</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Nicio informație disponibilă, consultați pagina anterioară pentru Stare distribuitor.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Nicio informație disponibilă, consultați pagina anterioară pentru Stare distribuitor.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Siguranță %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Siguranță %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Nefolosit</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Nefolosit</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Ars</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Ars</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Opriri din cauza erorilor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Opriri din cauza erorilor</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Ultima eroare</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">Penultima eroare</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">Ante-penultima eorare</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">4 erori in urma</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Comutator sistem</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Comutator sistem</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Releu extern</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Releu extern</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Contact programabil</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Contact programabil</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Baterii</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Baterii</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Capacitate</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Baterii</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Paralel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Paralel</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Serie</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Serie</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Min/max tensiune celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Min/max tensiune celula</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Min/max temperatura celula</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Min/max temperatura celula</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Echilibrare</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Echilibrare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Echilibrare</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Necunoscut</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Ieșire</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Ieșire</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Unitate de câmp</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Unitate de câmp</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Viteză motor</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Viteză motor</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Tensiune auxiliară</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Tensiune auxiliară</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Nicio alarma</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Nicio alarma</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Tensiune scazuta</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Tensiune scazuta</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Tensiune ridicata</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Tensiune ridicata</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Tensiune auxiliară scăzută</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Tensiune auxiliară scăzută</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Tensiune auxiliară ridicată</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Tensiune auxiliară ridicată</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Alarme tensiune auxiliară scazută</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Alarme tensiune auxiliară scazută</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Alarme tensiune auxiliară ridicată</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Alarme tensiune auxiliară ridicată</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Tensiune auxiliară minimă</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Tensiune auxiliară minimă</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Tensiune auxiliară maximă</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Tensiune auxiliară maximă</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Energie produsă</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Energie produsă</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Energie consumată</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Energie consumată</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Activeaza alarma</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Activeaza alarma</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Nivel activ</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Nivel activ</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Restabilire nivel</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Restabilire nivel</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Interval</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Interval</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Nivel</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Nivel</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Ramas</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Ramas</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Baterie senzor</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Baterie senzor</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Baterie senzor</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Tip senzor</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Tip senzor</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Implicit</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Implicit</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>European (0 la 180 Ohmi)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>European (0 la 180 Ohmi)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>US (240 la 30 Ohmi)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>US (240 la 30 Ohmi)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Personalizat</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Personalizat</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Personalizat</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Valoare senzor la stare gol</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Valoare senzor la stare gol</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Tip fluid</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Tip fluid</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Raport butan</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Raport butan</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Forma personalizata</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Forma personalizata</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Durata medie</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Durata medie</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Valoare senzor</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Valoare senzor</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Nu este definită nicio formă personalizată. Puteți defini una cu până la zece puncte. Rețineți că 0 % și 100 % sunt implicite.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Nu este definită nicio formă personalizată. Puteți defini una cu până la zece puncte. Rețineți că 0 % și 100 % sunt implicite.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punct %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punct %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Adauga punct</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Adauga punct</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Nivel senzor</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Nivel senzor</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Volum</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Nu sunt permise valorile duble ale nivelului senzorului.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Nu sunt permise valorile duble ale nivelului senzorului.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Valorile de volum trebuie să fie în creștere.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Valorile de volum trebuie să fie în creștere.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Monitorizare</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Monitorizare</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Deblocat (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Deblocat (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Deblocat (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Deblocat (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Deblocat (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Deblocat (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Blocat</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Blocat</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Configurare ordine faze</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Configurare ordine faze</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Comutare pozitie</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Comutare pozitie</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Monofazat</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>Doua faze</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>Doua faze</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>Trei feze</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>Trei feze</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Dispozitiv</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Viteza</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Incarcare</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Temperatura lichidului de racire</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Temperatura lichidului de racire</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Temperatura evacuarii</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Temperatura evacuarii</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Temperatura bobinajului</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Temperatura bobinajului</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Tensiune baterie de pornire</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Tensiune baterie de pornire</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Număr porniri</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Număr porniri</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Cotrol BMS</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Selector frontal blocat (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Selector frontal blocat (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Nicio eroare (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Nicio eroare (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>Totaluri AC</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>Totaluri AC</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energie L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energie L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Ordine faze</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Ordine faze</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L!-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L!-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Versiune manager de date</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Versiune manager de date</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Niciuna</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Ledul care clipeste indica acest CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Ledul care clipeste indica acest CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Dispozitiv bus Smappee</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Dispozitiv bus Smappee</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>Incarcator PV</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>Incarcator PV</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Această setare este dezactivată la conectarea Digital Multi Control.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Această setare este dezactivată la conectarea Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Această setare este dezactivată la conectarea unui VE.Bus BMS.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Această setare este dezactivată la conectarea unui VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC in %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC in %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Inversat</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Inversat</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Activeaza alarma</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Inversat</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Inverseaza functionalitatea alarmei</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Inverseaza functionalitatea alarmei</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Iradianță</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Iradianță</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Temperatura celulelor</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Temperatura celulelor</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Temperatura externă (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Temperatura externă (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Temperatura exterioara</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Temperatura exterioara</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Temperatura externă (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Temperatura externă (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Viteza vantului</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Viteza vantului</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Detecteaza automat</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Detecteaza automat</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Senzor de viteza vantului</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Senzor de viteza vantului</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Senzor temperatura exterioara</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Senzor temperatura exterioara</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Agregat</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Agregat</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Multiplicator</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Multiplicator</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Reseteaza contor</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Reseteaza contor</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Scurtcircuitat</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Polaritate inversata</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Baterie senzor descărcată</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Baterie senzor descărcată</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Umiditate</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Umiditate</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Presiune</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Presiune</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Scazut</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Decalaj</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Decalaj</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Scara</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Scara</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Tensiune senzor</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Tensiune senzor</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Putere totala PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Putere totala PV</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Pagină produs</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Pagină produs</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Senzor de curent alternativ %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Senzor de curent alternativ %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Este disponibilă o nouă versiune MK3.
+        <translation>Este disponibilă o nouă versiune MK3.
 NOTE: Actualizarea ar putea opri temporar sistemul.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Actualizați MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Actualizați MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Apăsați pentru actualizare</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Apăsați pentru actualizare</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>La actualizarea MK3, valorile vor reapărea după finalizarea actualizării</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>La actualizarea MK3, valorile vor reapărea după finalizarea actualizării</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Încărcarea bateriei la 100%.</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Încărcarea bateriei la 100%.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Încărcarea bateriei la 100%.</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Avansat</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>În curs de desfășurare</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>În curs de desfășurare</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Apăsați pentru a opri</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Apăsați pentru a opri</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Apasa pentru a porni</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Apasa pentru a porni</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Încărcați bateria la 100%.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Încărcați bateria la 100%.</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Sistemul va reveni la funcționarea normală, acordând prioritate energiei regenerabile.
+        <translation>Sistemul va reveni la funcționarea normală, acordând prioritate energiei regenerabile.
 Doriți să continuați?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Energia de la țărm va fi utilizată atunci când este disponibilă, iar opțiunea "Prioritate solară și eoliană" va fi ignorată.
+        <translation>Energia de la țărm va fi utilizată atunci când este disponibilă, iar opțiunea &quot;Prioritate solară și eoliană&quot; va fi ignorată.
 Doriți să continuați?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Energia de la țărm va fi utilizată pentru a completa o încărcare completă a bateriei pentru o singură dată.
+        <translation>Energia de la țărm va fi utilizată pentru a completa o încărcare completă a bateriei pentru o singură dată.
 După finalizarea procesului de încărcare, sistemul va reveni la funcționarea normală, acordând prioritate energiei solare și eoliene.
 Doriți să continuați?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Tensiune DC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Tensiune DC</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>Intensitate DC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>Intensitate DC</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Avansat</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Avansat</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Configurare alarma</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Configurare alarma</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>Un BMS VE.Bus opreste automat sistemul cand este necesara protejarea bateriilor. Prin urmare, controlarea sistemului din Color Control nu este posibila.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>Un BMS VE.Bus opreste automat sistemul cand este necesara protejarea bateriilor. Prin urmare, controlarea sistemului din Color Control nu este posibila.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Un asistent BMS instalat si configurat pentru un BMS VE.Bus, dar BMS-ul VE.Bus nu este gasit!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Un asistent BMS instalat si configurat pentru un BMS VE.Bus, dar BMS-ul VE.Bus nu este gasit!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>BMS VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>BMS VE.Bus</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Avertisment: Activarea egalizării într-un sistem ESS cu încărcătoare solare poate determina încărcarea bateriei la tensiune înaltă cu un curent prea mare.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Avertisment: Activarea egalizării într-un sistem ESS cu încărcătoare solare poate determina încărcarea bateriei la tensiune înaltă cu un curent prea mare.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Sistemul comuta automat in float imediat ce incarcarea de egalizare a fost finalizata.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Sistemul comuta automat in float imediat ce incarcarea de egalizare a fost finalizata.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Intrerupe egalizarea</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Intrerupe egalizarea</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Egalizare</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Egalizare</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Se intrerupe...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Se intrerupe...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Porneste...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Porneste...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Porneste...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Apasa pentru a intrerupe</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Apasa pentru a intrerupe</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Intrerupe si reporneste absortia</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Intrerupe si reporneste absortia</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Intrerupe si mergi la float</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Intrerupe si mergi la float</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Intrerupt</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Intrerupt</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Nu intrerupe</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Nu intrerupe</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Detectați sistemul VE.Bus din nou</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Detectați sistemul VE.Bus din nou</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Se redetecteaza...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Se redetecteaza...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Porniți sistemul VE.Bus din nou</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Porniți sistemul VE.Bus din nou</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Se repornește...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Se repornește...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Apăsați pentru a reporni</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Apăsați pentru a reporni</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>Intrare CA 1 ignorata</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>Intrare CA 1 ignorata</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>Intrare CA 2 ignorata</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>Intrare CA 2 ignorata</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Test releu ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Test releu ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Finalizat</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">In asteptare</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Finalizat</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Finalizat</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>In asteptare</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>In asteptare</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Diagnoza VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Diagnoza VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Contor de calitate a rețelei Faza L%1, dispozitiv %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Contor de calitate a rețelei Faza L%1, dispozitiv %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>Raport eroare VE.Bus 8 / 11</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>Raport eroare VE.Bus 8 / 11</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Doar alarma</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Doar alarma</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarma si avertizari</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarma si avertizari</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Eroare BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Eroare BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Numere de serie</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Numere de serie</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Ultimul raport de eroare VE.Bus 11 #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Ultimul raport de eroare VE.Bus 11 #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Test de siguranță BF în curs de desfășurare</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Test de siguranță BF în curs de desfășurare</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Test de siguranță BF OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Test de siguranță BF OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Nepotrivire AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Nepotrivire AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Eroare comunicare</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Eroare comunicare</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>Eroare releu GND</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>Eroare releu GND</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Nepotrivire UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Nepotrivire UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Nepotrivire perioadă</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Nepotrivire perioadă</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Nepotrivire acționare releu BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Nepotrivire acționare releu BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Eroare: PE2 deschis</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Eroare: PE2 deschis</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Eroare: PE2 închis</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Eroare: PE2 închis</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Etapă eroare: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Etapă eroare: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Faza L%1, dispozitiv %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Faza L%1, dispozitiv %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Raportarea Erorii 11 necesita cel putin versiunea 454 a firmware-ului VE.Bus.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Raportarea Erorii 11 necesita cel putin versiunea 454 a firmware-ului VE.Bus.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>Ciudatenii VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>Ciudatenii VE.Bus</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energie</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energie</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Putere</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Putere</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Tensiune</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Tensiune</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Intensitate</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Intensitate</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>locație</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>locație</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Faza</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Faza</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Intare AC activa</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Intare AC activa</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>"Ripple" DC ridicat</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>&quot;Ripple&quot; DC ridicat</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Tensiune ridicata CC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Tensiune ridicata CC</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Curent ridicat CC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Curent ridicat CC</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Eroare detectare temperatura</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Eroare detectare temperatura</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Eroare detectare tensiune</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Eroare detectare tensiune</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Supraincarcat</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Supraincarcat</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>"Ripple" DC</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>&quot;Ripple&quot; DC</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Senzor tensiune</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Senzor tensiune</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Rotirea fazelor</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Rotirea fazelor</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Rotirea fazelor</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Versiune VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Versiune VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>Dispozitiv MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>Dispozitiv MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Versiune MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Versiune MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Versiune Multi Control</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Versiune Multi Control</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Versiune BMS VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Versiune BMS VE.Bus</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Cu excepția cazului în care rețeaua eșuează</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Cu excepția cazului în care rețeaua eșuează</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>Intrare curent alternativ</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>Intrare curent alternativ</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>INTRARE AC</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>INTRARE AC</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>Intrare 1 AC</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>Intrare 1 AC</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>Intrare 2 AC</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>Intrare 2 AC</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Rol</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>Consumatori AC</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>Consumatori AC</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>Ieșire curent alternativ</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>Ieșire curent alternativ</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>Iesire AC</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>Iesire AC</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Fază curent alternativ L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Fază curent alternativ L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Senzor curent alternativ %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Senzor curent alternativ %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Senzori curent alternativ  </translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Senzori curent alternativ  </translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Activ</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Activ</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarma</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Supraincarcat</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Stare alarma</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Stare alarma</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarme</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarme</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Permite incarcarea</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Permite incarcarea</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Permite descarcarea</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Permite descarcarea</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Scanare automata</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Scanare automata</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Baterie</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Baterie</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Intensitate baterie</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Intensitate baterie</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>tensiune baterie</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>tensiune baterie</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Intensitate incarcare</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Intensitate incarcare</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Încărcare</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Încărcare</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Sterge eraorea</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Sterge eraorea</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Inchis</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Inchis</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Conectare</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Conectare</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Intensitate</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Intensitate</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Transformatoare curent</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Transformatoare curent</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Nume personalizat</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Nume personalizat</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Depanare</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Depanare</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Dispozitiv</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Dispozitiv</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Dezactivat</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>descarcare</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>descarcare</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Deconectat</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Deconectat</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Activ</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Activ</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Activat</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Activat</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energie</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energie</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Eroare</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Eroare</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Eroare:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Eroare:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Cod eroare</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Cod eroare</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Versiune Firmware</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Versiune Firmware</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generator</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Temperatura ridicată baterie</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Temperatura ridicată baterie</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Alarma nivel ridicat</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Alarma nivel ridicat</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Tensiune ridicata baterie de pornire</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Tensiune ridicata baterie de pornire</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Temperatura ridicata</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Temperatura ridicata</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Alarme tensiune ridicata</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Alarme tensiune ridicata</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Istoric</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Istoric</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 oră/ore</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 oră/ore</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>inactiv</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>inactiv</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inactiv</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inactiv</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Invertor/Încărcător</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>Adresa IP</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>Adresa IP</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Temperatura scazuta baterie</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Temperatura scazuta baterie</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Alarma nivel scazut</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Alarma nivel scazut</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Tensiune scazuta baterie pornire</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Tensiune scazuta baterie pornire</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Nivelul incarcarii scazut</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Nivelul incarcarii scazut</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Temperatura scazuta</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Temperatura scazuta</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Alarme tensiune scazuta</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Alarme tensiune scazuta</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Producator</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Producator</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Temperatura maxima</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Temperatura maxima</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Tensiune maxima</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Tensiune maxima</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Temperatura minima</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Temperatura minima</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Tensiune minima</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Tensiune minima</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Mod</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Mod</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Nume model</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Nume model</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Nu</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Nu</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Nicio eroare</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Nicio eroare</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Indisponibil</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Indisponibil</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Nedetectat</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Nedetectat</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Deconectat</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Deconectat</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>In regula</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>In regula</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Pornit</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Pornit</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Conectat</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Conectat</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Deschis</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Deschis</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Parola</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Parola</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Faza</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Faza</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Apasa pentru a sterge</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Apasa pentru a sterge</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Apasa pentru a reseta</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Apasa pentru a reseta</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Apasa pentru a scana</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Apasa pentru a scana</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>Invertor PV</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>Invertor PV</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>Putere PV</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>Putere PV</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Ore de liniste</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Ore de liniste</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Releu</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Releu</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Repornire</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Repornire</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Elimina</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Elimina</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>Functioneaza</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>Functioneaza</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Scanează %1 %</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Scanează %1 %</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Numar serial</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Numar serial</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Configurari</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Configurari</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Configurare</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Configurare</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Putere semnal</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Putere semnal</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Asteptare</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Asteptare</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Porneste cand conditia s-a indeplinit de</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Porneste cand conditia s-a indeplinit de</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Ora de inceput</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Ora de inceput</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Valoarea de pornire in timpul orelor de liniste</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Valoarea de pornire in timpul orelor de liniste</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Porneste cand avertizarea este activa de</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Porneste cand avertizarea este activa de</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Nivel de incarcare</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Nivel de incarcare</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Stare</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Stare</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Pornire (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Pornire (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Valoare de oprire in timpul orelor de liniste</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Valoare de oprire in timpul orelor de liniste</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Opreste cand conditia s-a indeplinit de</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Opreste cand conditia s-a indeplinit de</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Oprit</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Oprit</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatura</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Senzor temperatura</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Senzor temperatura</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Azi</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Azi</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Total</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Total</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Monitor</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Monitor</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Tip</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Tip</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Numar Unic de Identificare</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Numar Unic de Identificare</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Necunoscut</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Necunoscut</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Eroare VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Eroare VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Tensiune</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Tensiune</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Instanta VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Instanta VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Cand avertizarea este indepartata opreste dupa</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Cand avertizarea este indepartata opreste dupa</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Da</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Da</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Ieri</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Ieri</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Productie</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Productie</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Limita zero pentru alimentarea cu energie</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Limita zero pentru alimentarea cu energie</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Setare dată</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Setare dată</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Porniți acum</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Porniți acum</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Cursă cronometrată</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Cursă cronometrată</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Oprește-te acum</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Oprește-te acum</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Timp de functionare total</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Timp de functionare total</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Setați ora %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Setați ora %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Generatorul va continua să funcționeze dacă este îndeplinită o condiție de pornire automată.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Generatorul va continua să funcționeze dacă este îndeplinită o condiție de pornire automată.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Mod invertor / încărcător</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Mod invertor / încărcător</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Setare</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Setare</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Anuleaza</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Anuleaza</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Închidere</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Închidere</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Setați ora </translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Setați ora </translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>În uz</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>În uz</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Eroare schimb</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Eroare schimb</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Schimb complet</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Schimb complet</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Schimbarea instanțelor dispozitivului...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Schimbarea instanțelor dispozitivului...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Instanța dispozitivului %1 este deja utilizată de ‚’%3’. Schimbați instanțele de dispozitiv și atribuiți-l la %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Instanța dispozitivului %1 este deja utilizată de ‚’%3’. Schimbați instanțele de dispozitiv și atribuiți-l la %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Instanța dispozitivului %1 este deja utilizată de un alt dispozitiv de același tip. Schimbați instanțele de dispozitiv și atribuiți-l la %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Instanța dispozitivului %1 este deja utilizată de un alt dispozitiv de același tip. Schimbați instanțele de dispozitiv și atribuiți-l la %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Nu se pot schimba instanțele de dispozitiv: operațiunea a expirat.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Nu se pot schimba instanțele de dispozitiv: operațiunea a expirat.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Noile instanțe de dispozitiv vor fi active la repornire.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Noile instanțe de dispozitiv vor fi active la repornire.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Schimbare</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Schimbare</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Eroare în timpul verificării actualizărilor de firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Eroare în timpul verificării actualizărilor de firmware</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Descărcare și instalare firmware %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Descărcare și instalare firmware %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Instalare firmware...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Instalare firmware...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Eroare în timpul instalării firmware-ului</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Eroare în timpul instalării firmware-ului</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Nicio versiune mai noua disponibila</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Nicio versiune mai noua disponibila</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Nu s-a gasit niciun firmware</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Nu s-a gasit niciun firmware</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Combustibil</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Combustibil</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Apa dulce</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Apa dulce</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Apa reziduala</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Apa reziduala</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Live well</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Live well</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Ulei</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Ulei</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>APA REZIDUALA</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>APA REZIDUALA</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzină</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzină</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Motorină</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Motorină</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>GPL</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>GPL</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>GNL</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>GNL</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Ulei hidraulic</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Ulei hidraulic</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Apă crudă</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Apă crudă</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Setare blocată pentru nivelul de acces</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Setare blocată pentru nivelul de acces</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Parola incorecta</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Parola incorecta</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Pe scurt</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Pe scurt</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Sitem</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Sitem</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Niveluri</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Niveluri</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Notificari</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Notificari</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>acum</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>acum</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1 m în urmă</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1 m în urmă</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1 ore %2 m în urmă</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1 ore %2 m în urmă</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Zilnic</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Zilnic</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Zile lucratoare</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Zile lucratoare</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Weekend-uri</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Weekend-uri</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Luni</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Luni</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Marti</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Marti</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Miercuri</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Miercuri</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Joi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Joi</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Vineri</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Vineri</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Sambata</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Sambata</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Duminica</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Duminica</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 sau %4)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 sau %4)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Program %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Program %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Zi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Zi</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Nu este setat</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Nu este setat</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Limita nivel de incarcare (SOC)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Limita nivel de incarcare (SOC)</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Autoconsum peste limită</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Autoconsum peste limită</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>Fotovoltaic și baterie</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>Fotovoltaic și baterie</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Se verifica...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Se verifica...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Stare alarma</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Stare alarma</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarma</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Sterge istoric</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Sterge istoric</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Stergere</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Stergere</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Pornit fortat</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Pornit fortat</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Oprit fortat</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Oprit fortat</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Stare releu</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Stare releu</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Resetarea istoricului pe monitorul propriu-zis</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Resetarea istoricului pe monitorul propriu-zis</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Apasa pentru a deconecta</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Apasa pentru a deconecta</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Asteapta, se deconecteaza</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Asteapta, se deconecteaza</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Nu s-a gasist spatiu de stocare</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Nu s-a gasist spatiu de stocare</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>micro SD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>micro SD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 senzor temperatura</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 senzor temperatura</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 senzor de temperatură (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 senzor de temperatură (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Senzor de temperatură (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Senzor de temperatură (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Nicio acţiune</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Nicio acţiune</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Avertisment: Temperaturile de activare și dezactivare sunt setate la aceeași valoare. Acest lucru va conduce la ignorarea condiției.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Avertisment: Temperaturile de activare și dezactivare sunt setate la aceeași valoare. Acest lucru va conduce la ignorarea condiției.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Condiţie %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Condiţie %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Funcție dezactivată</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Funcție dezactivată</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Niciuna (Dezactivare)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Niciuna (Dezactivare)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Releu 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Releu 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Releu 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Releu 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Avertisment: Releul selectat mai sus nu este configurat pentru temperatură, această condiție va fi ignorată.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Avertisment: Releul selectat mai sus nu este configurat pentru temperatură, această condiție va fi ignorată.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Valoare de activare</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Valoare de activare</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Unitate volum</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Unitate volum</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Metri cubi</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Metri cubi</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Litri</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Litri</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Galoane (SUA)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Galoane (SUA)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Galoane (Imperial)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Galoane (Imperial)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Tensiune minimă</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Tensiune minimă</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Tensiune maximă</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Tensiune maximă</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Tensiune maximă</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Curent maxim</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Curent maxim</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Timp de încărcare</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Timp de încărcare</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Float</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">oră</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Float</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Float</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>oră</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>oră</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 eroare/erori apărută(e)</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 eroare/erori apărută(e)</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Incarcare</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Incarcare</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Penultim</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Penultim</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Al treilea de la capăt</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Al treilea de la capăt</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Al patrulea de la capăt</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Al patrulea de la capăt</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Putere maximă</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Putere maximă</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Nu se poate conecta</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Nu se poate conecta</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Deconectat, încercare de reconectare</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Deconectat, încercare de reconectare</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Conectare</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Conectare</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Conectare</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Conectat, în așteptarea mesajelor brokerului</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Conectat, în așteptarea mesajelor brokerului</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Conectat, se primesc mesaje de la broker</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Conectat, se primesc mesaje de la broker</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Conectat, se încarcă interfața cu utilizatorul</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Conectat, se încarcă interfața cu utilizatorul</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Versiune de protocol invalidă</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Versiune de protocol invalidă</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>ID client respins</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>ID client respins</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Serviciul de brokeraj nu este disponibil</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Serviciul de brokeraj nu este disponibil</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Nume de utilizator sau parolă necorespunzătoare</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Nume de utilizator sau parolă necorespunzătoare</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Client neautorizat</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Client neautorizat</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Eroare de conexiune de transport</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Eroare de conexiune de transport</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Eroare de încălcare a protocolului</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Eroare de încălcare a protocolului</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Eroare de nivel 5 al protocolului MQTT</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Eroare de nivel 5 al protocolului MQTT</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Opriți alarma</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Opriți alarma</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Putere totală</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Putere totală</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>Min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>Min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1z %2o</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1z %2o</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1o %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1o %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Avarie</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Avarie</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Obtinere adresa IP</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Obtinere adresa IP</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectare</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Deconectat</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Deconectat</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Deconectat</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>Consumatori AC</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>Consumatori AC</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>Consumatori DC</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>Consumatori DC</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Vânt</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Vânt</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Tarm</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Tarm</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Limita de curent de rețea</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Limita de curent de rețea</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Limita de curent a generatorului</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Limita de curent a generatorului</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Limita de curent la mal</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Limita de curent la mal</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Oprire</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Oprire</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Oprire</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 rămase</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 rămase</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 rezervor (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 rezervor (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>Încărcător de curent alternativ</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>Încărcător de curent alternativ</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Generator</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>Încărcător de curent continuu</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>Încărcător de curent continuu</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Generator de curent continuu</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Generator de curent continuu</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>SISTEM DC</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>SISTEM DC</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Celule de combustibil</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Celule de combustibil</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Generator cu arbore</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Generator cu arbore</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Generator de apă</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Generator de apă</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Încărcător eolian</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Încărcător eolian</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Scazut</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Scazut</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Ridicat</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Ridicat</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Mentine bateriile incarcate</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Mentine bateriile incarcate</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimizat cu durata de viață a bateriei</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimizat cu durata de viață a bateriei</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimizat fără durata de viață a bateriei</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimizat fără durata de viață a bateriei</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Control extern</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Schimbat</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Schimbat</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Se asteapta soarele</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Se asteapta soarele</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Se așteapta RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Se așteapta RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>În așteptare pentru pornire</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>În așteptare pentru pornire</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Eroare de testare la sol</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Eroare de testare la sol</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Eroare testare intrare CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Eroare testare intrare CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Curent rezidual detectat</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Curent rezidual detectat</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Subtensiune detectată</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Subtensiune detectată</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Supratensiune detectată</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Supratensiune detectată</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Supraîncălzire detectată</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Supraîncălzire detectată</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Limita de încărcare</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Limita de încărcare</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Pornire încărcare</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Pornire încărcare</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Programat</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Programat</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Programat</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Încălzire</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Încălzire</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Răcire</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Răcire</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Pornire test</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Pornire test</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Pornit manual</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Pornit manual</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Incarcare sistem</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Incarcare sistem</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>Functioneaza (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>Functioneaza (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>Functioneaza (cu dificultate)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>Functioneaza (cu dificultate)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Releu %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Releu %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Avarie</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Avarie</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorption</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorption</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Stocare</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Stocare</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Egalizare</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Egalizare</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Control extern</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Mod AES</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Mod AES</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Stare de defecțiune</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Stare de defecțiune</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Încărcare „Bulk”</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Încărcare „Bulk”</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Încărcare „Absorption”</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Încărcare „Absorption”</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Încărcare „Float”</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Încărcare „Float”</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Mod de depozitare</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Mod de depozitare</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Încărcare de egalizare</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Încărcare de egalizare</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Trecere</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Trecere</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Dimensiune invertor</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Dimensiune invertor</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Assisting</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Assisting</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Mod sursa de alimentare</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Mod sursa de alimentare</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Sustine</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Trezire</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Trezire</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Absortie repetata</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Absortie repetata</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Egalizare automată</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Egalizare automată</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>Battery Safe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>Battery Safe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Detectare încărcătură</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Detectare încărcătură</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Blocat</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Blocat</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">SSE dinamic</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>SSE dinamic</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>SSE dinamic</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Grup principal</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Grup principal</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Instanta principala</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Instanta principala</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Grup si instanta principala</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Grup si instanta principala</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Master de grup și independent</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Master de grup și independent</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>DOAR INCARCATOR</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>DOAR INCARCATOR</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Doar invertor</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Doar invertor</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Alarma tensiune scazuta baterie</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Alarma tensiune ridicata baterie</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Alarmă de scurtcircuit</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Alarmă de scurtcircuit</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Dezactivați punct de acces</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Dezactivați punct de acces</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Intrare CC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Intrare CC</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Pentru bateriile cu litiu, nu se recomandă o încărcare sub 10 %. Pentru alte tipuri de baterii, verificați fișa tehnică pentru nivelul minim recomandat de producător.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Pentru bateriile cu litiu, nu se recomandă o încărcare sub 10 %. Pentru alte tipuri de baterii, verificați fișa tehnică pentru nivelul minim recomandat de producător.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Dezactivați pornirea automată?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Dezactivați pornirea automată?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Invertor/Încărcător (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Invertor/Încărcător (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Afișare utilizare CPU</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Afișare utilizare CPU</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Părăsiți aplicația</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Părăsiți aplicația</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Ieșire</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Ieșire</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Versiunea aplicației</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Versiunea aplicației</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Temperatură ulei</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Temperatură ulei</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Rețineți că modificarea setării Time-to-go discharge floor (Timp până la descărcarea minimă) modifică și setarea Low state-of-charge (Stare de încărcare scăzută) din meniul releu.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Rețineți că modificarea setării Time-to-go discharge floor (Timp până la descărcarea minimă) modifică și setarea Low state-of-charge (Stare de încărcare scăzută) din meniul releu.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Timp de funcționare</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Timp de funcționare</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Încărcat Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Încărcat Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Cicluri începute</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Cicluri începute</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Cicluri încheiate</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Cicluri încheiate</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Număr de creșteri de putere</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Număr de creșteri de putere</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Număr de descărcări profunde</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Număr de descărcări profunde</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Istoric ciclu de încărcare</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Istoric ciclu de încărcare</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Valoare senzor la stare plin</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Valoare senzor la stare plin</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Timp de service</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Timp de service</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Funcționalitatea de pornire automată</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Funcționalitatea de pornire automată</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Asigurați-vă că generatorul nu este conectat la intrarea de curent alternativ %1 în momentul în care se utilizează această opțiune</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Asigurați-vă că generatorul nu este conectat la intrarea de curent alternativ %1 în momentul în care se utilizează această opțiune</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Cronometrul de service a fost resetat</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Cronometrul de service a fost resetat</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Scanarea continuă poate interfera cu Wi-Fi-ul.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Scanarea continuă poate interfera cu Wi-Fi-ul.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Intervale măsurare minime și maxime</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Intervale măsurare minime și maxime</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Repornirea aplicației...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Repornirea aplicației...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Nu s-a reușit schimbarea limbii!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Nu s-a reușit schimbarea limbii!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Niciodata</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Vă rugăm să așteptați în timp ce se schimbă limba.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Vă rugăm să așteptați în timp ce se schimbă limba.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Vizualizare unitate pe scurt</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Vizualizare unitate pe scurt</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Nu există etichete</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Nu există etichete</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Afișare volume rezervor</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Afișare volume rezervor</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Afișare procente</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Afișare procente</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Notă: Dacă nu se poate afișa curentul (de exemplu, când se afișează un total pentru surse combinate de curent alternativ și continuu), atunci se va afișa în schimb puterea.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Notă: Dacă nu se poate afișa curentul (de exemplu, când se afișează un total pentru surse combinate de curent alternativ și continuu), atunci se va afișa în schimb puterea.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Limite de curent de încărcare</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Limite de curent de încărcare</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Versiune oficială</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Versiune oficială</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Versiune beta</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Versiune beta</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Testare (intern Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Testare (intern Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Dezvoltare (intern Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Dezvoltare (intern Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Reporneste...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Reporneste...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Activează LED-urile de stare</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Activează LED-urile de stare</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Încălzire și răcire</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Încălzire și răcire</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Timp de oprire a generatorului</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Timp de oprire a generatorului</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Alarmă atunci când generatorul nu este în modul de pornire automată</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Alarmă atunci când generatorul nu este în modul de pornire automată</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Se va declanșa o alarmă atunci când funcția de pornire automată este lăsată dezactivată pentru mai mult de 10 minute</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Se va declanșa o alarmă atunci când funcția de pornire automată este lăsată dezactivată pentru mai mult de 10 minute</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Autoconsum din baterie</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Autoconsum din baterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Toate sarcinile sistemului</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Toate sarcinile sistemului</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Numai sarcini critice</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Numai sarcini critice</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">SOC minim (exceptand deconectarea de la retea)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Starea de viață a bateriei</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Starea de viață a bateriei</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Accesați Signal K la http://venus.local:3000 și prin VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Accesați Signal K la http://venus.local:3000 și prin VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Accesați Node-RED la https://venus.local:1881 și prin VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Accesați Node-RED la https://venus.local:1881 și prin VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Masuratori baterie</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Masuratori baterie</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Stare sistem</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Stare sistem</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Lista dispozitive</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Lista dispozitive</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Retea locala</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Instanțe de dispozitive VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Instanțe de dispozitive VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Alarma de temperatură ridicată</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Alarma de temperatură ridicată</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Controlat de BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Controlat de BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarme și erori</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarme și erori</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Această funcție necesită versiunea de firmware 400 sau o versiune mai recentă. Contactați instalatorul dumneavoastră pentru a vă actualiza Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Această funcție necesită versiunea de firmware 400 sau o versiune mai recentă. Contactați instalatorul dumneavoastră pentru a vă actualiza Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Incărcătorul nu este pregătit, egalizarea nu poate fi pornită</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Incărcătorul nu este pregătit, egalizarea nu poate fi pornită</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Egalizarea nu poate fi declansata in starea bulk a incarcarii</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Egalizarea nu poate fi declansata in starea bulk a incarcarii</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Curent maxim</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Curent maxim</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Putere maximă</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Putere maximă</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Curent minim</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Curent minim</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Niciuna</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Indisponibil</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Oprit</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">In regula</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Istoric general</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Istoric general</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Configurari</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Necunoscut</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Randament astăzi</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Randament astăzi</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Firmware instalat, dispozitiv repornit</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Firmware instalat, dispozitiv repornit</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Control de intrare tactilă</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Control de intrare tactilă</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Eroare de testare a contactelor sudate (în scurtcircuit)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Eroare de testare a contactelor sudate (în scurtcircuit)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Comutarea la 3 faze</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Comutarea la 3 faze</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Comutarea la 1 fază</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Comutarea la 1 fază</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Opriți încărcarea</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Opriți încărcarea</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Rezervat</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Rezervat</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Mod invertor</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Mod invertor</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Out L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Out L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Intrarea</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Intrarea</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Transfer</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Transfer</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Pagina se va reîncărca automat în zece secunde pentru a încărca cea mai recentă versiune.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Pagina se va reîncărca automat în zece secunde pentru a încărca cea mai recentă versiune.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Invertor (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Invertor (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Invertoare / încărcătoare</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Invertoare / încărcătoare</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Nu s-au găsit contoare de energie
+        <translation>Nu s-au găsit contoare de energie
 
 Rețineți că acest meniu afișează doar contoarele Carlo Gavazzi conectate prin RS485. Pentru orice alt contor, inclusiv pentru contoarele Carlo Gavazzi conectate prin ethernet, consultați în schimb meniul Dispozitive Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Reglare automată</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Reglare automată</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Când este activată, valorile minime și maxime ale măsurătorilor și graficelor se ajustează automat pe baza valorilor anterioare.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Când este activată, valorile minime și maxime ale măsurătorilor și graficelor se ajustează automat pe baza valorilor anterioare.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Resetați toate valorile intervalului la zero</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Resetați toate valorile intervalului la zero</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Resetarea valorilor intervalului</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Resetarea valorilor intervalului</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Sunteți sigur că doriți să resetați toate valorile la zero?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Sunteți sigur că doriți să resetați toate valorile la zero?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Curent maxim: AC în 1 conectat</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Curent maxim: AC în 1 conectat</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Curent maxim: AC în 2 conectate</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Curent maxim: AC în 2 conectate</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Curent maxim: fără intrări de curent alternativ</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Curent maxim: fără intrări de curent alternativ</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>Ieșire CC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>Ieșire CC</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solar</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solar</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Turatie motor</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Turatie motor</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Temperatura motor</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Temperatura motor</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Temperatura controller</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Temperatura controller</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Ciclu activ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Ciclu activ</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Ciclu %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Ciclu %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>DC deconectat</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>DC deconectat</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Alimentare oprită</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Alimentare oprită</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Schimbare funcție</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Schimbare funcție</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Actualizarea firmware-ului</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Actualizarea firmware-ului</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Resetare software</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Resetare software</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Incomplet</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Incomplet</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Timp scurs</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Timp scurs</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Încărcare / întreținere (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Încărcare / întreținere (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Baterie (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;final&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Baterie (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;final&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Tensiune de ieșire AC scăzută</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Tensiune de ieșire AC scăzută</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Tensiune de ieșire AC ridicată</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Tensiune de ieșire AC ridicată</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Randament total</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Randament total</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Randament sistem</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Randament sistem</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Istoric zilnic</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Istoric zilnic</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Nu trebuie configurate alarme</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Nu trebuie configurate alarme</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Tensiune maxima PV</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Tensiune maxima PV</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Tensiune maxima baterie</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Tensiune maxima baterie</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Tensiune minima baterie</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Tensiune minima baterie</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Eroare de bancă de baterii</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Eroare de bancă de baterii</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Tensiunea bateriei nu este suportată</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Tensiunea bateriei nu este suportată</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Număr incorect de baterii</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Număr incorect de baterii</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Configurație invalidă a bateriei</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Configurație invalidă a bateriei</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Starea echilibrului</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Starea echilibrului</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Echilibrat</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Echilibrat</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Dezechilibrat</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Dezechilibrat</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Utilizați această opțiune în sistemele care nu efectuează reducerea consumului de energie.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Utilizați această opțiune în sistemele care nu efectuează reducerea consumului de energie.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Utilizați această opțiune pentru reducerea vârfurilor de tensiune.</translation>
+        <translation>Utilizați această opțiune pentru reducerea vârfurilor de tensiune.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Pragul de reducere a vârfurilor este setat cu ajutorul setării limitei curentului de intrare CA. Consultați documentația pentru informații suplimentare.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Pragul de reducere a vârfurilor este setat cu ajutorul setării limitei curentului de intrare CA. Consultați documentația pentru informații suplimentare.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Pragurile de reducere a vârfurilor pentru import și export pot fi modificate în acest ecran. Consultați documentația pentru informații suplimentare.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Pragurile de reducere a vârfurilor pentru import și export pot fi modificate în acest ecran. Consultați documentația pentru informații suplimentare.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Limitați curentul de import al sistemului de curent alternativ</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Limitați curentul de import al sistemului de curent alternativ</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Pentru a utiliza această funcție, Contorizarea rețelei trebuie să fie setată pe Contor extern și trebuie să fie instalat un asistent ESS actualizat.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Pentru a utiliza această funcție, Contorizarea rețelei trebuie să fie setată pe Contor extern și trebuie să fie instalat un asistent ESS actualizat.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Curent maxim de import al sistemului (pe fază)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Curent maxim de import al sistemului (pe fază)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Pentru a utiliza această funcție, Contorizarea rețelei trebuie să fie setată pe Contor extern.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Pentru a utiliza această funcție, Contorizarea rețelei trebuie să fie setată pe Contor extern.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Curent maxim de export al sistemului (pe fază)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Curent maxim de export al sistemului (pe fază)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Cablat</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Cablat</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Pe scurt</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Sarcina sistemului este ridicată, închiderea panoului lateral pentru a reduce sarcina CPU</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Sarcina sistemului este ridicată, închiderea panoului lateral pentru a reduce sarcina CPU</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Limita intensitate curent</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Limita intensitate curent</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Scurtcircuit</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Scurtcircuit</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Cumpărare</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Cumpărare</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Vânzarea</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Vânzarea</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Țintă SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Țintă SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>Ieșire CA %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>Ieșire CA %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Monitor</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Monitor</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Dispozitiv RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Dispozitiv RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Pauză animații electronice</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Pauză animații electronice</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Capacitate totală</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Capacitate totală</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Număr de BMS-uri</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Număr de BMS-uri</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Limitarea curentului de export de curent alternativ al sistemului</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Limitarea curentului de export de curent alternativ al sistemului</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Dispozitive Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Dispozitive Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Adăugați dispozitiv</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Adăugați dispozitiv</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Scanare dupa dispozitive</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Scanare dupa dispozitive</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Dispozitive salvate</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Dispozitive salvate</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Dispozitive descoperite</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Dispozitive descoperite</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Adăugați un dispozitiv Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Adăugați un dispozitiv Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protocol</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protocol</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Port</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Port</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Unitate</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Unitate</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>No Modbus devices saved</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>No Modbus devices saved</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Dispozitiv %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Dispozitiv %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Eliminați dispozitivul Modbus?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Eliminați dispozitivul Modbus?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Nu au fost descoperite dispozitive Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Nu au fost descoperite dispozitive Modbus</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Baterie %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Baterie %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>Intensitate AC</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>Intensitate AC</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Pornirea/oprirea generatorului dezactivată</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Pornirea/oprirea generatorului dezactivată</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Funcționalitatea de pornire de la distanță este dezactivată pe generator. GX nu va putea porni sau opri generatorul acum. Activați-o pe panoul de control al generatorului.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Funcționalitatea de pornire de la distanță este dezactivată pe generator. GX nu va putea porni sau opri generatorul acum. Activați-o pe panoul de control al generatorului.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Functionalitate de pornire automata</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Functionalitate de pornire automata</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Timpul curent de funcționare</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Stare comandă</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Stare comandă</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Stare generator</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Stare generator</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Modul de pornire de la distanță</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Modul de pornire de la distanță</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Presiune ulei</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Presiune ulei</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Niveluri de încărcare programate</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Niveluri de încărcare programate</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Activ (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Activ (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Oprire manuală</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Oprire manuală</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Deschidere circuit</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Deschidere circuit</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (indisponibil)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (indisponibil)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Intrare tactilă pornit</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Intrare tactilă pornit</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Intrare tactilă oprit</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Intrare tactilă oprit</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Intrare tactilă dezactivat</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Intrare tactilă dezactivat</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Confirmarea alertelor</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Confirmarea alertelor</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Cod de eroare comandă</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Cod de eroare comandă</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Utilizați acest meniu pentru a defini datele despre baterie afișate în momentul în care faceți clic pe pictograma Baterie de pe pagina Prezentare generală. Aceeași selecție este vizibilă și pe portalul VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Utilizați acest meniu pentru a defini datele despre baterie afișate în momentul în care faceți clic pe pictograma Baterie de pe pagina Prezentare generală. Aceeași selecție este vizibilă și pe portalul VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Tensiune sistem [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Tensiune sistem [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Informații de conectare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Informații de conectare</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Vă rugăm să selectați...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Vă rugăm să selectați...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Securizat</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Securizat</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Protejat prin parolă, iar comunicarea în rețea este criptată</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Protejat prin parolă, iar comunicarea în rețea este criptată</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Slab</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Slab</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Protejat cu parolă, dar comunicarea în rețea nu este criptată</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Protejat cu parolă, dar comunicarea în rețea nu este criptată</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Nesecurizat</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Nesecurizat</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Nu există parolă și comunicarea prin rețea nu este criptată</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Nu există parolă și comunicarea prin rețea nu este criptată</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Parola trebuie să aibă cel puțin 8 caractere</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Introduceți parola</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Parola trebuie să aibă cel puțin 8 caractere</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Parola trebuie să aibă cel puțin 8 caractere</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Selectați profilul "Securizat"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Selectați profilul &quot;Securizat&quot;?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Selectați profilul "slab"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Selectați profilul &quot;slab&quot;?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Selectați profilul "Nesecurizat"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Selectați profilul &quot;Nesecurizat&quot;?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Serviciile rețelei locale sunt protejate prin parolă
+        <translation>- Serviciile rețelei locale sunt protejate prin parolă
 - Comunicarea în rețea este criptată
 - O conexiune securizată cu VRM este activată
 - Setările nesecurizate nu pot fi activate</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Serviciile rețelei locale sunt protejate prin parolă
+        <translation>- Serviciile rețelei locale sunt protejate prin parolă
 - Accesul necriptat la site-urile locale este de asemenea activat (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Serviciile rețelei locale nu au nevoie de parolă
+        <translation>- Serviciile rețelei locale nu au nevoie de parolă
 - Accesul necriptat la site-urile locale este de asemenea activat (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Parolă rădăcină</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Parolă rădăcină</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Deconectare</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Deconectare</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Deconectați-vă acum</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Deconectați-vă acum</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Să vă deconectați?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Să vă deconectați?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Acest lucru va deconecta toate conexiunile la rețeaua locală.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Acest lucru va deconecta toate conexiunile la rețeaua locală.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Deconectare</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Deconectare</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Numai citire</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Numai citire</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Complet</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Complet</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Sunteți sigur?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Sunteți sigur?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Schimbarea acestei setări la Numai citire sau Dezactivat vă va bloca accesul.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Schimbarea acestei setări la Numai citire sau Dezactivat vă va bloca accesul.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Acces MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Acces MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>"%1" nu este un număr.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&quot;%1&quot; nu este un număr.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Confirmați</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Confirmați</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Utilizați un număr cu %1 cifre sau mai puțin.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Utilizați un număr cu %1 cifre sau mai puțin.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>"%1" nu este o adresă IP validă.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&quot;%1&quot; nu este o adresă IP validă.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>"%1" nu este un număr de port valid. Utilizați un număr între 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&quot;%1&quot; nu este un număr de port valid. Utilizați un număr între 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 nu este un număr de unitate valid. Utilizați un număr cuprins între 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 nu este un număr de unitate valid. Utilizați un număr cuprins între 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Timpul curent de funcționare</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Timpul curent de funcționare</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Cod de eroare generator</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Cod de eroare generator</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Temperatura radiatorului</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Temperatura radiatorului</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Tensiune incarcare</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Tensiunea de încărcare este controlată în prezent de BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Tensiunea de încărcare este controlată în prezent de BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Limita de curent de încărcare</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Limita de curent de încărcare</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>Controlat de BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>Controlat de BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Controlul de catre BMS este activata automat cand BMS-ul este prezent. Reconfigureaza daca configuratia sistemului s-a schimbat sau BMS-ul nu mai este prezent.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Controlul de catre BMS este activata automat cand BMS-ul este prezent. Reconfigureaza daca configuratia sistemului s-a schimbat sau BMS-ul nu mai este prezent.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Cronometrul de serviciu dezactivat.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Cronometrul de serviciu dezactivat.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Portalul VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Portalul VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (acces VPN de la distanță)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (acces VPN de la distanță)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SoC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SoC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Trebuie configurat un profil de securitate înainte ca serviciile de rețea să poată fi activate, consultați Setări - General</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Trebuie configurat un profil de securitate înainte ca serviciile de rețea să poată fi activate, consultați Setări - General</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>„%1”a fost înlocuit cu „%2” deoarece conținea caractere invalide.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>„%1”a fost înlocuit cu „%2” deoarece conținea caractere invalide.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Initializare...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Initializare...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Back-end s-a pornit...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Back-end s-a pornit...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Back-end s-a oprit.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Back-end s-a oprit.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Conexiunea a eșuat.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Conexiunea a eșuat.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Acest dispozitiv GX este deconectat de la Tailscale.
+        <translation>Acest dispozitiv GX este deconectat de la Tailscale.
 
 Vă rugăm să așteptați sau să vă verificați conexiunea la internet.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Așteptăm un răspuns de la Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Așteptăm un răspuns de la Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Conectați acest dispozitiv GX la contul dvs. Tailscale prin deschiderea acestui link:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Conectați acest dispozitiv GX la contul dvs. Tailscale prin deschiderea acestui link:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Vă rugăm să așteptați sau să vă verificați conexiunea la internet.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Vă rugăm să așteptați sau să vă verificați conexiunea la internet.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Stare necunoscută: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Stare necunoscută: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Eroare: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Eroare: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Dezactivați Tailscale pentru a edita aceste setări.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Dezactivați Tailscale pentru a edita aceste setări.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Activați Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Activați Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Nume mașină</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Nume mașină</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Ieșire din contul Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Ieșire din contul Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Acces la rețeaua locală</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Acces la rețeaua locală</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Acces la rețeaua ethernet locală</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Acces la rețeaua ethernet locală</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Acces la rețeaua WiFi locală</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Acces la rețeaua WiFi locală</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Rețea(e) personalizată(e)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Rețea(e) personalizată(e)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Exemplu: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Exemplu: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Explicație:
+        <translation>Explicație:
 
 Această caracteristică, numită rute de subrețea de către Tailscale, permite accesul de la distanță la alte dispozitive din rețeaua (rețelele) locală (locale).
 
@@ -7386,2990 +8028,3058 @@ Câmpurile de rețele personalizate acceptă o listă de subrețele cu notație 
 După adăugarea/activarea unei noi rețele, trebuie să o aprobați o dată în consola de administrare Tailscale.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Argumente personalizate "tailscale up" </translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Argumente personalizate &quot;tailscale up&quot; </translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>URL personalizat al serverului (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>URL personalizat al serverului (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Acest controler de generator necesită un releu ajutător pentru a fi controlat, dar releul ajutător nu este configurat. Vă rugăm să configurați releul 1 în Setări → Releu la "Releu de ajutor pentru generator conectat".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Acest controler de generator necesită un releu ajutător pentru a fi controlat, dar releul ajutător nu este configurat. Vă rugăm să configurați releul 1 în Setări → Releu la &quot;Releu de ajutor pentru generator conectat&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Alarme de tensiune ridicată a bateriei de pornire</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Alarme de tensiune ridicată a bateriei de pornire</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Sărirea de la încălzirea generatorului</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Sărirea de la încălzirea generatorului</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>În funcțiune, dar fără servicii (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>În funcțiune, dar fără servicii (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Parolă rădăcină schimbată la %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Parolă rădăcină schimbată la %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Releu de ajutor pentru generator conectat</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Releu de ajutor pentru generator conectat</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Poziția sarcinilor CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Poziția sarcinilor CA</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Intrare și ieșire CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Intrare și ieșire CA</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Utilizați această opțiune atunci când sarcinile de curent alternativ sunt prezente la intrarea invertorului/încărcătorului. Utilizați această opțiune dacă nu sunteți sigur.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Utilizați această opțiune atunci când sarcinile de curent alternativ sunt prezente la intrarea invertorului/încărcătorului. Utilizați această opțiune dacă nu sunteți sigur.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Numai ieșire CA</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Numai ieșire CA</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Utilizați această opțiune în momentul în care sistemul utilizează un contor de rețea, dar toate sarcinile de curent alternativ sunt la ieșirea invertorului/încărcătorului.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Utilizați această opțiune în momentul în care sistemul utilizează un contor de rețea, dar toate sarcinile de curent alternativ sunt la ieșirea invertorului/încărcătorului.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Lunar</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Lunar</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>Încărcător EV</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>Încărcător EV</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Pompă de căldură</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Pompă de căldură</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Sarcini esențiale</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Sarcini esențiale</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Porniți și opriți generatorul pe baza condițiilor de pornire automată configurate.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Porniți și opriți generatorul pe baza condițiilor de pornire automată configurate.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Setări grup electrogen DC</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Setări grup electrogen DC</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Temperatura alternatorului</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Temperatura alternatorului</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Temperatura motorului</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Temperatura motorului</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Timp de functionare total</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Timp de functionare total</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Profil de securitate a rețelei</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Profil de securitate a rețelei</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Ultimele %1 zile</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Ultimele %1 zile</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generatorul se va opri în %1, cu excepția cazului în care sunt activate condiții de pornire automată care îl mențin în funcțiune.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generatorul se va opri în %1, cu excepția cazului în care sunt activate condiții de pornire automată care îl mențin în funcțiune.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generatorul va funcționa până când este oprit manual, cu excepția cazului în care sunt activate condiții de pornire automată care îl mențin în funcțiune.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generatorul va funcționa până când este oprit manual, cu excepția cazului în care sunt activate condiții de pornire automată care îl mențin în funcțiune.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Interfață clasică</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Interfață clasică</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>UI nouă</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>UI nouă</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Limba schimbată cu succes!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Limitarea puterii</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Limba schimbată cu succes!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Pentru dispozitivele Multi-RS și HS19, setările ESS sunt disponibile pe pagina produsului RS System.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Pentru dispozitivele Multi-RS și HS19, setările ESS sunt disponibile pe pagina produsului RS System.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Pornirea/oprirea grupului electrogenerator</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Pornirea/oprirea grupului electrogenerator</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Schimbarea versiunii firmware nu este posibilă fără a selecta "Profil de securitate rețea" în "Setări / General".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Schimbarea versiunii firmware nu este posibilă fără a selecta &quot;Profil de securitate rețea&quot; în &quot;Setări / General&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Durată</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Durată</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Alarme de sistem</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Alarme de sistem</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Nicio alarmă de sistem</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Nicio alarmă de sistem</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Înapoi</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Înapoi</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Ce este nou</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Ce este nou</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>Salt</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>Salt</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Bine ați venit!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Bine ați venit!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Suntem încântați să vă prezentăm o interfață complet reproiectată, care îmbunătățește atât ușurința în utilizare, cât și estetica GX-ului dvs.
+        <translation>Suntem încântați să vă prezentăm o interfață complet reproiectată, care îmbunătățește atât ușurința în utilizare, cât și estetica GX-ului dvs.
 
 Cu o navigare simplificată și un aspect nou, tot ceea ce vă place este acum și mai ușor de accesat și mai atrăgător din punct de vedere vizual.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Mod întunecat - luminos</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Mod întunecat - luminos</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Mediile diferite necesită setări de afișare diferite. Modurile întuneric și lumină asigură cea mai bună experiență de vizionare, indiferent de locul în care vă aflați.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Mediile diferite necesită setări de afișare diferite. Modurile întuneric și lumină asigură cea mai bună experiență de vizionare, indiferent de locul în care vă aflați.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Toate informațiile cheie de care aveți nevoie, prezentate într-un aspect simplu și curat. Piesa centrală este un widget personalizabil cu inele, care vă oferă acces rapid la informațiile despre sistem dintr-o singură privire.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Toate informațiile cheie de care aveți nevoie, prezentate într-un aspect simplu și curat. Piesa centrală este un widget personalizabil cu inele, care vă oferă acces rapid la informațiile despre sistem dintr-o singură privire.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Obțineți un control sporit cu panoul nostru de prezentare actualizat, care oferă date în timp real despre sistem - toate într-un singur loc pentru o monitorizare ușoară.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Obțineți un control sporit cu panoul nostru de prezentare actualizat, care oferă date în timp real despre sistem - toate într-un singur loc pentru o monitorizare ușoară.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Controale</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Controale</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Toate controalele de zi cu zi sunt acum combinate în noul panou Controale. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Toate controalele de zi cu zi sunt acum combinate în noul panou Controale. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watts &amp; Amperi</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watts &amp; Amperi</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Acum puteți comuta între wați și amperi. Alegeți unitatea care se potrivește cel mai bine preferințelor dvs.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Acum puteți comuta între wați și amperi. Alegeți unitatea care se potrivește cel mai bine preferințelor dvs.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Aflați mai multe</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Aflați mai multe</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Accesați link-ul de mai jos pentru a afla mai multe despre IU reînnoită.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Accesați link-ul de mai jos pentru a afla mai multe despre IU reînnoită.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Scanați codul QR pentru a afla mai multe despre IU reînnoită.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Scanați codul QR pentru a afla mai multe despre IU reînnoită.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Efectuat</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Efectuat</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Următor</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Următor</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Eroare: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Eroare: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Eroare activă</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Eroare activă</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Timpul de functionare total al generatorului (ore)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Timpul de functionare total al generatorului (ore)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation></translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation></translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation></translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation></translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation></translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation></translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Resetarea din fabrică a Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Resetarea din fabrică a Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Sunteți sigur că doriți să resetați Node-RED la setările din fabrică? Acest lucru va șterge toate fluxurile.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Sunteți sigur că doriți să resetați Node-RED la setările din fabrică? Acest lucru va șterge toate fluxurile.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation></translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation></translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation></translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Valoare de dezactivare</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Valoare de dezactivare</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation></translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation></translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation></translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation></translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation></translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Pe scurt</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Sitem</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation></translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation></translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation></translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Functia start/stop a generatorului nu este activa, mergi la configurari releu si seteaza-l pe "Start/Stop genset"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Ora standard Maroc</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Ora standard Africa Centrală si de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Ora standard Africa de Sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Ora standard Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Ora standard Egipt</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Ora standard Africa de Est</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Ora standard Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Ora standard America de Sud si de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Ora standard Groenlanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Ora standard Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Ora standard Newfoundland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Ora standard SA de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Ora standard Atlantic</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Ora standard Brazilia Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Ora standard Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Ora standard Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Ora standard SA de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Ora standard Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Ora standard de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Ora standard SA Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Ora standard Statele Unite de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Ora standard Canada Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Ora standard America Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Ora standard Centrala (Mexic)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Ora standard Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Ora standard montana (Mexic)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Ora standard montana</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Ora standard montana Statele Unite</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Ora standard Pacific (Mexic)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Ora standard Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Ora standard Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Ora standard Hawaii-Aleutian</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Ora standard Noua Zeelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Ora standard Pacific Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Ora standard Pacific de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Ora standard Australia de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Ora standard Asia SE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Ora standard Asia Centrală</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Ora standard Asia de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Ora standard Africa de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Ora standard Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Ora standard SA de Vest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Ora Europei de Vest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Ora standard Kamceatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Ora standard Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Ora standard Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Ora standard Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Ora standard Tokyo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Ora standard Coreea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Ora standard Singapore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ora standard Ulaanbaatar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Ora standard Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Ora standard Asia de Nord-Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Ora standard China</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Ora standard Asia SE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Ora standard Asia de Nord</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Ora standard Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Ora standard Asia Centrală-Nord</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Ora standard Asia Centrală</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Ora standard Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Ora standard Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Ora standard Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Ora standard India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Ora standard Asia de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Ora standard Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Ora standard Ekaterinburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Ora standard Georgia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Ora standard Caucaz</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Ora standard Azerbaijan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Ora standard Araba</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Ora standard Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Ora standard Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Ora standard Araba</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Ora standard Araba</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Ora standard Syria</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Ora standard Orientul Mijlociu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Ora standard Iordania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Ora standard Israel</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Mean Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Ora standard Azore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Ora standard Capul Verde</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Ora standard Tazmania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Ora standard Australia de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Ora standard AUS de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Ora standard Australia Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Ora standard AUS Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Ora standard Australia de Vest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Ora standard Atlantic Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Ora standard Linia datei</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Ora GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Ora Europei Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Ora Central Europeana</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Ora standard Romance</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Ora Europei de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Ora Europei de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Ora standard FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Ora standard GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Ora standard Belarus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Ora Standard Rusă</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Ora standard Turcia</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Ora standard Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Ora standard a Insulei Crăciunului</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Ora standard Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Ora Standard Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Ora standard Noua Zeelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Ora standard Pacific Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Ora standard Pacific de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Ora Standard</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Ora standard Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Ora standard a Insulei Paștelui</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Functia start/stop a generatorului nu este activa, mergi la configurari releu si seteaza-l pe &quot;Start/Stop genset&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Necunoscut</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Producția de energie solară</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Intrare CC</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">Consumatori AC</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">Consumatori DC</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Sitem</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Stare</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Randament total</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Randament sistem</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Doar alarma</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarma si avertizari</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Avertisment</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Nicio eroare</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Nicio eroare</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Eroare necunoscută: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Eroare necunoscută: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Nicio eroare</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Nicio eroare</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Eroare initializare baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Eroare initializare baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Nicio baterie conectata</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Nicio baterie conectata</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Baterie necunoscuta</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Baterie necunoscuta</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Tip de baterie diferit</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Tip de baterie diferit</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Numar de baterii incorect</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Numar de baterii incorect</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Shunt Lynx lipsa</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Shunt Lynx lipsa</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Eroare masurare baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Eroare masurare baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Eroare calcul intern</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Eroare calcul intern</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Nr baterii in serie incorect</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Nr baterii in serie incorect</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Eroare hardware</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Eroare hardware</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Eroare wathcdog</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Eroare wathcdog</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Supratensiune</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Supratensiune</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Tensiune sub limita</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Tensiune sub limita</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Temperatura peste limita</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Temperatura peste limita</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Temperatura sub limita</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Temperatura sub limita</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Standby sub limita de incarcare</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Standby sub limita de incarcare</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Eroare ADC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Eroare ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Eroare comunicare baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Eroare comunicare baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Eroare preincarcare</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Eroare preincarcare</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Eroare contactor de siguranta</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Eroare contactor de siguranta</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Eroare actualizare baterie</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Eroare actualizare baterie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Eroare cablul BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Eroare cablul BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Defecțiunea tensiunii de referință</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Defecțiunea tensiunii de referință</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Tensiune de sistem greșită</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Tensiune de sistem greșită</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Timp de expirare a preîncărcării</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Timp de expirare a preîncărcării</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Eroare ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Eroare ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Datele de calibrare pierdute</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Datele de calibrare pierdute</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Setari invalide</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Setari invalide</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Interblocare</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Interblocare</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Oprire de urgenta</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Oprire de urgenta</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Timeout de comunicare</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Timeout de comunicare</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Blocaj de siguranță</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Blocaj de siguranță</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Supratemperatură terminal</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Supratemperatură terminal</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Nicio eroare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Temperatura ridicată baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Tensiune ridicata baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Fir Tsense baterie conectat gresit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Fir Tsense baterie absent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Fir Vsense baterie conectat gresit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Fir Vsense baterie absent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Pierderi mari pe cablajul bateriei</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Tensiune scazuta baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>"Ripple" ridicat pe tensiune baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Nivel incarcare baterie scazut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Problema tensiune medie baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Temperatura bateriei este prea mică</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Temperatura ridicata incarcator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Intensitate incarcator peste limita</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Curent negativ charger</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Timp incarcare bulk expirat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Probleme la senzorul de intensitate al incarcatorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Tsensor intern conectat gresit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Tsensor intern absent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Ventilator incarcator nedetectat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Intensitate peste limita la ventilatorul incarcatorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Borna incarcator supraincalzita</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Scurtcircuit incarcator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Proplema la treapta de putere a incarcatorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Protectie la supraincarcare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Supratensiune intrare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Supraintensitate intrare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Supraputere intrare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Problema polaritate intrare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Tensiune absenta intrare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Oprire intrare (fara reincercari)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Oprire intrare (reincercare)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Defectiune interna intrare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Avarie la izolarea fotovoltaică</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>S-a detectat un defect la impamantare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Invertor supraincarcat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Temperatura invertor prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Curent de varf invertor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Nivel DC inter invertor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Nivel gresit iesire AC invertor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Eroare stadiu de putere invertor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Invertor conectat la AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Eroare de testare a releului ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Eroare de testare a releului ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Dispozitivul a disparut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Dispozitiv incompatibil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Conexiune BMS pierduta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Retea configurata gresit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Rotirea fazelor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Intrări multiple de curent alternativ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Supraîncărcare de fază</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Eroare la scrierea in memorie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Temperatura procesor prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Comunicare pierduta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Datele de calibrare pierdute</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Firmware incompatibil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Hardware incompatibil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Setari invalide</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Tensiunea de referinta a esuat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Verificare esuata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Istoric invalid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Contoare de kWh invalide</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Eroare de tensiune de curent continuu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Eroare senzor GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Eroare alimentare 3V3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Eroare alimentare 5 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Eroare alimentare 12 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Eroare alimentare 15 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Oprirea intrării fotovoltaice</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Poziționați comutatorul într-o poziție de deblocare pentru a modifica setările.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Utilizați sursa de date D-Bus: conectați-vă la adresa D-Bus specificată.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>adresa</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Utilizați sursa de date D-Bus: conectați-vă la adresa D-Bus standard</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Utilizați sursa de date MQTT: conectați-vă la adresa de broker MQTT specificată.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>adresa</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>ID-ul portalului de dispozitiv al sursei de date MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>ID portal</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>MQTT VRM webhost segment</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>segment</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Nume de utilizator sursă de date MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Utilizator</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Parola sursei de date MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>par</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Tokenul sursei de date MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>token</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Activează contorul FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Omite ecranul de întâmpinare</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Utilizați o sursă de date simulată pentru testare.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Dispozitiv oprit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>MK2 nou/vechi amestecat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Eroare dispozitiv anticipata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Niciun alt dispozitiv detectat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Supratensiune pe Iesirea-AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Eroare program DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>BMS VE.Bus fara assistent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Test releu impamantare esuat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Eroare sincronizare ora sistem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Test releu retea de alimentare esuat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Nepotrivire configuratie cu al 2-lea mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Eroare transmisie dispozitiv</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Se așteaptă configurarea sau dongle-ul lipsește</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Fază principală lipsă</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>S-a produs supratensiune</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Secundarul nu are intrare de curent alternativ!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Dispozitivul nu poate fi secundar</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>A fost inițiată protectia sistemului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Incompatibilitate Firmware</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Eroare interna</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Testul eșuat al releului împiedică conectarea</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Eroare VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Eroare necunoscută:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Eroare interna</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Nicio eroare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Temperatura ridicată baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Tensiune ridicata baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Tensiune scazuta baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Tensiunea bateriei a depășit configurația max.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Temperatura ridicată a alternatorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Rotații mari ale alternatorului pe minut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Temperatură ridicată FET de unitate de teren</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Senzorul necesar lipsește</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Alternator de joasă tensiune</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Decalaj de înaltă tensiune a alternatorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Tensiunea alternatorului a depășit configurația max.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Tensiune ridicată a alternatorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Bateria deconectată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Deconectare tensiune ridicată a bateriei</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Instanța bateriei este în afara intervalului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Prea multe BMS-uri</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Bateria urmează să se deconecteze</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Prea multe dispozitive de urmărit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Deconectare tensiune mică baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Deconectare curent mare baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Deconectarea bateriei la temperatură ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Deconectarea bateriei la temperatură scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Conexiune BMS pierduta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC dezactivat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>Convertorul CD/CD nu este pregătit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>Tensiune primară mare CD/CD</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>Tensiune primară mică CD/CD</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>Tensiune secundară mare CD/CD</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>Tensiune secundară mică CD/CD</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>Temperatură ridicată CD/CD</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>Configurare greșită CD/CD</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Senzorul de temperatură al bateriei este defect</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Eroare necunoscută:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Eroare necunoscută:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Nicio eroare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Temperatura ridicată baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Tensiune ridicata baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Fir Tsense baterie conectat gresit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Fir Tsense baterie absent</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Fir Vsense baterie conectat gresit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Fir Vsense baterie absent</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Pierderi mari pe cablajul bateriei</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Tensiune scazuta baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>&quot;Ripple&quot; ridicat pe tensiune baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Nivel incarcare baterie scazut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Problema tensiune medie baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Temperatura bateriei este prea mică</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Temperatura ridicata incarcator</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Intensitate incarcator peste limita</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Curent negativ charger</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Timp incarcare bulk expirat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Probleme la senzorul de intensitate al incarcatorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Tsensor intern conectat gresit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Tsensor intern absent</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Ventilator incarcator nedetectat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Intensitate peste limita la ventilatorul incarcatorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Borna incarcator supraincalzita</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Scurtcircuit incarcator</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Proplema la treapta de putere a incarcatorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Protectie la supraincarcare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Supratensiune intrare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Supraintensitate intrare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Supraputere intrare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Problema polaritate intrare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Tensiune absenta intrare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Oprire intrare (fara reincercari)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Oprire intrare (reincercare)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Defectiune interna intrare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Avarie la izolarea fotovoltaică</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>S-a detectat un defect la impamantare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Invertor supraincarcat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Temperatura invertor prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Curent de varf invertor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Nivel DC inter invertor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Nivel gresit iesire AC invertor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Eroare stadiu de putere invertor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Invertor conectat la AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Eroare de testare a releului ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Eroare de testare a releului ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Dispozitivul a disparut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Dispozitiv incompatibil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Conexiune BMS pierduta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Retea configurata gresit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Rotirea fazelor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Intrări multiple de curent alternativ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Supraîncărcare de fază</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Eroare la scrierea in memorie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Temperatura procesor prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Comunicare pierduta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Datele de calibrare pierdute</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Firmware incompatibil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Hardware incompatibil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Setari invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Tensiunea de referinta a esuat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Verificare esuata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Istoric invalid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Contoare de kWh invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Eroare de tensiune de curent continuu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Eroare senzor GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>Eroare alimentare 3V3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>Eroare alimentare 5 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>Eroare alimentare 12 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>Eroare alimentare 15 V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Oprirea intrării fotovoltaice</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Eroare necunoscută:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Eroare necunoscută:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Eroare necunoscută:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Eroare necunoscută:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Nicio eroare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>Tensiune AC L1 prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>Tensiune AC prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Tensiune AC L1 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Tensiune AC prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Frecventa AC L1 prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Frecventa AC prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Frecventa AC L1 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Frecventa AC prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>Intensitate AC L1 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>Intensitate AC prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Putere AC L1 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>Putere AC prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Oprire de urgenta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Intensitate servo prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Presiune ulei prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Presiune ulei prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Temperatura motor prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Temperatura motor prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Temperatura bobinajului prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Temperatura bobinajului prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Temperatura evacuare prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Temperatura evacuare prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Temperatură electronică scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Temperatură electronică ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Tensiune de pornire prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Intensitate demaror prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Tensiune de aprindere prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Curent aprindere prea ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Tensiune de ajutor la pornire la rece prea ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Curent de ajutor la pornire la rece prea ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Tensiunea magnetului de menținere a combustibilului prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Intensitatea curentului electrovalvei este prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Tensiunea bobinei de menținere a solenoidului de oprire este prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Intensitatea curentului in bobina electrovalvei este prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Tensiunea bobinei de tragere a solenoidului de oprire prea scăzută </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Intensitatea curentului solenoidului de deconectare prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Tensiunea ventilatorului/pompei de apă prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Curentul ventilatorului/pompei de apă prea ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Tensiunea senzorului de curent scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Curentul senzorului de curent ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Tensiunea de ieșire a amplificatorului prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Intensitate boost prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Curent de alimentare a bărilor colectoare prea scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Curent de alimentare a bărilor colectoare prea ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Tensiune baterie de pornire prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Tensiune baterie de pornire prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Turatie prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Turatie prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Oprire neașteptată/problemă cu alimentarea cu combustibil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Tensiunea contactorului de putere prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Intensitate releu putere prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>Tensiune AC L2 prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Tensiune AC L2 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>Frecventa AC L2 prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Frecventa AC L2 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>Intensitate AC L2 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>Putere AC L2 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Tensiune AC L3 prea scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>Tensiune AC L3 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Frecventa AC L3 scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Frecventa AC L3 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>Intensitate AC L3 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>Putere AC L3 prea ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Tensiunea invertorului de ieșire prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Curentul invertorului de ieșire prea ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Tensiunea ieșirii universale (1A) prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Curentul ieșirii universale (1A) prea scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Tensiunea ieșirii universale (5A) prea scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Curentul ieșirii universale (5A) prea scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Tensiune continuă AGT 1 scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Tensiune continuă AGT 1 ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>Curent continuu AGT 1 scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>Curent continuu AGT 1 ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Tensiune continuă AGT 2 scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Tensiune continuă AGT 2 ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>Curent continuu AGT 2 scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>Curent continuu AGT 2 ridicat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Răcitor AGT B6 scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>Răcitor AGT B6 scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>Șină AGT B6 (-) scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>Șină AGT B6 (-) ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>Șină AGT B6 (+) scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>Șină AGT B6 (+) ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Temperatura cobustibil scazuta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Temperatura cobustibil ridicata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Nivel combustibil scazut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Unitate de contro deconectata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Panou deconectat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Servisare necesara</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Modul trifazic deconectat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Modul AGT deconectat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Sincronizare esuata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>ECU extern pierdut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Filtru de aer admisie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Mesaj de diagnosticare (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Modul sincronizare deconectat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Echilibrare esuata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Mod sincronizare dezactivat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Indicator roșu de oprire (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Indicator de avertizare chihlimbar (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Indicator defecțiune (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Indicator de protecție (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Camp rotatie gresit</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Senzor nivel combustibil deconectat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Pornirea fără invertor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Bară colectoare 1 sub tensiune</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Cerere de pornire refuzată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Pornire de la distanță refuzată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Deconectare forțată a releului de sarcină</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Modulul de sincronizare este offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>BMS pierdut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Tensiunea legăturii de c.c. al convertorului scăzută/Inversare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Curentul de legătură de c.c. al convertorului scăzut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Tensiunea de preîncărcare c.c. a convertorului scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Tensiunea de preîncărcare c.c. a convertorului ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Eroare driver IGBT/MOSFET convertor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Bucla de control al puterii de eroare a convertorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Detectarea frecvenței CA a convertorului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Eroare valoare control convertor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Setare din fabrică modificată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parametru modificat în modul admin</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Intervenție manuală (sistem ext.)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Initializare esuata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Monitorizare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Temperatură ridicată a invertorului L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Temperatură ridicată a invertorului L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Temperatură ridicată a invertorului L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Temperatura ridicată a invertorului pentru legătura CC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Invertor supraincarcat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Comunicarea cu invertorul intrerupta</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Supraincarcare DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Supratensiune DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Fara conexiune</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Nicio eroare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Eroare necunoscută: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Eroare necunoscută:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Presiunea uleiului</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Supratemperatură cap cilindru</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Controlul încărcării</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Viteză mai mare decât cea așteptată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Viteză excesivă</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Temperatura uleiului mai mare decât cea preconizată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Circuit deschis al temperaturii uleiului / scurtcircuit la alimentare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Temperatura uleiului scurtcircuitată la masă</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Punct de referință analogic ridicat / scurtcircuit la alimentare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Punct de referință analogic scăzut / scurtcircuit la masă</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Timeout primire mesaj TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Timeout primire mesaj CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Tensiune ridicată baterie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Tensiunea bateriei scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Semnal de viteză distorsionat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Senzor intern de 5 V cu alimentare ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Senzor intern de 5 V cu alimentare scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Presiune barometrică ridicată</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Presiune barometrică scăzută</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Pompă de combustibil de ieșire scurtcircuitată la alimentare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Pompa de combustibil de ieșire scurtcircuitată la masă</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Bujie incandescentă de ieșire scurtcircuitată la alimentare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Bujia de incandescență de ieșire scurtcircuitată la masă</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Circuit deschis al injectorului/partea inferioară scurtcircuitat(ă) la masă</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Bobina injectorului scurtcircuită intern</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Partea inferioară a injectorului scurtcircuită la alimentare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Ore de service expirate</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Defecțiune procesor</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Eroare necunoscută:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Baterie</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Baterie</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Frigider</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Frigider</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Generic</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Generic</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Camera</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Camera</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>În aer liber</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>În aer liber</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Încălzitor de apă</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Încălzitor de apă</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Congelator</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Congelator</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Eroare necunoscută:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Nicio eroare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>Tensiune AC L1 prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>Tensiune AC prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>Tensiune AC L1 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>Tensiune AC prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>Frecventa AC L1 prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>Frecventa AC prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>Frecventa AC L1 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>Frecventa AC prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>Intensitate AC L1 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>Intensitate AC prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>Putere AC L1 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>Putere AC prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Oprire de urgenta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Intensitate servo prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Presiune ulei prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Presiune ulei prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Temperatura motor prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Temperatura motor prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Temperatura bobinajului prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Temperatura bobinajului prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Temperatura evacuare prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Temperatura evacuare prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Temperatură electronică scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Temperatură electronică ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Tensiune de pornire prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Intensitate demaror prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Tensiune de aprindere prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Curent aprindere prea ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Tensiune de ajutor la pornire la rece prea ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Curent de ajutor la pornire la rece prea ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Tensiunea magnetului de menținere a combustibilului prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Intensitatea curentului electrovalvei este prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Tensiunea bobinei de menținere a solenoidului de oprire este prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Intensitatea curentului in bobina electrovalvei este prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Tensiunea bobinei de tragere a solenoidului de oprire prea scăzută </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Intensitatea curentului solenoidului de deconectare prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Tensiunea ventilatorului/pompei de apă prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Curentul ventilatorului/pompei de apă prea ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Tensiunea senzorului de curent scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Curentul senzorului de curent ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Tensiunea de ieșire a amplificatorului prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Intensitate boost prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Curent de alimentare a bărilor colectoare prea scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Curent de alimentare a bărilor colectoare prea ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Tensiune baterie de pornire prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Tensiune baterie de pornire prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Turatie prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Turatie prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Oprire neașteptată/problemă cu alimentarea cu combustibil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Tensiunea contactorului de putere prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Intensitate releu putere prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>Tensiune AC L2 prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>Tensiune AC L2 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>Frecventa AC L2 prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>Frecventa AC L2 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>Intensitate AC L2 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>Putere AC L2 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>Tensiune AC L3 prea scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>Tensiune AC L3 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>Frecventa AC L3 scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>Frecventa AC L3 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>Intensitate AC L3 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>Putere AC L3 prea ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Tensiunea invertorului de ieșire prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Curentul invertorului de ieșire prea ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Tensiunea ieșirii universale (1A) prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Curentul ieșirii universale (1A) prea scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Tensiunea ieșirii universale (5A) prea scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Curentul ieșirii universale (5A) prea scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>Tensiune continuă AGT 1 scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>Tensiune continuă AGT 1 ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>Curent continuu AGT 1 scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>Curent continuu AGT 1 ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Tensiune continuă AGT 2 scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Tensiune continuă AGT 2 ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>Curent continuu AGT 2 scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>Curent continuu AGT 2 ridicat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>Răcitor AGT B6 scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>Răcitor AGT B6 scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>Șină AGT B6 (-) scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>Șină AGT B6 (-) ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>Șină AGT B6 (+) scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>Șină AGT B6 (+) ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Temperatura cobustibil scazuta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Temperatura cobustibil ridicata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Nivel combustibil scazut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Unitate de contro deconectata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Panou deconectat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Servisare necesara</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Modul trifazic deconectat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Modul AGT deconectat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Sincronizare esuata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>ECU extern pierdut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Filtru de aer admisie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Mesaj de diagnosticare (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Modul sincronizare deconectat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Echilibrare esuata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Mod sincronizare dezactivat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Indicator roșu de oprire (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Indicator de avertizare chihlimbar (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Indicator defecțiune (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Indicator de protecție (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Camp rotatie gresit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Senzor nivel combustibil deconectat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Pornirea fără invertor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Bară colectoare 1 sub tensiune</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Cerere de pornire refuzată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Pornire de la distanță refuzată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Deconectare forțată a releului de sarcină</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Modulul de sincronizare este offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>BMS pierdut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Tensiunea legăturii de c.c. al convertorului scăzută/Inversare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Curentul de legătură de c.c. al convertorului scăzut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Tensiunea de preîncărcare c.c. a convertorului scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Tensiunea de preîncărcare c.c. a convertorului ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Eroare driver IGBT/MOSFET convertor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Bucla de control al puterii de eroare a convertorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Detectarea frecvenței CA a convertorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Eroare valoare control convertor</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Setare din fabrică modificată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parametru modificat în modul admin</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Intervenție manuală (sistem ext.)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Initializare esuata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Monitorizare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Temperatură ridicată a invertorului L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Temperatură ridicată a invertorului L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Temperatură ridicată a invertorului L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Temperatura ridicată a invertorului pentru legătura CC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Invertor supraincarcat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Comunicarea cu invertorul intrerupta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>Supraincarcare DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>Supratensiune DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Fara conexiune</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Nicio eroare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Eroare necunoscută: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Eroare necunoscută:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Presiunea uleiului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Supratemperatură cap cilindru</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Controlul încărcării</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Viteză mai mare decât cea așteptată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Viteză excesivă</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Temperatura uleiului mai mare decât cea preconizată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Circuit deschis al temperaturii uleiului / scurtcircuit la alimentare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Temperatura uleiului scurtcircuitată la masă</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Punct de referință analogic ridicat / scurtcircuit la alimentare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Punct de referință analogic scăzut / scurtcircuit la masă</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Timeout primire mesaj TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Timeout primire mesaj CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Tensiune ridicată baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Tensiunea bateriei scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Semnal de viteză distorsionat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Senzor intern de 5 V cu alimentare ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Senzor intern de 5 V cu alimentare scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Presiune barometrică ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Presiune barometrică scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Pompă de combustibil de ieșire scurtcircuitată la alimentare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Pompa de combustibil de ieșire scurtcircuitată la masă</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Bujie incandescentă de ieșire scurtcircuitată la alimentare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Bujia de incandescență de ieșire scurtcircuitată la masă</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Circuit deschis al injectorului/partea inferioară scurtcircuitat(ă) la masă</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Bobina injectorului scurtcircuită intern</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Partea inferioară a injectorului scurtcircuită la alimentare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Ore de service expirate</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Defecțiune procesor</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Poziționați comutatorul într-o poziție de deblocare pentru a modifica setările.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Utilizați sursa de date D-Bus: conectați-vă la adresa D-Bus specificată.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Utilizați sursa de date D-Bus: conectați-vă la adresa D-Bus standard</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Utilizați sursa de date MQTT: conectați-vă la adresa de broker MQTT specificată.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>ID-ul portalului de dispozitiv al sursei de date MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>ID portal</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>MQTT VRM webhost segment</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>segment</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Nume de utilizator sursă de date MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Utilizator</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Parola sursei de date MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>par</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Tokenul sursei de date MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>token</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Activează contorul FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Omite ecranul de întâmpinare</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Utilizați o sursă de date simulată pentru testare.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Ora standard Maroc</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Ora standard Africa Centrală si de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Ora standard Africa de Sud</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Ora standard Namibia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Ora standard Egipt</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Ora standard Africa de Est</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Ora standard Argentina</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Ora standard America de Sud si de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Ora standard Groenlanda</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Ora standard Montevideo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Ora standard Newfoundland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Ora standard SA de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Ora standard Atlantic</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Ora standard Brazilia Centrala</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Ora standard Pacific SA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Ora standard Paraguay</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Ora standard SA de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Ora standard Venezuela</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Ora standard de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Ora standard SA Pacific</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Ora standard Statele Unite de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Ora standard Canada Centrala</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Ora standard America Centrala</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Ora standard Centrala (Mexic)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Ora standard Centrala</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Ora standard montana (Mexic)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Ora standard montana</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Ora standard montana Statele Unite</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Ora standard Pacific (Mexic)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Ora standard Pacific</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Ora standard Alaska</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Ora standard Hawaii-Aleutian</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Ora standard Noua Zeelanda</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Ora standard Pacific Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Ora standard Pacific de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Ora standard Australia de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Ora standard Asia SE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Ora standard Asia Centrală</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Ora standard Asia de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Ora standard Africa de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Ora standard Pacific SA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Ora standard SA de Vest</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Ora Europei de Vest</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Ora standard Kamceatka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Ora standard Magadan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Ora standard Vladivostok</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Ora standard Yakutsk</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Ora standard Tokyo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Ora standard Coreea</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Ora standard Singapore</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Ora standard Ulaanbaatar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Ora standard Taipei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Ora standard Asia de Nord-Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Ora standard China</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Ora standard Asia SE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Ora standard Asia de Nord</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Ora standard Myanmar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Ora standard Asia Centrală-Nord</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Ora standard Asia Centrală</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Ora standard Bangladesh</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Ora standard Nepal</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Ora standard Sri Lanka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Ora standard India</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Ora standard Asia de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Ora standard Pakistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Ora standard Ekaterinburg</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Ora standard Georgia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Ora standard Caucaz</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Ora standard Azerbaijan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Ora standard Araba</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Ora standard Afghanistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Ora standard Iran</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Ora standard Araba</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Ora standard Araba</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Ora standard Syria</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Ora standard Orientul Mijlociu</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Ora standard Iordania</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Ora standard Israel</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Greenwich Mean Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Ora standard Azore</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Ora standard Capul Verde</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Ora standard Tazmania</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Ora standard Australia de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Ora standard AUS de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Ora standard Australia Centrala</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Ora standard AUS Centrala</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Ora standard Australia de Vest</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Ora standard Atlantic Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Ora standard Linia datei</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>Ora GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Ora Europei Centrale</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Ora Central Europeana</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Ora standard Romance</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Ora Europei de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Ora Europei de Est</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Ora standard FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Ora standard GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Ora standard Belarus</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Ora Standard Rusă</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Ora standard Turcia</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Ora standard Mauritius</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Ora standard a Insulei Crăciunului</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Ora standard Tonga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Ora Standard Fiji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Ora standard Noua Zeelanda</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Ora standard Pacific Central</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Ora standard Pacific de Vest</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Samoa Ora Standard</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Ora standard Hawaii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Ora standard a Insulei Paștelui</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Eroare interna</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Eroare necunoscută:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Eroare interna</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Nicio eroare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Temperatura ridicată baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Tensiune ridicata baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Tensiune scazuta baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Tensiunea bateriei a depășit configurația max.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Temperatura ridicată a alternatorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Rotații mari ale alternatorului pe minut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Temperatură ridicată FET de unitate de teren</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Senzorul necesar lipsește</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Alternator de joasă tensiune</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Decalaj de înaltă tensiune a alternatorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Tensiunea alternatorului a depășit configurația max.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Tensiune ridicată a alternatorului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Bateria deconectată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Deconectare tensiune ridicată a bateriei</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Instanța bateriei este în afara intervalului</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Prea multe BMS-uri</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Bateria urmează să se deconecteze</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Prea multe dispozitive de urmărit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Deconectare tensiune mică baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Deconectare curent mare baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Deconectarea bateriei la temperatură ridicată</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Deconectarea bateriei la temperatură scăzută</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Conexiune BMS pierduta</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC dezactivat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>Convertorul CD/CD nu este pregătit</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>Tensiune primară mare CD/CD</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>Tensiune primară mică CD/CD</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>Tensiune secundară mare CD/CD</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>Tensiune secundară mică CD/CD</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>Temperatură ridicată CD/CD</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>Configurare greșită CD/CD</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Senzorul de temperatură al bateriei este defect</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_ru.ts
+++ b/i18n/venus-gui-v2_ru.ts
@@ -1,10377 +1,11085 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ru">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Отключено</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Отключено</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Перегрузка инвертора</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Перегрузка инвертора</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Мощность</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Мощность</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Выкл</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Выкл</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Авто</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Авто</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Батарея</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Подключено</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Отключено</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Генератор</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Высокое напряжение батареи</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Высокое напряжение батареи</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Инвертор / зарядное устройство</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Инвертор / зарядное устройство</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Низкое напряжение батареи</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Низкое напряжение батареи</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Вручную</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Вручную</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Нет</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Нет</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Положение</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Положение</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Скорость</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Скорость</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Состояние</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Состояние</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Устанавливается %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Устанавливается %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Неизвестная ошибка</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Неизвестная ошибка</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Минимальное состояние заряда батареи</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Минимальное состояние заряда батареи</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Неизвестно</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Введите пароль</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Введите пароль</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Нажмите для проверки</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Нажмите для проверки</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Сеть</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Сеть</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Выход солнечной энергии</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Выход солнечной энергии</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Внешнее управление</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Внешнее управление</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Резервуары</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Резервуары</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Окружающая среда</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Окружающая среда</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Нет текущих оповещений</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Нет текущих оповещений</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Общие</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Общие</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Прошивка</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Прошивка</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Дата &amp; время</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Дата &amp; время</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Установка системы</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Установка системы</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Экран &amp; язык</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Экран &amp; язык</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>Онлайн-портал VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>Онлайн-портал VRM</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Измерители энергии</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Измерители энергии</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>Фотоэлектрические инверторы</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>Фотоэлектрические инверторы</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>Модем GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>Модем GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Запуск/остановка генератора</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Запуск/остановка генератора</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Насос резервуара</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Насос резервуара</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Служба клиентской поддержки</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Служба клиентской поддержки</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Функции устройства Venus OS Large</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Функции устройства Venus OS Large</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Предельный срок службы батареи: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Предельный срок службы батареи: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Автоматический запуск</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Автозапуск будет отключен, и генератор не будет автоматически запускаться в соответствии с заданными условиями.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Автозапуск будет отключен, и генератор не будет автоматически запускаться в соответствии с заданными условиями.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Ручная остановка</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Ручная остановка</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Ручной запуск</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Ручной запуск</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Положение</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Автоматический запуск</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Автоматический запуск</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Переключатели</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Переключатели</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Уровень доступа</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Уровень доступа</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Пользователь</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Пользователь</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Пользователь &amp; установщик</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Пользователь &amp; установщик</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Суперпользователь</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Суперпользователь</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Настраиваемая услуга: {name}</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Настраиваемая услуга: {name}</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Убедитесь, что после отключения DVCC система VE.Bus также сброшена.</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Убедитесь, что после отключения DVCC система VE.Bus также сброшена.</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Ограничение тока заряда</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Ограничение тока заряда</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Максимальный ток заряда</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Максимальный ток заряда</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Использовать %1</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Использовать %1</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Начните, когда %1 будет больше, чем</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Начните, когда %1 будет больше, чем</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Начните, когда %1 будет меньше, чем</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Начните, когда %1 будет меньше, чем</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Остановитесь, если %1 больше, чем</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Остановитесь, если %1 больше, чем</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Остановитесь, когда %1 станет меньше</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Остановитесь, когда %1 станет меньше</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Удалить IP-адрес?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Удалить IP-адрес?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Максимум: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Максимум: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Подключение</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Подключение</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Продукт</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Продукт</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Имя</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Имя</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Имя</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>ID продукта</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>ID продукта</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Версия аппаратной части</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Версия аппаратной части</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Имя устройства</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Имя устройства</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Управление внешним переключателем отключено</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Управление внешним переключателем отключено</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Генератор в неисправном состоянии</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Генератор в неисправном состоянии</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Генератор не обнаружен на входе переменного тока</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Генератор не обнаружен на входе переменного тока</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Общее время работы от последнего тестового запуска</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Общее время работы от последнего тестового запуска</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Время до следующего тестового запуска</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Время до следующего тестового запуска</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Сейчас работает</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Сейчас работает</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Ручной запуск</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Ручной запуск</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Запуск генератора</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Запуск генератора</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Ежедневное время работы</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Ежедневное время работы</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Значение должно быть выше, чем конечное значение</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Значение должно быть выше, чем конечное значение</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Значение должно быть ниже, чем начальное значение</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Значение должно быть ниже, чем начальное значение</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>AC выход</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>AC выход</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">AC выход</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Используйте АС нагр. для запуска/остановки</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Используйте АС нагр. для запуска/остановки</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Измерение</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Измерение</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Общее потребление</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Общее потребление</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Общий выход инвертора переменного тока</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Общий выход инвертора переменного тока</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Самая высока фаза AC out инвертера</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Самая высока фаза AC out инвертера</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Запуск, если мощность выше, чем</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Запуск, если мощность выше, чем</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Остановка, когда мощность ниже, чем</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Остановка, когда мощность ниже, чем</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Батарейный монитор</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Батарейный монитор</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Батарейный монитор недоступен, выберите другой</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Батарейный монитор недоступен, выберите другой</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Батарейный монитор</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Батарейный монитор недоступен, выберите другой</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>После потери связи</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>После потери связи</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Остановка генератора</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Остановка генератора</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Поддержание работы генератора</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Поддержание работы генератора</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Остановка генератора при наличии переменного тока</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Остановка генератора при наличии переменного тока</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>Состояние заряда аккумулятора</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>Состояние заряда аккумулятора</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Высокая температура инвертера</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Высокая температура инвертера</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Высокая температура инвертера</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Внимание, запуск при высокой температуре</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Внимание, запуск при высокой температуре</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Внимание, запуск при перегрузке</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Внимание, запуск при перегрузке</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Периодическое включение</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Периодическое включение</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Интервал работы</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Интервал работы</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 день(ы)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 день(ы)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Пропустить запуск, если длительность была свыше</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Пропустить запуск, если длительность была свыше</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Всегда</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Всегда</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Дата начала интервала работы</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Дата начала интервала работы</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Длительность работы (чч:мм)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Длительность работы (чч:мм)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Выполнять до полной зарядки батареи</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Выполнять до полной зарядки батареи</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS ОК (фиксированно)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS ОК (фиксированно)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS подключен, но нет фикса GPS</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS подключен, но нет фикса GPS</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>GPS не подключен</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>GPS не подключен</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Широта</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Широта</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Долгота</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Долгота</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 км/ч</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 км/ч</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 миф</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 миф</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 кт</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 кт</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 м/с</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 м/с</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Курс</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Курс</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Высота</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Высота</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Количество спутников</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Количество спутников</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Точка установки сети</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Точка установки сети</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Заданное значение переменного тока</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Заданное значение переменного тока</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Текущий: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Текущий: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Напряжение: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Напряжение: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Пределы (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Пределы (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Заряд: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Заряд: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Разряд: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Разряд: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Пределы (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Пределы (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Видимый</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Видимый</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Скрытый</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Скрытый</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Дополнительное измерение)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Дополнительное измерение)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Выход %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Выход %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Активный мониторинг батареи</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Активный мониторинг батареи</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Имя</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Введите имя</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Введите имя</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Введите имя</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Непрерывное сканирование</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Непрерывное сканирование</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Bluetooth-адаптеры</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Bluetooth-адаптеры</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>PIN-код</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>PIN-код</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Перед подключением может потребоваться удаление существующей информации о сопряжении.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Перед подключением может потребоваться удаление существующей информации о сопряжении.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Тип фазы</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Тип фазы</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Одна фаза</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Одна фаза</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Много фаз</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Много фаз</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>PV инвертер в фазе 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>PV инвертер в фазе 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>PV инвертер в фазе 2, положение</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>PV инвертер в фазе 2, положение</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>Профиль CAN-шины</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>Профиль CAN-шины</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Отключено</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 кбит/с)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 кбит/с)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 кбит/с)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 кбит/с)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Вверх, но без услуг (250 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Вверх, но без услуг (250 кбит/с)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Устройства</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Устройства</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>Выход NMEA 2000</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>Выход NMEA 2000</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Селектор уникальных идентификационных номеров</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Селектор уникальных идентификационных номеров</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Пожалуйста, подождите: изменение и проверка уникального номера занимает определенное время</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Пожалуйста, подождите: изменение и проверка уникального номера занимает определенное время</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Вышеуказанный параметр задает, какой блок уникальных идентификационных номеров использовать для уникальных идентификационных номеров NAME в поле PGN 60928 NAME. Изменяется только при использовании нескольких устройств GX в одной сети VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Вышеуказанный параметр задает, какой блок уникальных идентификационных номеров использовать для уникальных идентификационных номеров NAME в поле PGN 60928 NAME. Изменяется только при использовании нескольких устройств GX в одной сети VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Вышеуказанный параметр задает, какой блок уникальных идентификационных номеров использовать для серийного номера в поле DGN 60928 ADDRESS_CLAIM. Изменяется только при использовании нескольких устройств GX в одной сети RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Вышеуказанный параметр задает, какой блок уникальных идентификационных номеров использовать для серийного номера в поле DGN 60928 ADDRESS_CLAIM. Изменяется только при использовании нескольких устройств GX в одной сети RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Проверка уникальных идентификационных номеров</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Проверка уникальных идентификационных номеров</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Нажмите для проверки</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>К этому уникальному номеру подключено другое устройство, пожалуйста, выберите новый номер.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>К этому уникальному номеру подключено другое устройство, пожалуйста, выберите новый номер.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>ОК: ни одно другое устройство не связано с этим уникальным номером.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>ОК: ни одно другое устройство не связано с этим уникальным номером.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Статус сети</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Статус сети</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Настраиваемая яркость</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Настраиваемая яркость</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Яркость</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Яркость</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Время отключения экрана</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Время отключения экрана</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 секунд</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 секунд</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 секунд</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 секунд</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 минута</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 минута</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 минут</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 минут</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 минут</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 минут</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Никогда</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Никогда</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Режим отображения</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Режим отображения</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>темный</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>темный</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>свет</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>свет</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Уровни краткого обзора</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Уровни краткого обзора</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Язык</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Язык</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Изменение языка</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Изменение языка</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Индикация электрической мощности</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Индикация электрической мощности</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Мощность (Вт)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Мощность (Вт)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Ток (амперы)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Ток (амперы)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Единицы</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Единицы</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Уровень %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Уровень %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Цельсия (°C)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Цельсия (°C)</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Фаренгейта (F)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Фаренгейта (F)</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;ВНИМАНИЕ: &lt;/b&gt; Перед настройкой прочтите руководство.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;ВНИМАНИЕ: &lt;/b&gt; Перед настройкой прочтите руководство.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Предельное управляемое напряжение заряда батареи</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Предельное управляемое напряжение заряда батареи</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Максимальное напряжение заряда</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Максимальное напряжение заряда</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - Совместное определение напряжения</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - Совместное определение напряжения</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>SТS - Совместное определение температуры</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>SТS - Совместное определение температуры</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Датчик недоступен, установите другой</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Датчик недоступен, установите другой</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Датчик недоступен, установите другой</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Используемый датчик</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Используемый датчик</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS-общее значение тока</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS-общее значение тока</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Статус SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Статус SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Отключено (Внешнее управление)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Отключено (Внешнее управление)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Отключено (без зарядных устройств)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Отключено (без зарядных устройств)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Отключено (нет монитора батареи)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Отключено (нет монитора батареи)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Автоматический выбор</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Автоматический выбор</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>BMS управление отсутствует</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>BMS управление отсутствует</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Управляющая система BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Управляющая система BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Недоступно, выберите другой вариант</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Недоступно, выберите другой вариант</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Автоматический выбор</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Автоматический выбор</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Нет</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Дата/время релиза</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Дата/время релиза</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Обновления онлайн</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Обновления онлайн</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Установить прошивку с SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Установить прошивку с SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Сохраненная резервная прошивка</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Сохраненная резервная прошивка</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Проверка наличия обновлений на SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Проверка наличия обновлений на SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Прошивка найдена</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Прошивка найдена</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Установка %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Установка %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Нажмите обновить до %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Нажмите обновить до %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Нажмите обновить до %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Прошивка выпущена (дата/время)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Прошивка выпущена (дата/время)</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Автообновление</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Автообновление</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Только проверка</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Только проверка</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Только проверка и скачивание</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Только проверка и скачивание</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Проверка и обновление</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Проверка и обновление</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Лента обновлений</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Лента обновлений</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Тип изображения</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Тип изображения</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Нормальное</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Нормальное</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Крупный</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Крупный</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Проверка обновлений</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Проверка обновлений</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Доступно обновление</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Доступно обновление</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Устанавливается %1%2 %</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Устанавливается %1%2 %</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Устанавливается %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Обновить дату/время релиза</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Обновить дату/время релиза</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Инверторы</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Инверторы</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Инверторы PV найдены</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Инверторы PV найдены</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Обнаруженные IP адреса</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Обнаруженные IP адреса</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Добавить IP адреса вручную</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Добавить IP адреса вручную</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>Порт TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>Порт TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Многофазный</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Многофазный</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Сплит-фаза (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Сплит-фаза (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Показать</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Показать</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1...</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1...</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1...</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out...</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out...</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2...</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2...</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Повторное сканирование IP-адресов?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Повторное сканирование IP-адресов?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Сканировать снова</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Сканировать снова</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH по LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH по LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Удаленная поддержка</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Удаленная поддержка</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Туннель дистанционной поддержки</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Туннель дистанционной поддержки</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>IP и порт дистанционной поддержки</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>IP и порт дистанционной поддержки</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Выйти из системы</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Перезагрузитесь сейчас</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Перезагрузитесь сейчас</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Устройство было перезагружено.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Звуковая сигнализация</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Звуковая сигнализация</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Демо-режим</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Демо-режим</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS демо</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS демо</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Демо 1 лодки/кемпера</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Демо 1 лодки/кемпера</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Демо 2 лодки/дома на колесах</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Демо 2 лодки/дома на колесах</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Запуск демо режима приведет к изменению некоторых настроек, интерфейс пользователя на некоторое время перестанет отвечать.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Запуск демо режима приведет к изменению некоторых настроек, интерфейс пользователя на некоторое время перестанет отвечать.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Условия</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Условия</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Минимальное время работы</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Минимальное время работы</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Время разминки</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Время разминки</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Время охлаждения</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Время охлаждения</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Определить генератор на АС входе</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Определить генератор на АС входе</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Ни один из АС входов не назначен генератору. Зайдите в системные настройки и установите корректный АС вход для генератора для включения его функций.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Ни один из АС входов не назначен генератору. Зайдите в системные настройки и установите корректный АС вход для генератора для включения его функций.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Сигнализация сработает, если от генератора на вход переменного тока инвертора не будет поступать мощность. Убедитесь, что генератору назначен правильный вход переменного тока на странице системных настроек.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Сигнализация сработает, если от генератора на вход переменного тока инвертора не будет поступать мощность. Убедитесь, что генератору назначен правильный вход переменного тока на странице системных настроек.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Начало тихих часов</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Начало тихих часов</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Окончание тихих часов</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Окончание тихих часов</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Время работы и обслуживание</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Время работы и обслуживание</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Сброс счетчиков ежедневной работы</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Сброс счетчиков ежедневной работы</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Счетчик ежедневной работы был обнулен</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Счетчик ежедневной работы был обнулен</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Нет возможности изменить счетчики во время работы генератора</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Нет возможности изменить счетчики во время работы генератора</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Интервал обслуживания генератора (часы)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Интервал обслуживания генератора (часы)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Интервал времени обслуживания установлен на %1h. Используйте кнопку "Сброс сервисного таймера", чтобы сбросить сервисный таймер.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Интервал времени обслуживания установлен на %1h. Используйте кнопку &quot;Сброс сервисного таймера&quot;, чтобы сбросить сервисный таймер.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Сброс таймера обслуживания</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Сброс таймера обслуживания</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Настройки GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Настройки GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>yyyy-mm-dd</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>yyyy-mm-dd</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Единица скорости</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Единица скорости</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Километры в час</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Километры в час</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Метры в секунду</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Метры в секунду</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Мили в час</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Мили в час</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Узлы</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Узлы</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Нет подключенного модема GSM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Нет подключенного модема GSM</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>интернет</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>интернет</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Носитель</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Носитель</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Может потребоваться настройка APN, обратитесь к своему поставщику услуг за дополнительной информацией.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Может потребоваться настройка APN, обратитесь к своему поставщику услуг за дополнительной информацией.
 Если устройство не работает, проверьте SIM-карту, убедившись, что баланс положительный и услуги передачи данных подключены.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Разрешить роуминг</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Разрешить роуминг</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Сим-статус</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Сим-статус</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM-карта не вставлена</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM-карта не вставлена</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>Требуется PIN-код</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>Требуется PIN-код</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>Требуется PUK-код</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>Требуется PUK-код</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Ошибка SIM-карты</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Ошибка SIM-карты</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM-карта занята</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM-карта занята</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Неверная SIM-карта</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Неверная SIM-карта</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Неверный PIN-код</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Неверный PIN-код</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>готов</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>готов</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Неизвестная ошибка</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>По умолчанию</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>По умолчанию</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Использовать APN по умолчанию</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Использовать APN по умолчанию</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Имя APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Имя APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Использовать аутентификацию</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Использовать аутентификацию</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Имя пользователя</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Имя пользователя</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Собственное потребление</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Собственное потребление</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Помощник ESS не найден</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Помощник ESS не найден</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Счетик сети</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Счетик сети</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Внешний замер</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Внешний замер</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Инвертор/зарядное устройство</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Инвертор/зарядное устройство</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Выход переменного тока инвертора используется</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Выход переменного тока инвертора используется</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Многофазное регулирование</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Многофазное регулирование</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Общее всех фаз</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Общее всех фаз</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Отдельная фаза</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Отдельная фаза</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Каждая фаза регулируется для индивидуального достижения заданного значения сети (эффективность системы снижается).
+        <translation>Каждая фаза регулируется для индивидуального достижения заданного значения сети (эффективность системы снижается).
 
 ВНИМАНИЕ: Используйте только в том случае, если этого требует поставщик коммунальных услуг.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Суммарная мощность всех фаз интеллектуально регулируется для достижения заданного значения в сети (эффективность системы оптимизирована).
+        <translation>Суммарная мощность всех фаз интеллектуально регулируется для достижения заданного значения в сети (эффективность системы оптимизирована).
 
 Используйте, если это не запрещено поставщиком коммунальных услуг.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Неактивно</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Динамическая ESS (система включения аварийного сигнала)</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Минимум SOC разряда (без неисправности сети)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Минимум SOC разряда (без неисправности сети)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Действующее ограничение состояния заряда батареи</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Действующее ограничение состояния заряда батареи</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Удержание</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Зарядка</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Ограничение пиковой нагрузки</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Ограничение пиковой нагрузки</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Только выше минимального уровня заряда</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Только выше минимального уровня заряда</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Всегда</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Всегда</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Разряд отключен</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Разряд отключен</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Медленный заряд</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Медленный заряд</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Удержание</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Удержание</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Зарядка</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Зарядка</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Ограничение мощности заряда</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Ограничение мощности заряда</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Максимальная мощность заряда</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Максимальная мощность заряда</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Ограничение мощности инвертора</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Ограничение мощности инвертора</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Максимальная мощность инвертора</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Максимальная мощность инвертора</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Точка установки сети</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Точка установки сети</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Подача сети</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Подача сети</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>Фотоэлектрический генератор переменного тока - чрезмерная подача</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>Фотоэлектрический генератор переменного тока - чрезмерная подача</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>Фотоэлектрический генератор постоянного тока - чрезмерная подача</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>Фотоэлектрический генератор постоянного тока - чрезмерная подача</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Система ограничения подачи</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Система ограничения подачи</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Максимальная подача</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Максимальная подача</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Ограничение  подачи активно</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Ограничение  подачи активно</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Аналоговые входы</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Аналоговые входы</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Цифровые входы</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Цифровые входы</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Цифровой вход %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Цифровой вход %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Измеритель импульсов</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Измеритель импульсов</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Дверная сигнализация</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Дверная сигнализация</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Трюмный насос</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Трюмный насос</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Трюмная сигнализация</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Трюмная сигнализация</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Охранная сигнализация</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Охранная сигнализация</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Сигнализация задымления</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Сигнализация задымления</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Противопожарная сигнализация</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Противопожарная сигнализация</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>Сигнализация CO2</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>Сигнализация CO2</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Датчики Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Датчики Bluetooth</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Обратите внимание, что эти функции официально не поддерживаются компанией Victron. С вопросами вы можете обратиться к сообществу Victron community.victronenergy.com.
+        <translation>Обратите внимание, что эти функции официально не поддерживаются компанией Victron. С вопросами вы можете обратиться к сообществу Victron community.victronenergy.com.
 
 Документация на странице https://ve3.nl/vol.</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Сервер Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Сервер Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Сервер Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Сервер Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Включен (безопасный режим)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Включен (безопасный режим)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Отложено на %1 сек.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Отложено на %1 сек.</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID портала VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID портала VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Интервал логов</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Интервал логов</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 минут</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 минут</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 минут</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 минут</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 час</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 час</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 часа</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 часа</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 часов</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 часов</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 часов</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 часов</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 день</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 день</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Используйте защищенное соединение (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Используйте защищенное соединение (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Последний контакт</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Последний контакт</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Неожиданный текст ответа</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Неожиданный текст ответа</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Неожиданный HTTP-ответ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Неожиданный HTTP-ответ</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Таймаут соединения</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Таймаут соединения</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Ошибка подключения</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Ошибка подключения</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Сбой DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Сбой DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Ошибка маршрутизации</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Ошибка маршрутизации</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM недоступен</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM недоступен</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Неизвестная ошибка</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Неизвестная ошибка</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Сообщение об ошибке:
+        <translation>Сообщение об ошибке:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Перезагрузка устройства если нет контакта</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Перезагрузка устройства если нет контакта</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Нет задержки сброса контакта (чч:мм)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Нет задержки сброса контакта (чч:мм)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Где хранится</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Где хранится</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Нет активного буфера</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Нет активного буфера</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Внутренний накопитель</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Внутренний накопитель</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Передача</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Передача</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Внешнее накопитель</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Внешнее накопитель</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Неизвестная ошибка</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Без ошибок</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Без ошибок</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Места на устройстве хранения не осталось</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Места на устройстве хранения не осталось</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Ошибка ввода/вывода</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Ошибка ввода/вывода</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Ошибка монтирования</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Ошибка монтирования</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Содержит файл прошивки. Не используется.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Содержит файл прошивки. Не используется.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD карта / USB флешка без возможности записи</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD карта / USB флешка без возможности записи</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Свободное место на диске</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Свободное место на диске</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>байт</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>байт</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>байт</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>байт</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Сохраненные записи</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Сохраненные записи</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 запись</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 запись</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Самая ранняя дата записи</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Самая ранняя дата записи</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Включить Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Включить Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Ошибок не найдено</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Ошибок не найдено</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Время последней ошибки</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Время последней ошибки</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Доступные услуги</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Доступные услуги</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>Идентификатор устройства: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>Идентификатор устройства: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Функция (реле 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Функция (реле 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Функция</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Функция</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Реле сигнализации</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Реле сигнализации</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Насос резервуара</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Вручную</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Полярность реле сигнализации</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Полярность реле сигнализации</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Нормально разомкнуты</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Нормально разомкнуты</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Нормально замкнуты</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Нормально замкнуты</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Реле 1 ВКЛ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Реле 1 ВКЛ</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Реле Вкл</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Реле Вкл</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Функция (реле 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Функция (реле 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Реле 2 ВКЛ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Реле 2 ВКЛ</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Правила контроля температуры</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Правила контроля температуры</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Включение реле по температуре</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Включение реле по температуре</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Ни одно реле не настроено на активацию по температуре. Перейдите на страницу настроек реле, расположенную в главном меню настроек, и установите для функции реле значение "Температура".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Ни одно реле не настроено на активацию по температуре. Перейдите на страницу настроек реле, расположенную в главном меню настроек, и установите для функции реле значение &quot;Температура&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Эта опция позволяет переключаться между актуальной и предыдущей версиями прошивки. Интернет и карта SD не требуются.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Эта опция позволяет переключаться между актуальной и предыдущей версиями прошивки. Интернет и карта SD не требуются.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Прошивка %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Прошивка %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Нажмите для загрузки</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Нажмите для загрузки</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Прошивка %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Перезагрузка на %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Перезагрузка на %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Переключение версии прошивки невозможно, если для автоматического обновления установлено значение " Проверить и обновить". Установите автообновление на "Отключено" или "Только проверка", чтобы включить эту опцию.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Переключение версии прошивки невозможно, если для автоматического обновления установлено значение &quot; Проверить и обновить&quot;. Установите автообновление на &quot;Отключено&quot; или &quot;Только проверка&quot;, чтобы включить эту опцию.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Резервная прошивка недоступна</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Резервная прошивка недоступна</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Консоль по VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-шина через TCP/IP (отладка)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-шина через TCP/IP (отладка)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Мощность солнечной системы</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Мощность солнечной системы</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Транспортное средство</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Транспортное средство</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Лодка</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Лодка</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Имя системы</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Имя системы</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Автоматически</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Автоматически</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Сеть</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Автоматически</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Определяется пользователем</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Определяется пользователем</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Имя, определяемое пользователем</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Имя, определяемое пользователем</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>Вход переменного тока 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>Вход переменного тока 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>Вход переменного тока 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>Вход переменного тока 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Сбой мониторинга сети</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Сбой мониторинга сети</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Мониторинг отключения берегового канала</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Мониторинг отключения берегового канала</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Автоматический выбор</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Автоматический выбор</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Имеет DC систему</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Имеет DC систему</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Синхронизируйте состояние заряда VE.Bus с батареей</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Синхронизируйте состояние заряда VE.Bus с батареей</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Используйте ток солнечного зарядного устройства для подъема заряда VE.Bus</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Используйте ток солнечного зарядного устройства для подъема заряда VE.Bus</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Контроль напряжения солнечного зарядного устройства</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Контроль напряжения солнечного зарядного устройства</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Контроль тока солнечного зарядного устройства</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Контроль тока солнечного зарядного устройства</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS управление</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS управление</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS управление</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Не включена функция запуска/остановки насоса резервуара. Перейдите в настройки реле и установите функцию "Насос бака".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Не включена функция запуска/остановки насоса резервуара. Перейдите в настройки реле и установите функцию &quot;Насос бака&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Состояние насоса</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Состояние насоса</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Авто</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Датчик насоса</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Датчик насоса</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Уровень начала</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Уровень начала</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Уровень завершения</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Уровень завершения</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Соединение потеряно</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Соединение потеряно</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Отключено</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Отключено</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Скрыто]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Скрыто]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Подключиться к сети?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Подключиться к сети?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Подключение</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Подключение</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Забыть сеть?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Забыть сеть?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Забудьте</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Забудьте</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Вы уверены, что хотите забыть эту сеть?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Вы уверены, что хотите забыть эту сеть?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC адрес</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC адрес</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>IP конфигурация</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>IP конфигурация</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Вручную</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Выкл</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Зафиксировано</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Зафиксировано</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Маска сети</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Маска сети</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Шлюз</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Шлюз</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS сервер</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS сервер</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Локальный IP-адрес</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Локальный IP-адрес</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Осторожно, для систем ESS, а также систем с управляемой батареей экземпляр устройства CAN-bus должен оставаться настроенным на 0. Дополнительную информацию смотрите в руководстве GX.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Осторожно, для систем ESS, а также систем с управляемой батареей экземпляр устройства CAN-bus должен оставаться настроенным на 0. Дополнительную информацию смотрите в руководстве GX.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Экземпляр устройства</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Экземпляр устройства</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Сетевой адрес</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Сетевой адрес</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Устройства VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Устройства VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Устройство# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Устройство# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Не точек доступа</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Не точек доступа</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Нет подключенных Wi-Fi адаптеров</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Нет подключенных Wi-Fi адаптеров</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Создать точку доступа</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Создать точку доступа</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Сети Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Сети Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Вы уверены, что хотите отключить точку доступа?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Вы уверены, что хотите отключить точку доступа?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Дата/время UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Дата/время UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Дата/время местное</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Дата/время местное</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Часовой пояс</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Часовой пояс</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Африка</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Африка</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Америка</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Америка</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Антарктида</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Антарктида</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Artic</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Artic</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Азия</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Азия</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Атлантика</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Атлантика</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Австралия</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Австралия</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Европа</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Европа</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Индия</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Индия</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Тихий океан</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Тихий океан</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>далее</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>далее</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Неподключенный %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Неподключенный %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Перезагрузиться?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Перезагрузиться?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Изменения экземпляра VRM не будут применены до перезагрузки устройства.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Изменения экземпляра VRM не будут применены до перезагрузки устройства.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Устройство перезагружается...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Устройство перезагружается...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Устройство было перезагружено.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Устройство было перезагружено.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Сигнализация о низком напряжении батареи</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Сигнализация о низком напряжении батареи</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Сигнализация о высоком напряжении батареи</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Сигнализация о высоком напряжении батареи</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Последняя ошибка</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Последняя ошибка</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Предпоследняя ошибка</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Предпоследняя ошибка</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Третья последняя ошибка</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Третья последняя ошибка</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Четвертая последняя ошибка</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Четвертая последняя ошибка</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>В сети</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>В сети</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Установка режима</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Установка режима</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Отдельный</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Отдельный</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Отдельный</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Нагрузка</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Нагрузка</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Внешнее управление</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Зарядка &amp; HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Зарядка &amp; HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Зарядка &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Зарядка &amp; BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Внешнее управление и BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Внешнее управление и BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Зарядка, HUB-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Зарядка, HUB-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Настройка ведущего</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Настройка ведущего</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Ведомый</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Ведомый</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Ведомый</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Ведущий в группе</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Ведущий в группе</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Ведущий зарядки</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Ведущий зарядки</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Ведущий группы &amp; зарядки</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Ведущий группы &amp; зарядки</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Напряжение заряда</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Напряжение заряда</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Сброс</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Сброс</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Управление BMS включается автоматически при наличии BMS. Сброс при изменении конфигурации системы или при отсутствии BMS.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Управление BMS включается автоматически при наличии BMS. Сброс при изменении конфигурации системы или при отсутствии BMS.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Общая фотоэлектрическая мощность</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Нагрузка</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Нагрузка</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 найден</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 найден</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 История</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 История</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 История</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Работа по сети</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Работа по сети</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Вид таблицы</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Вид таблицы</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>График</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>График</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Предупреждение</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Предупреждение</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Тревога</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Тревога</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Тревога</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Объем</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Объем</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Короткое замыкание</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Короткое замыкание</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Обратная полярность</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Обратная полярность</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Станции зарядки электромобилей</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Станции зарядки электромобилей</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Сессия</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Сессия</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Время</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Время</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Режим заряда</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Режим заряда</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Запускайте и останавливайте процесс самостоятельно. Используйте его для быстрой зарядки и тщательного контроля.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Запускайте и останавливайте процесс самостоятельно. Используйте его для быстрой зарядки и тщательного контроля.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Запускается и останавливается в зависимости от уровня заряда батареи. Оптимально подходит для ночных и длительных зарядок, чтобы избежать перезарядки.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Запускается и останавливается в зависимости от уровня заряда батареи. Оптимально подходит для ночных и длительных зарядок, чтобы избежать перезарядки.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Более низкие тарифы на электроэнергию в непиковые часы или если вы хотите, чтобы ваш EV был полностью заряжен и готов к работе в определенное время.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Более низкие тарифы на электроэнергию в непиковые часы или если вы хотите, чтобы ваш EV был полностью заряжен и готов к работе в определенное время.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Начать зарядку</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Начать зарядку</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Блокировка дисплея зарядного устройства</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Блокировка дисплея зарядного устройства</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Адрес источника</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Адрес источника</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Установка</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Установка</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Экземпляр строки #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Экземпляр строки #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Экземпляр линии</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Экземпляр линии</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Экземпляр зарядного устройства</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Экземпляр зарядного устройства</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Экземпляр инвертора</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Экземпляр инвертора</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Источник постоянного тока #%1 экземпляр</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Источник постоянного тока #%1 экземпляр</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Экземпляр источника постоянного тока</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Экземпляр источника постоянного тока</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Источник постоянного тока #%1 приоритет</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Источник постоянного тока #%1 приоритет</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Приоритет экземпляра источника постоянного тока</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Приоритет экземпляра источника постоянного тока</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Экземпляр резервуара</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Экземпляр резервуара</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Устройства RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Устройства RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Включение визуализатора частоты кадров</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Включение визуализатора частоты кадров</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Не поддерживается</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Не поддерживается</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Удалить отключенные устройства</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Удалить отключенные устройства</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Найдено неподдерживаемое устройство</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Найдено неподдерживаемое устройство</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Функция реле</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Функция реле</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Тревога</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Запуск/остановка генератора или зарядного устройства</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Запуск/остановка генератора или зарядного устройства</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Ручное управление</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Предохранитель перегорел</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Ручное управление</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Ручное управление</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Всегда открыто (не используйте реле)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Всегда открыто (не используйте реле)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Обратите внимание, что изменение параметра Низкий уровень заряда также изменяет параметр Время до полного разряда в меню батареи.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Обратите внимание, что изменение параметра Низкий уровень заряда также изменяет параметр Время до полного разряда в меню батареи.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Предохранитель перегорел</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Предохранитель перегорел</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Светодиоды статуса</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Светодиоды статуса</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Нет</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Основной переключатель</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Основной переключатель</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Нагреватель</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Нагреватель</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Внутренний вентилятор</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Внутренний вентилятор</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Флаги предупреждения</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Флаги предупреждения</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Флаги тревоги</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Флаги тревоги</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Переключатель</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Переключатель</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Инициализация</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Инициализация</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Отключение</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Отключение</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Обновление</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Обновление</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Запуск работы</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Запуск работы</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Предварительный заряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Предварительный заряд</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Проверка контактора</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Проверка контактора</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Состояние системы</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Состояние системы</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Температура батареи</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Температура батареи</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Температура воздуха</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Температура воздуха</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Напряжение стартера</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Напряжение стартера</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Напряжение шины</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Напряжение шины</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Напряжение верхней секции</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Напряжение верхней секции</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Ошибка связи</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Состояние системы</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Напряжение шины</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Напряжение нижней секции</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Напряжение нижней секции</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Отклонение центральной точки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Отклонение центральной точки</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Потреблено А/ч</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Потреблено А/ч</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Время работы</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Время работы</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Подробности</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Подробности</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Сигналы тревоги на уровне модуля</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Сигналы тревоги на уровне модуля</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Диагностика</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Диагностика</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Предохранители</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Предохранители</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>Ввод/вывод</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>Ввод/вывод</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>Система</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>Система</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Параметры</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Параметры</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Новое определение батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Новое определение батареи</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Нажмите для определения</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Нажмите для определения</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Нажмите для определения</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Новое определение батареи может занять до 60 секунд. В это время название батареи может быть неверным.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Новое определение батареи может занять до 60 секунд. В это время название батареи может быть неверным.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Высокий ток заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Высокий ток заряда</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Высокий ток разряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Высокий ток разряда</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Низкий SOC</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Низкий SOC</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Высокое напряжение батареи</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Низкий SOC</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Низкое напряжение стартера</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Низкое напряжение стартера</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Высокое напряжение стартера</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Высокое напряжение стартера</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Датчик температуры батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Датчик температуры батареи</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Напряжение центральной точки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Напряжение центральной точки</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Предохранитель перегорел</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Высокая внутренняя температура</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Высокая внутренняя температура</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Температура низкого заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Температура низкого заряда</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Температура высокого заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Температура высокого заряда</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Внутренняя неисправность</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Внутренняя неисправность</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Автоматический выключатель отключен</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Автоматический выключатель отключен</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Разбалансировка ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Разбалансировка ячейки</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Низкое напряжение ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Низкое напряжение ячейки</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Минимальное напряжение батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Минимальное напряжение батареи</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Максимальное напряжение батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Максимальное напряжение батареи</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Минимальная температура ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Минимальная температура ячейки</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Максимальная температура ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Максимальная температура ячейки</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Аккумуляторные модули</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Аккумуляторные модули</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 онлайн</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 онлайн</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 в автономном режиме</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 в автономном режиме</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Количество модулей, блокирующих заряд/разряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Количество модулей, блокирующих заряд/разряд</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Установленная/доступная емкость</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Установленная/доступная емкость</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Самый глубокий разряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Самый глубокий разряд</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Последний разряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Последний разряд</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Средний разряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Средний разряд</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Всего циклов заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Всего циклов заряда</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Количество полных разрядов</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Количество полных разрядов</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Всего использовано А/ч</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Всего использовано А/ч</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Минимальное напряжение ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Минимальное напряжение ячейки</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Максимальное напряжение ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Максимальное напряжение ячейки</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Время от последнего полного заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Время от последнего полного заряда</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Число синхронизаций</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Число синхронизаций</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Сигнализация низкого напряжения стартерной батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Сигнализация низкого напряжения стартерной батареи</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Минимальное напряжение стартерной батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Минимальное напряжение стартерной батареи</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Максимальное напряжение стартерной батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Максимальное напряжение стартерной батареи</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Разряженная энергия</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Разряженная энергия</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Заряженная энергия</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Заряженная энергия</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Ограничение напряжения заряда (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Ограничение напряжения заряда (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Ограничение тока заряда (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Ограничение тока заряда (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Ограничение тока разряда (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Ограничение тока разряда (CCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Отключение по низкому напряжению (всегда игнорировать)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Отключение по низкому напряжению (всегда игнорировать)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Аккумуляторная батарея</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Аккумуляторная батарея</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Реле (на мониторе батареи)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Реле (на мониторе батареи)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Восстановить заводские настройки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Восстановить заводские настройки</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Нажмите для восстановления</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Нажмите для восстановления</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Восстановить заводские настройки по умолчанию?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Восстановить заводские настройки по умолчанию?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth включен</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth включен</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Номинальное напряжение</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Номинальное напряжение</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Вольт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Вольт</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Вольт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Вольт</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Вольт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Вольт</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Емкость</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Емкость</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Емкость</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Напряжение заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Напряжение заряда</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Следовой ток</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Следовой ток</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Время определения заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Время определения заряда</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Экспонента Пейкерта</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Экспонента Пейкерта</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Фактор эффективности заряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Фактор эффективности заряда</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Ограничение тока</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Ограничение тока</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Период усреднения оставшегося времени</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Период усреднения оставшегося времени</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Порог оставшегося времени для разряда</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Порог оставшегося времени для разряда</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Смещение тока</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Смещение тока</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Синхронизируйте состояние заряда до 100 %</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Синхронизируйте состояние заряда до 100 %</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Нажмите для синхронизации</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Нажмите для синхронизации</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Откалибруйте точку нуля тока</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Откалибруйте точку нуля тока</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Нажмите для установки на 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Нажмите для установки на 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Распределитель %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Распределитель %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Нет питания на сборной шине</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Нет питания на сборной шине</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Соединение потеряно</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n предохранитель(и) перегорел</numerusform>
-        <numerusform>%n предохранитель(и) перегорел</numerusform>
-        <numerusform>%n предохранитель(и) перегорел</numerusform>
-        <numerusform>%n предохранитель(и) перегорел</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n предохранитель(и) перегорел</numerusform>
+            <numerusform>%n предохранитель(и) перегорел</numerusform>
+            <numerusform>%n предохранитель(и) перегорел</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Информация отсутствует, состояние распределителя см. на предыдущей странице.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Информация отсутствует, состояние распределителя см. на предыдущей странице.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Предохранитель %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Предохранитель %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Не используется</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Не используется</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Взорванный</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Взорванный</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Отключения из-за ошибок</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Отключения из-за ошибок</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Последняя ошибка</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">Предпоследняя ошибка</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">Третья последняя ошибка</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">Четвертая последняя ошибка</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Переключатель системы</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Переключатель системы</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Внешнее реле</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Внешнее реле</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Программируемый контакт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Программируемый контакт</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Батареи</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Батареи</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Емкость</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Батареи</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Параллельно</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Параллельно</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Последовательно</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Последовательно</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Мин/макс напряжение ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Мин/макс напряжение ячейки</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Мин/макс температура ячейки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Мин/макс температура ячейки</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Балансировка</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Балансировка</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Балансировка</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Неизвестно</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Выход</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Выход</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Полевой импульс</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Полевой импульс</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Скорость двигателя</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Скорость двигателя</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Вспомогательное напряжение</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Вспомогательное напряжение</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>нет неисправностей</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>нет неисправностей</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Низкое напряжение</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Низкое напряжение</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Высокое напряжение</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Высокое напряжение</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Низкое вспомогательное напряжение</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Низкое вспомогательное напряжение</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Высокое вспомогательное напряжение</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Высокое вспомогательное напряжение</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Оповещения о низком вспомогательном напряжении</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Оповещения о низком вспомогательном напряжении</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Оповещения о высоком вспомогательном напряжении</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Оповещения о высоком вспомогательном напряжении</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Минимальное вспомогательное напряжение</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Минимальное вспомогательное напряжение</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Максимальное вспомогательное напряжение</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Максимальное вспомогательное напряжение</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Производимая энергия</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Производимая энергия</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Потребляемая энергия</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Потребляемая энергия</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Включить оповещения</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Включить оповещения</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Активный уровень</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Активный уровень</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Восстановить уровень</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Восстановить уровень</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Отложить</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Отложить</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Уровень</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Уровень</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Осталось</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Осталось</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Датчик батареи</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Датчик батареи</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Датчик батареи</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Тип датчика</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Тип датчика</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>По умолчанию</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>По умолчанию</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Европейский (0 - 180 Ом)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Европейский (0 - 180 Ом)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>США (240 - 30 Ом)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>США (240 - 30 Ом)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Настроить</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Настроить</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Настроить</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Значение датчика когда пуст</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Значение датчика когда пуст</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Тип жидкости</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Тип жидкости</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Соотношение бутана</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Соотношение бутана</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Пользовательская форма</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Пользовательская форма</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Усредненное время</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Усредненное время</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Значение датчика</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Значение датчика</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Пользовательская форма не определена. Вы можете определить одну, содержащую до десяти точек. Обратите внимание, что 0% и 100% подразумеваются.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Пользовательская форма не определена. Вы можете определить одну, содержащую до десяти точек. Обратите внимание, что 0% и 100% подразумеваются.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Точка %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Точка %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Добавить точку</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Добавить точку</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Датчик уровня</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Датчик уровня</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Объем</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Дублирование значений уровня датчика не допускается.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Дублирование значений уровня датчика не допускается.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Значения объема должны увеличиваться.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Значения объема должны увеличиваться.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Устройство защиты</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Устройство защиты</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Разблокировано (кВАРч)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Разблокировано (кВАРч)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Разблокировано (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Разблокировано (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Разблокировано (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Разблокировано (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Заблокировано</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Заблокировано</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Конфигурация фазы</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Конфигурация фазы</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Переключить позицию</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Переключить позицию</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Одна фаза</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2-фазный</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2-фазный</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3-фазный</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3-фазный</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Устройства</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>Переменный ток</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>Переменный ток</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Двигатель</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Двигатель</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Скорость</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Нагрузка</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Температура хладагента</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Температура хладагента</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Температура выхлопа</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Температура выхлопа</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Температура обмотки</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Температура обмотки</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Напряжение стартерной батареи</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Напряжение стартерной батареи</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Количество стартов</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Количество стартов</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS управление</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Передний селектор заблокирован (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Передний селектор заблокирован (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Ошибка отсутствует (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Ошибка отсутствует (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>Всего переменного тока</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>Всего переменного тока</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Энергия L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Энергия L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Последовательность фаз</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Последовательность фаз</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Версия диспетчера данных</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Версия диспетчера данных</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>КТ %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>КТ %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Нет</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Мигающий светодиод указывает на этот КТ</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Мигающий светодиод указывает на этот КТ</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Устройства Smappee bus</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Устройства Smappee bus</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>PV зарядное устройство</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>PV зарядное устройство</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Эта настройка отключена, если подключен цифровой мультиконтроллер.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Эта настройка отключена, если подключен цифровой мультиконтроллер.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Эта настройка отключена, если подключена система VE.Bus BMS.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Эта настройка отключена, если подключена система VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC в %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC в %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>постоянного тока</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>постоянного тока</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Инвертировано</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Инвертировано</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Включить оповещения</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Инвертировано</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Инверт. логика сигнала тревоги</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Инверт. логика сигнала тревоги</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Интенсивность излучения</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Интенсивность излучения</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Температура ячейки</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Температура ячейки</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Внешняя температура (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Внешняя температура (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Наружная температура</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Наружная температура</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Внешняя температура (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Внешняя температура (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Скорость ветра</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Скорость ветра</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Автоопределение</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Автоопределение</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Скорость ветра</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Скорость ветра</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Датчик внешней температуры</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Датчик внешней температуры</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Совокупно</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Совокупно</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Умножить</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Умножить</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Сброс счетчика</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Сброс счетчика</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Короткое замыкание</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Обратная полярность</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Низкий уровень заряда батареи датчика</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Низкий уровень заряда батареи датчика</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Влажность</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Влажность</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Давление</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Давление</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Низкий</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Смещение</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Смещение</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Шкала</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Шкала</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Датчик напряжения</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Датчик напряжения</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Общая фотоэлектрическая мощность</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Общая фотоэлектрическая мощность</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Страница продукта</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Страница продукта</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Датчик переменного тока %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Датчик переменного тока %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Доступна новая версия MK3.
+        <translation>Доступна новая версия MK3.
 ПРИМЕЧАНИЕ: Обновление может временно остановить работу системы.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Обновление MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Обновление MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Нажмите для обновления</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Нажмите для обновления</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Обновление MK3, значения снова появятся после завершения обновления</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Обновление MK3, значения снова появятся после завершения обновления</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Зарядка аккумулятора до 100 %</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Зарядка аккумулятора до 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Зарядка аккумулятора до 100 %</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Продвинутый</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>В процессе выполнения</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>В процессе выполнения</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Нажмите для остановки</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Нажмите для остановки</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Нажмите для начала</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Нажмите для начала</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Зарядите аккумулятор до 100 %</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Зарядите аккумулятор до 100 %</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Система вернется к нормальному режиму работы, отдавая предпочтение возобновляемым источникам энергии.
+        <translation>Система вернется к нормальному режиму работы, отдавая предпочтение возобновляемым источникам энергии.
 Вы хотите продолжить?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Береговое питание будет использоваться, если оно доступно, а опция "Приоритет солнечной и ветровой энергии" будет игнорироваться.
+        <translation>Береговое питание будет использоваться, если оно доступно, а опция &quot;Приоритет солнечной и ветровой энергии&quot; будет игнорироваться.
 Вы хотите продолжить?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Береговое питание будет использоваться для полной зарядки аккумулятора в течение одного времени.
+        <translation>Береговое питание будет использоваться для полной зарядки аккумулятора в течение одного времени.
 После завершения процесса зарядки система вернется к нормальному режиму работы, отдавая приоритет солнечной и ветровой энергии.
 Вы хотите продолжить?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Постоянное напряжение</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Постоянное напряжение</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>Переменный ток</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>Переменный ток</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Продвинутый</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Продвинутый</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Настройка сигнализации</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Настройка сигнализации</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>A VE.Bus BMS автоматически выключает систему при необходимости защиты батареи. Контролирование системы по Цветному контролю в этом случае невозможно.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>A VE.Bus BMS автоматически выключает систему при необходимости защиты батареи. Контролирование системы по Цветному контролю в этом случае невозможно.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Помощник BMS установлен и настроен для VE.Bus BMS, но VE.Bus BMS не обнаружен в системе!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Помощник BMS установлен и настроен для VE.Bus BMS, но VE.Bus BMS не обнаружен в системе!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Предупреждение: Активация функции выравнивания в системе ESS с солнечными зарядными устройствами может привести к зарядке батареи высоким напряжением при слишком высоком токе.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Предупреждение: Активация функции выравнивания в системе ESS с солнечными зарядными устройствами может привести к зарядке батареи высоким напряжением при слишком высоком токе.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Система автоматически переключится в режим плавающего заряда после завершения выравнивания.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Система автоматически переключится в режим плавающего заряда после завершения выравнивания.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Прервать выравнивание</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Прервать выравнивание</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Выравнивание</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Выравнивание</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Прерывание...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Прерывание...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Запуск...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Запуск...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Запуск...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Нажмите для прерывания</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Нажмите для прерывания</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Прервать и перезапустить абсорбцию</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Прервать и перезапустить абсорбцию</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Прервать и начать плавающий заряд</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Прервать и начать плавающий заряд</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Прервать</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Прервать</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Не прерывать</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Не прерывать</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Переопределить систему VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Переопределить систему VE.Bus</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Заново определяю...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Заново определяю...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Перезапустить систему VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Перезапустить систему VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Перезапуск...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Перезапуск...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Нажмите для перезапуска</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Нажмите для перезапуска</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>Вход переменного тока 1 игнорируется</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>Вход переменного тока 1 игнорируется</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>Вход переменного тока 2 игнорируется</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>Вход переменного тока 2 игнорируется</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Тест реле ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Тест реле ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Завершен</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Ожидание...</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Завершен</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Завершен</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Ожидание...</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Ожидание...</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Диагностика VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Диагностика VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Счетчик качества сети Фаза L%1, устройство %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Счетчик качества сети Фаза L%1, устройство %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.Bus Error 8 / 11 report</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.Bus Error 8 / 11 report</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Только оповещения</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Только оповещения</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Тревоги &amp; предупреждения</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Тревоги &amp; предупреждения</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Ошибка BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Ошибка BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Серийные номера</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Серийные номера</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Последний отчет VE.Bus Error 11 #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Последний отчет VE.Bus Error 11 #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Проводится тест на безопасность BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Проводится тест на безопасность BF</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Тест безопасности BF OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Тест безопасности BF OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Несоответствие AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Несоответствие AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Ошибка связи</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Ошибка связи</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>GND Ошибка реле</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>GND Ошибка реле</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Несоответствие UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Несоответствие UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Период Несоответствие времени</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Период Несоответствие времени</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Несоответствие привода реле BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Несоответствие привода реле BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Ошибка: PE2 открыт</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Ошибка: PE2 открыт</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Ошибка: PE2 закрыт</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Ошибка: PE2 закрыт</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Неудачный шаг: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Неудачный шаг: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Фаза L%1, устройство %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Фаза L%1, устройство %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Сообщение об ошибке VE.Bus #11 требует минимальную версию прошивки VE.Bus 454.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Сообщение об ошибке VE.Bus #11 требует минимальную версию прошивки VE.Bus 454.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>Нарушения в работе VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>Нарушения в работе VE.Bus</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Энергия</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Энергия</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Мощность</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Мощность</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Напряжение</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Напряжение</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Ток</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Ток</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Место</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Место</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Фаза</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Фаза</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Вход переменного тока активен</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Вход переменного тока активен</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Высокие пульсации DC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Высокие пульсации DC</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Высокое напряжение постояного тока</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Высокое напряжение постояного тока</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Высокий ток заряда переменного тока</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Высокий ток заряда переменного тока</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Ошибка датчика температуры</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Ошибка датчика температуры</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Ошибка датчика напряжения</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Ошибка датчика напряжения</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Перегрузка</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Перегрузка</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>Неравномерность DC</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>Неравномерность DC</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Датчик напряжения</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Датчик напряжения</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Изменение фазы</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Изменение фазы</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Изменение фазы</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Версия VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Версия VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2 устройство</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2 устройство</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Версия MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Версия MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Версия Мультиконтроля</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Версия Мультиконтроля</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Версия VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Версия VE.Bus BMS</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Пока сеть не отключится</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Пока сеть не отключится</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>Вход переменного тока</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>Вход переменного тока</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC ВХОД</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC ВХОД</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>Вход переменного тока 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>Вход переменного тока 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>Вход переменного тока 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>Вход переменного тока 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Роль</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Роль</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC нагрузка</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC нагрузка</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>ВЫХОД ПЕРЕМЕННОГО ТОКА</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>ВЫХОД ПЕРЕМЕННОГО ТОКА</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>AC выход</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>AC выход</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Фаза переменного тока L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Фаза переменного тока L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Датчик переменного тока %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Датчик переменного тока %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Датчики переменного тока</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Датчики переменного тока</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Активно</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Активно</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Тревога</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Перегрузка</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Статус оповещений</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Статус оповещений</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Сигнализации</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Сигнализации</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Разрешить зарядку</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Разрешить зарядку</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Разрешить разрядку</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Разрешить разрядку</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Автоматическое сканирование</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Автоматическое сканирование</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Батарея</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Батарея</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Ток АКБ</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Ток АКБ</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Напр. АКБ</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Напр. АКБ</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Ток заряда</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Ток заряда</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>заряжается</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>заряжается</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Сбросить ошибку</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Сбросить ошибку</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Закрыто</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Закрыто</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Подключено</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Подключено</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Ток</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Ток</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Трансформаторы тока</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Трансформаторы тока</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Пользовательское название</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Пользовательское название</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Устранение неполадок</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Устранение неполадок</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Устройство</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Устройство</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Отключено</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>разряжается</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>разряжается</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Отключено</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Отключено</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Включено</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Включено</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Включено</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Включено</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Энергия</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Энергия</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Ошибка</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Ошибка:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Ошибка:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Код ошибки</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Код ошибки</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Версия прошивки</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Версия прошивки</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Генератор</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Генератор</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Высокая температура батареи</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Высокая температура батареи</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Оповещение при высоком уровне</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Оповещение при высоком уровне</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Высокое напряжение батареи стартера</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Высокое напряжение батареи стартера</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Высокая температура</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Высокая температура</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Сигнализация о высоком напряжении</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Сигнализация о высоком напряжении</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>История</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>История</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Час(ы)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Час(ы)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>без нагрузки</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>без нагрузки</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Неактивно</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Неактивно</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Инвертор / зарядное устройство</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP адрес</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP адрес</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Низкая температура батареи</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Низкая температура батареи</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Оповещение при низком уровне</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Оповещение при низком уровне</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Низкое напряжение батареи стартера</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Низкое напряжение батареи стартера</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Низкое состояние заряда</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Низкое состояние заряда</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Низкая температура</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Низкая температура</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Сигнализация о низком напряжении</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Сигнализация о низком напряжении</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Производитель</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Производитель</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Максимальная температура</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Максимальная температура</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Максимальное напряжение</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Максимальное напряжение</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Минимальная температура</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Минимальная температура</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Минимальное напряжение</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Минимальное напряжение</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Режим</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Режим</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Название модели</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Название модели</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Нет</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Нет</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Без ошибок</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Без ошибок</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Недоступно</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Недоступно</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Не подключено</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Не подключено</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Оффлайн</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Оффлайн</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>Ok</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>Ok</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Вкл</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Вкл</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Онлайн</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Онлайн</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Открыто</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Открыто</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Пароль</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Пароль</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Фаза</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Фаза</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Нажмите для сброса</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Нажмите для сброса</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Сбросить</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Сбросить</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Нажмите для сканирования</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Нажмите для сканирования</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>PV инвертер</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>PV инвертер</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>PV мощность</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>PV мощность</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Спокойные часы</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Спокойные часы</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Реле</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Реле</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Перезагрузка</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Перезагрузка</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Удалить</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Удалить</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>Работает</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>Работает</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Сканирование %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Сканирование %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Серийный номер</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Серийный номер</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Настройки</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Установка</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Установка</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Уровень сигнала</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Уровень сигнала</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Ожидание</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Ожидание</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Запуск после достижения условия для</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Запуск после достижения условия для</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Время начала</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Время начала</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Начальное значение в тихие часы</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Начальное значение в тихие часы</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Запуск, когда предупреждение активно для</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Запуск, когда предупреждение активно для</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Состояние заряда</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Состояние заряда</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Состояние</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Состояние</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Запуск (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Запуск (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Конечное значение в тихие часы</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Конечное значение в тихие часы</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Остановка после достижения условия для</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Остановка после достижения условия для</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Остановлено</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Остановлено</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Температура</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Температура</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Датчик температуры</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Датчик температуры</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Сегодня</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Сегодня</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Всего</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Всего</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Счетчик</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Счетчик</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Тип</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Тип</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Уникальный идентификационный номер</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Уникальный идентификационный номер</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Неизвестно</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Ошибка VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Ошибка VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Напряжение</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Напряжение</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Версия VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Версия VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Остановка после снятия предупреждения</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Остановка после снятия предупреждения</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Да</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Да</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Вчера</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Вчера</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Прирост</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Прирост</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Ограничение нулевого уровня подачи</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Ограничение нулевого уровня подачи</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Установите дату</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Установите дату</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Начните прямо сейчас</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Начните прямо сейчас</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Запланированный запуск</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Запланированный запуск</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Остановитесь сейчас</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Остановитесь сейчас</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Общее время работы</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Общее время работы</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Установить время %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Установить время %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Генератор будет продолжать работать, если выполняется условие автозапуска.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Генератор будет продолжать работать, если выполняется условие автозапуска.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Режим инвертора / зарядного устройства</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Режим инвертора / зарядного устройства</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>сентябрь</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>сентябрь</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Отмена</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Закрыть</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Закрыть</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Установите время</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Установите время</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Уже используется</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Уже используется</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Ошибка подкачки</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Ошибка подкачки</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Обмен завершен</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Обмен завершен</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Поменяйте местами экземпляры устройств...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Поменяйте местами экземпляры устройств...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Экземпляр устройства %1 уже используется устройством '%3'. Поменять экземпляры устройств местами и назначить этот экземпляр на %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Экземпляр устройства %1 уже используется устройством &apos;%3&apos;. Поменять экземпляры устройств местами и назначить этот экземпляр на %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Экземпляр устройства %1 уже используется другим устройством того же типа. Поменять экземпляры устройств местами и назначить этот экземпляр на %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Экземпляр устройства %1 уже используется другим устройством того же типа. Поменять экземпляры устройств местами и назначить этот экземпляр на %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Невозможно обменять экземпляры устройств: операция завершилась по таймеру.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Невозможно обменять экземпляры устройств: операция завершилась по таймеру.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Новые экземпляры устройств будут активны при перезагрузке.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Новые экземпляры устройств будут активны при перезагрузке.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Обмен</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Обмен</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Ошибка при проверке обновлений микропрограммы</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Ошибка при проверке обновлений микропрограммы</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Загрузка и установка прошивки %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Загрузка и установка прошивки %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Устанавливается прошивка...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Устанавливается прошивка...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Ошибка при установке микропрограммы</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Ошибка при установке микропрограммы</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Нет более свежей версии</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Нет более свежей версии</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Прошивка не обнаружена</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Прошивка не обнаружена</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Топливо</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Топливо</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Свежая вода</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Свежая вода</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Грязная вода</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Грязная вода</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Рабочая скважина</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Рабочая скважина</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Нефть</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Нефть</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Темная вода</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Темная вода</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Бензин</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Бензин</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Дизельное топливо</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Дизельное топливо</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>Сжиженный углеводородный газ</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>Сжиженный углеводородный газ</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>Сжиженный природный газ</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>Сжиженный природный газ</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Гидравлическое масло</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Гидравлическое масло</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Сырая вода</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Сырая вода</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Установка блокировки для уровня доступа</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Установка блокировки для уровня доступа</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Неверный пароль</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Неверный пароль</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Краткое описание</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Краткое описание</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Обзор</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Обзор</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Уровни</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Уровни</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Уведомления</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Уведомления</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Сейчас</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Сейчас</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1m ago</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1m ago</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1ч %2м назад</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1ч %2м назад</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Каждый день</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Каждый день</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Рабочие дни</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Рабочие дни</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Выходные</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Выходные</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>понедельник</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>понедельник</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Вторник</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Вторник</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>среда</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>среда</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Четверг</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Четверг</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Пятница</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Пятница</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>суббота</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>суббота</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>воскресенье</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>воскресенье</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 или %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 или %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Расписание %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Расписание %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>День</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>День</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Не установлено</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Не установлено</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Ограничение SOC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Ограничение SOC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Автономное потребление превысило установленный лимит</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Автономное потребление превысило установленный лимит</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">фотоэлектрический</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>фотоэлектрический</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>фотоэлектрический</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>Фотоэлектрические панели и батарея</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>Фотоэлектрические панели и батарея</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Проверяю...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Проверяю...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Статус сигнализации</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Статус сигнализации</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Тревога</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Сбросить историю</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Сбросить историю</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Сброс</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Сброс</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Принудительное включение</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Принудительное включение</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Принудительно выкл</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Принудительно выкл</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Статус реле</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Статус реле</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Сброс истории на самом мониторе</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Сброс истории на самом мониторе</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Нажмите для извлечения</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Нажмите для извлечения</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Извлечение, пожалуйста, подождите</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Извлечение, пожалуйста, подождите</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Устройство хранения не обнаружено</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Устройство хранения не обнаружено</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 датчик температуры</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 датчик температуры</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>Датчик температуры %1 (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>Датчик температуры %1 (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Датчик температуры (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Датчик температуры (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Нет действий</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Нет действий</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Предупреждение: Температуры активации и деактивации установлены на одно и то же значение. Это приведет к тому, что условие будет проигнорировано.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Предупреждение: Температуры активации и деактивации установлены на одно и то же значение. Это приведет к тому, что условие будет проигнорировано.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Состояние %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Состояние %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Функция отключена</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Функция отключена</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Нет (Отключено)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Нет (Отключено)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Реле 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Реле 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Реле 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Реле 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Предупреждение: Выбранное выше реле не настроено на температуру, это условие будет проигнорировано.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Предупреждение: Выбранное выше реле не настроено на температуру, это условие будет проигнорировано.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Значение активации</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Значение активации</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Единица объема</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Единица объема</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Кубические метры</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Кубические метры</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Литры (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Литры (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Галлоны (США)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Галлоны (США)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Галлоны (имперские)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Галлоны (имперские)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Минимальное напряжение</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Минимальное напряжение</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Максимальное напряжение</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Максимальное напряжение</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Максимальное напряжение</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Максимальный ток</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Максимальный ток</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Время зарядки</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Время зарядки</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Зарядка</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Плавающий</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Зарядка</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Зарядка</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Поглощение</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Поглощение</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Плавающий</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Плавающий</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>hr</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>hr</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>Возникла ошибка(и) %1</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>Возникла ошибка(и) %1</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Нагрузка</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Нагрузка</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2-й последний</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2-й последний</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3-й последний</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3-й последний</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4-й последний</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4-й последний</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Максимальная мощность</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Максимальная мощность</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Невозможно подключиться</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Невозможно подключиться</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Отключено, пытаюсь подключиться снова</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Отключено, пытаюсь подключиться снова</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Подключение</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Подключение</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Подключение</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Подключен, ожидает сообщений от брокера</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Подключен, ожидает сообщений от брокера</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Подключен, получает сообщения брокера</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Подключен, получает сообщения брокера</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Подключаемый, загружаемый пользовательский интерфейс</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Подключаемый, загружаемый пользовательский интерфейс</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Неверная версия протокола</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Неверная версия протокола</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Идентификатор клиента отклонен</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Идентификатор клиента отклонен</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Услуги брокера недоступны</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Услуги брокера недоступны</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Плохое имя пользователя или пароль</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Плохое имя пользователя или пароль</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Клиент не авторизован</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Клиент не авторизован</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Ошибка транспортного соединения</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Ошибка транспортного соединения</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Ошибка нарушения протокола</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Ошибка нарушения протокола</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Ошибка 5-го уровня протокола MQTT</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Ошибка 5-го уровня протокола MQTT</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Отключить сигнализацию</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Отключить сигнализацию</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Общая мощность</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Общая мощность</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1 дн %2 ч</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1 дн %2 ч</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1ч %2мин</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1ч %2мин</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1 мин %2 сек</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1 мин %2 сек</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1 мин</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1 мин</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1сек</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1сек</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0 мин</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0 мин</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Неисправность</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Неисправность</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Получение IP адреса</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Получение IP адреса</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Подключено</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Отключить</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Отключить</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Отключено</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC нагрузки</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC нагрузки</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>dcLoads</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>dcLoads</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Ветер</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Ветер</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Крепление</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Крепление</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Ограничение тока сети</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Ограничение тока сети</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Ограничение тока генератора</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Ограничение тока генератора</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Ограничение тока берега</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Ограничение тока берега</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Остановка</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Остановка</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Остановка</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 на выход</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 на выход</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 танк (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 танк (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>Зарядное устройство переменного тока</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>Зарядное устройство переменного тока</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Генератор</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Генератор</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>Зарядное устройство постоянного тока</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>Зарядное устройство постоянного тока</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Генератор постоянного тока</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Генератор постоянного тока</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC СИСТЕМА</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC СИСТЕМА</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Топливный элемент</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Топливный элемент</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Вал-генератор</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Вал-генератор</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Генератор воды</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Генератор воды</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Ветровое зарядное устройство</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Ветровое зарядное устройство</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Низкий</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Низкий</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Высокий</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Высокий</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Поддерживайте заряд батарей</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Поддерживайте заряд батарей</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Оптимизировано время автономной работы</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Оптимизировано время автономной работы</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Оптимизировано без времени автономной работы</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Оптимизировано без времени автономной работы</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Внешнее управление</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Заряжено</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Заряжено</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>В ожидании солнца</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>В ожидании солнца</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>В ожидании RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>В ожидании RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Ожидание начала</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Ожидание начала</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Ошибка проверки заземления</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Ошибка проверки заземления</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Ошибка проверки CP-входа</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Ошибка проверки CP-входа</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Обнаружен остаточный ток</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Обнаружен остаточный ток</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Обнаружено пониженное напряжение</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Обнаружено пониженное напряжение</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Обнаружено перенапряжение</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Обнаружено перенапряжение</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Обнаружен перегрев</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Обнаружен перегрев</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Предел зарядки</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Предел зарядки</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Начать зарядку</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Начать зарядку</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Запланировано</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Запланировано</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Запланировано</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Разминка</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Разминка</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Охлаждение</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Охлаждение</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Тестовый запуск</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Тестовый запуск</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Запущено вручную</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Запущено вручную</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Загрузка</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Загрузка</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>Работает (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>Работает (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>Запущено (ускорено)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>Запущено (ускорено)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Реле %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Реле %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Неисправность</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Неисправность</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Поглощение</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Поглощение</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Сохранение</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Сохранение</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Выравнивание</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Выравнивание</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Внешнее управление</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Низкая мощность</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Низкая мощность</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Состояние неисправности</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Состояние неисправности</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Насыпная зарядка</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Насыпная зарядка</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Абсорбционная зарядка</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Абсорбционная зарядка</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Зарядка поплавка</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Зарядка поплавка</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Режим хранения</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Режим хранения</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Уравнительная зарядка</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Уравнительная зарядка</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Проходная</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Проходная</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Инвертирование</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Инвертирование</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Помощь</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Помощь</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Режим поддержки мощности</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Режим поддержки мощности</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Удержание</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Проснись</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Проснись</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Повторная абсорбция</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Повторная абсорбция</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Автоматическое выравнивание</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Автоматическое выравнивание</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>Battery Safe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>Battery Safe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Обнаружение нагрузки</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Обнаружение нагрузки</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Заблокировано</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Заблокировано</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Тест</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Тест</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Динамическая ESS (система включения аварийного сигнала)</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Динамическая ESS (система включения аварийного сигнала)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Динамическая ESS (система включения аварийного сигнала)</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Ведущий в группе</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Ведущий в группе</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Ведущий единицы</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Ведущий единицы</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Ведущий группы &amp; единицы</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Ведущий группы &amp; единицы</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Ведущий группы &amp; автономно</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Ведущий группы &amp; автономно</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Только зарядное устройство</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Только зарядное устройство</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Только инвертер</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Только инвертер</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Сигнализация о низком напряжении батареи</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Сигнализация о высоком напряжении батареи</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Сигнализация короткого замыкания</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Сигнализация короткого замыкания</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Отключить точку доступа</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Отключить точку доступа</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Вход постоянного тока</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Вход постоянного тока</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Для литиевых батарей не рекомендуется зарядка ниже 10%. Для других типов аккумуляторов минимальный уровень заряда, рекомендованный производителем, указан в техническом описании.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Для литиевых батарей не рекомендуется зарядка ниже 10%. Для других типов аккумуляторов минимальный уровень заряда, рекомендованный производителем, указан в техническом описании.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Отключить автозапуск?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Отключить автозапуск?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Инвертор/зарядное устройство (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Инвертор/зарядное устройство (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Отображение использования процессора</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Отображение использования процессора</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Выйти из приложения</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Выйти из приложения</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Увольнение</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Увольнение</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Версия приложения</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Версия приложения</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Температура масла</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Температура масла</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Обратите внимание, что при изменении параметра "Время до разряда" также изменяется параметр "Низкий уровень заряда" в меню реле.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Обратите внимание, что при изменении параметра &quot;Время до разряда&quot; также изменяется параметр &quot;Низкий уровень заряда&quot; в меню реле.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Время работы</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Время работы</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Заряжено Ач</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Заряжено Ач</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Циклов начато</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Циклов начато</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Циклов завершено</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Циклов завершено</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Количество включений</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Количество включений</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Количество глубоких разрядов</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Количество глубоких разрядов</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>История циклов зарядки</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>История циклов зарядки</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Значение датчика когда полон</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Значение датчика когда полон</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Время на обслуживание</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Время на обслуживание</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Функциональность автозапуска</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Функциональность автозапуска</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Убедитесь, что генератор не подключен к входу переменного тока %1 при использовании этой опции.</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Убедитесь, что генератор не подключен к входу переменного тока %1 при использовании этой опции.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Таймер обслуживания был сброшен</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Таймер обслуживания был сброшен</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Непрерывное сканирование может помешать работе Wi-Fi.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Непрерывное сканирование может помешать работе Wi-Fi.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Минимальный и максимальный диапазоны измерений</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Минимальный и максимальный диапазоны измерений</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Стартовая страница</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Перезапуск приложения...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Перезапуск приложения...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Не удалось изменить язык!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Не удалось изменить язык!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 минута</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 минут</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 минут</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Никогда</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Пожалуйста, подождите, пока будет изменен язык.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Пожалуйста, подождите, пока будет изменен язык.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Краткое описание устройства</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Краткое описание устройства</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Без этикеток</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Без этикеток</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Показать объемы резервуаров</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Показать объемы резервуаров</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Показать проценты</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Показать проценты</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Примечание: Если ток не может быть отображен (например, при показе суммарного значения для комбинированных источников переменного и постоянного тока), вместо него будет показана мощность.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Примечание: Если ток не может быть отображен (например, при показе суммарного значения для комбинированных источников переменного и постоянного тока), вместо него будет показана мощность.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Пределы тока заряда</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Пределы тока заряда</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Официальный релиз</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Официальный релиз</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Бета-версия</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Бета-версия</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Тестирование (внутреннее тестирование Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Тестирование (внутреннее тестирование Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Разработать (внутреннее устройство Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Разработать (внутреннее устройство Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Перезагрузка...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Перезагрузка...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Включите светодиодные индикаторы состояния</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Включите светодиодные индикаторы состояния</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Разминка и охлаждение</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Разминка и охлаждение</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Время остановки генератора</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Время остановки генератора</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Сигнал тревоги, когда генератор не находится в режиме автозапуска</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Сигнал тревоги, когда генератор не находится в режиме автозапуска</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Если функция автозапуска не работает более 10 минут, включается сигнал тревоги.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Если функция автозапуска не работает более 10 минут, включается сигнал тревоги.</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Самопотребление от аккумулятора</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Самопотребление от аккумулятора</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Все нагрузки на систему</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Все нагрузки на систему</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Только критические нагрузки</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Только критические нагрузки</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Минимум SOC разряда (без неисправности сети)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Срок службы батареи</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Срок службы батареи</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Доступ к сигналу K на сайте http://venus.local:3000 и через VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Доступ к сигналу K на сайте http://venus.local:3000 и через VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Доступ к Node-RED на сайте https://venus.local:1881 и через VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Доступ к Node-RED на сайте https://venus.local:1881 и через VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Показатели батареи</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Показатели батареи</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Состояние системы</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Состояние системы</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Список устройств</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Список устройств</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Экземпляры устройств VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Экземпляры устройств VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Сигнализация высокой температуры</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Сигнализация высокой температуры</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Контролируется BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Контролируется BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Сигналы тревоги и ошибки</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Сигналы тревоги и ошибки</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Для этой функции требуется микропрограмма версии 400 или выше. Для обновления Multi/Quattro обратитесь к своему установщику.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Для этой функции требуется микропрограмма версии 400 или выше. Для обновления Multi/Quattro обратитесь к своему установщику.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Зарядное устройство не готово, уравнивание не может быть запущено</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Зарядное устройство не готово, уравнивание не может быть запущено</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Уравнивание не может быть запущено в состоянии массового заряда</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Уравнивание не может быть запущено в состоянии массового заряда</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Эко</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Эко</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Максимальный ток</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Максимальный ток</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Максимальная мощность</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Максимальная мощность</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Минимальный ток</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Минимальный ток</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Нет</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Недоступно</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Выкл</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">Ok</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Общая история</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Общая история</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Настройки</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Неизвестно</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Доходность сегодня</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Доходность сегодня</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Прошивка установлена, устройство перезагружается</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Прошивка установлена, устройство перезагружается</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Управление сенсорным входом</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Управление сенсорным входом</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Ошибка проверки сварных контактов (короткое замыкание)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Ошибка проверки сварных контактов (короткое замыкание)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Переключение на 3 фазы</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Переключение на 3 фазы</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Переключение на 1 фазу</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Переключение на 1 фазу</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Прекратить зарядку</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Прекратить зарядку</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Зарезервировано</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Зарезервировано</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Инверторный режим</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Инверторный режим</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Выход переменного тока L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Выход переменного тока L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Вход</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Вход</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Проходной</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Проходной</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Страница автоматически перезагрузится через десять секунд, чтобы загрузить последнюю версию.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Страница автоматически перезагрузится через десять секунд, чтобы загрузить последнюю версию.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Инвертор (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Инвертор (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Инвертор/зарядные устройства</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Инвертор/зарядные устройства</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Счетчики энергии не найдены
+        <translation>Счетчики энергии не найдены
 
-Обратите внимание, что в этом меню отображаются только счетчики Carlo Gavazzi, подключенные по RS485. Для любых других счетчиков, включая счетчики Carlo Gavazzi, подключенные через Ethernet, смотрите меню "Устройства Modbus TCP/UDP".</translation>
+Обратите внимание, что в этом меню отображаются только счетчики Carlo Gavazzi, подключенные по RS485. Для любых других счетчиков, включая счетчики Carlo Gavazzi, подключенные через Ethernet, смотрите меню &quot;Устройства Modbus TCP/UDP&quot;.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Автонастройка</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Автонастройка</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Если эта функция включена, минимальные и максимальные значения датчиков и графиков автоматически корректируются на основе прошлых значений.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Если эта функция включена, минимальные и максимальные значения датчиков и графиков автоматически корректируются на основе прошлых значений.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Сброс всех значений диапазона на ноль</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Сброс всех значений диапазона на ноль</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Сброс значений диапазона</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Сброс значений диапазона</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Вы уверены, что хотите сбросить все значения в ноль?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Вы уверены, что хотите сбросить все значения в ноль?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Максимальный ток: Переменный ток в 1 подключенном</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Максимальный ток: Переменный ток в 1 подключенном</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Максимальный ток: Переменный ток в 2 подключенных</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Максимальный ток: Переменный ток в 2 подключенных</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Максимальный ток: без входов переменного тока</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Максимальный ток: без входов переменного тока</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>выход постоянного тока</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>выход постоянного тока</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Солнечная энергия</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Солнечная энергия</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Обороты мотора</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Обороты мотора</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Температура мотора</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Температура мотора</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Температура контроллера</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Температура контроллера</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Активный цикл</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Активный цикл</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Цикл %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Цикл %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>Разъединитель постоянного тока</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>Разъединитель постоянного тока</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Выключено</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Выключено</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Изменение функции</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Изменение функции</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Обновление прошивки</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Обновление прошивки</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Программный сброс</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Программный сброс</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Неполный</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Неполный</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Прошедшее время</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Прошедшее время</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Зарядка/поддержание (Ач)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Зарядка/поддержание (Ач)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Батарея (V&lt;sub&gt;начало&lt;/sub&gt;/V&lt;sub&gt;конец&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Батарея (V&lt;sub&gt;начало&lt;/sub&gt;/V&lt;sub&gt;конец&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Низкое напряжение переменного тока</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Низкое напряжение переменного тока</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Высокое выходное напряжение переменного тока</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Высокое выходное напряжение переменного тока</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Общая выработка</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Общая выработка</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Выработка системы</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Выработка системы</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Ежедневная история</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Ежедневная история</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Настройка сигналов тревоги не требуется</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Настройка сигналов тревоги не требуется</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Максимальное PV напряжение</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Максимальное PV напряжение</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Максимальное напряжение батареи</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Максимальное напряжение батареи</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Минимальное напряжение батареи</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Минимальное напряжение батареи</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Ошибка аккумуляторной батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Ошибка аккумуляторной батареи</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Напряжение аккумулятора не поддерживается</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Напряжение аккумулятора не поддерживается</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Неправильное количество батарей</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Неправильное количество батарей</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Неверная конфигурация батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Неверная конфигурация батареи</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Состояние балансировщика</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Состояние балансировщика</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Сбалансированный</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Сбалансированный</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Дисбаланс</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Дисбаланс</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Используйте эту опцию в системах, которые не обеспечивают ограничение пиковой нагрузки.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Используйте эту опцию в системах, которые не обеспечивают ограничение пиковой нагрузки.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Используйте эту опцию для пиковой экономии.</translation>
+        <translation>Используйте эту опцию для пиковой экономии.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Порог снижения пиковой нагрузки устанавливается с помощью настройки ограничения входного переменного тока. Дополнительную информацию см. в документации.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Порог снижения пиковой нагрузки устанавливается с помощью настройки ограничения входного переменного тока. Дополнительную информацию см. в документации.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>На этом экране можно изменить пороговые значения пиковой экономии для импорта и экспорта. Дополнительную информацию см. в документации.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>На этом экране можно изменить пороговые значения пиковой экономии для импорта и экспорта. Дополнительную информацию см. в документации.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Ограничение тока импорта переменного тока системы</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Ограничение тока импорта переменного тока системы</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Чтобы воспользоваться этой функцией, для параметра Grid metering должен быть установлен режим External meter, а также должен быть установлен актуальный ассистент ESS.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Чтобы воспользоваться этой функцией, для параметра Grid metering должен быть установлен режим External meter, а также должен быть установлен актуальный ассистент ESS.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Максимальный ток импорта системы (на фазу)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Максимальный ток импорта системы (на фазу)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Для использования этой функции необходимо установить параметр "Внешний счетчик".</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Для использования этой функции необходимо установить параметр &quot;Внешний счетчик&quot;.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Максимальный ток экспорта системы (на фазу)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Максимальный ток экспорта системы (на фазу)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Проводной</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Проводной</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Краткое описание</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Высокая загрузка системы, закрытие боковой панели для снижения нагрузки на процессор</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Высокая загрузка системы, закрытие боковой панели для снижения нагрузки на процессор</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Ограничение входящего тока</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Ограничение входящего тока</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Короткое замыкание</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Короткое замыкание</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Покупка</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Покупка</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Продам</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Продам</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Целевой SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Целевой SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>Выход переменного тока %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>Выход переменного тока %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Счетчик</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Счетчик</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Устройства RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Устройства RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Приостановить электронную анимацию</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Приостановить электронную анимацию</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Общая вместимость</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Общая вместимость</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Количество СЭЗ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Количество СЭЗ</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-шина BMS LV (500 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-шина BMS LV (500 кбит/с)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-шина BMS HV (500 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-шина BMS HV (500 кбит/с)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Ограничение переменного тока системы экспорта</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Ограничение переменного тока системы экспорта</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Устройства Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Устройства Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Добавить устройство</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Добавить устройство</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Сканирование на наличие устройств</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Сканирование на наличие устройств</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Сохраненные устройства</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Сохраненные устройства</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Обнаруженные устройства</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Обнаруженные устройства</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Добавить устройство Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Добавить устройство Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Протокол</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Протокол</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Порт</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Порт</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Устройство</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Устройство</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Устройства Modbus не сохранены</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Устройства Modbus не сохранены</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Устройство %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Устройство %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Удалить устройство Modbus?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Удалить устройство Modbus?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Устройства Modbus не обнаружены</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Устройства Modbus не обнаружены</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Аккумулятор %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Аккумулятор %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>AC ток</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>AC ток</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Запуск/остановка генератора отключена</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Запуск/остановка генератора отключена</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>На генераторной установке отключена функция дистанционного запуска. Теперь GX не сможет запустить или остановить генераторную установку. Включите ее на панели управления генераторной установки.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>На генераторной установке отключена функция дистанционного запуска. Теперь GX не сможет запустить или остановить генераторную установку. Включите ее на панели управления генераторной установки.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Функция автозапуска</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Функция автозапуска</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Текущее время работы</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Состояние управления</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Состояние управления</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Состояние генераторной установки</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Состояние генераторной установки</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Режим дистанционного запуска</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Режим дистанционного запуска</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Давление масла</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Давление масла</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Запланированные уровни заряда</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Запланированные уровни заряда</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Активно (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Активно (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Ручная остановка</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Ручная остановка</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Разомкнутая цепь</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Разомкнутая цепь</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (недоступно)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (недоступно)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Сенсорный вход включен</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Сенсорный вход включен</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Сенсорный вход выключен</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Сенсорный вход выключен</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Сенсорный вход запрещен</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Сенсорный вход запрещен</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Подтверждение предупреждений</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Подтверждение предупреждений</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Код ошибки управления</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Код ошибки управления</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Используйте это меню для определения данных о батарее, отображаемых при нажатии на значок батареи на странице обзора. Этот же выбор отображается и на портале VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Используйте это меню для определения данных о батарее, отображаемых при нажатии на значок батареи на странице обзора. Этот же выбор отображается и на портале VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Напряжение системы</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Напряжение системы</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Информация о подключении</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Информация о подключении</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Пожалуйста, выберите...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Пожалуйста, выберите...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Обеспеченный</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Обеспеченный</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Защита паролем и шифрование сетевой связи</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Защита паролем и шифрование сетевой связи</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Слабый</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Слабый</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Защищено паролем, но сетевое взаимодействие не зашифровано</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Защищено паролем, но сетевое взаимодействие не зашифровано</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Необеспеченные</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Необеспеченные</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Пароль отсутствует, сетевое взаимодействие не шифруется</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Пароль отсутствует, сетевое взаимодействие не шифруется</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Пароль должен состоять не менее чем из 8 символов</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Введите пароль</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Пароль должен состоять не менее чем из 8 символов</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Пароль должен состоять не менее чем из 8 символов</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Выбрать профиль "Защищенный"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Выбрать профиль &quot;Защищенный&quot;?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Выбрать профиль "Слабый"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Выбрать профиль &quot;Слабый&quot;?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Выбрать профиль "Незащищенный"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Выбрать профиль &quot;Незащищенный&quot;?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Службы локальной сети защищены паролем
+        <translation>- Службы локальной сети защищены паролем
 - Сетевое взаимодействие зашифровано
 - Включено безопасное соединение с VRM
 - Незащищенные настройки не могут быть включены</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Службы локальной сети защищены паролем
+        <translation>- Службы локальной сети защищены паролем
 - Доступ к локальным веб-сайтам без шифрования также разрешен (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Службы локальной сети не требуют пароля
+        <translation>- Службы локальной сети не требуют пароля
 - Доступ к локальным веб-сайтам без шифрования также разрешен (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Корневой пароль</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Корневой пароль</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Выйти</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Выйти</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Выйти из системы</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Выйти из системы</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Выйти из системы?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Выйти из системы?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Это приведет к отключению всех подключений к локальной сети.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Это приведет к отключению всех подключений к локальной сети.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Выйти</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Выйти</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Только для чтения</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Только для чтения</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Полный</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Полный</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Вы уверены?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Вы уверены?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Изменение этого параметра на "Только для чтения" или "Выкл." заблокирует доступ к нему.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Изменение этого параметра на &quot;Только для чтения&quot; или &quot;Выкл.&quot; заблокирует доступ к нему.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Доступ к MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Доступ к MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' не является числом.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; не является числом.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Да, отпишите меня</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Да, отпишите меня</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Используйте число с %1 цифрами или меньше.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Используйте число с %1 цифрами или меньше.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' не является действительным IP-адресом.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; не является действительным IP-адресом.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' - это неправильный номер порта. Используйте число в диапазоне 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; - это неправильный номер порта. Используйте число в диапазоне 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 - это неправильный номер единицы измерения. Используйте число в диапазоне 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 - это неправильный номер единицы измерения. Используйте число в диапазоне 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Текущее время работы</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Текущее время работы</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Коды ошибок генераторной установки</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Коды ошибок генераторной установки</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Температура радиатора</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Температура радиатора</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Напряжение заряда</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>В настоящее время напряжение заряда контролируется системой BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>В настоящее время напряжение заряда контролируется системой BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Ограничение тока заряда</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Ограничение тока заряда</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>Контролируется BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>Контролируется BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Управление BMS включается автоматически при наличии BMS. Сбросьте настройку, если конфигурация системы изменилась или если BMS отсутствует.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Управление BMS включается автоматически при наличии BMS. Сбросьте настройку, если конфигурация системы изменилась или если BMS отсутствует.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Сервисный таймер отключен.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Сервисный таймер отключен.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Портал удаленного мониторинга Виктрон (VRM)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Портал удаленного мониторинга Виктрон (VRM)</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (удаленный VPN-доступ)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (удаленный VPN-доступ)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Перед включением сетевых служб необходимо настроить профиль безопасности, см. раздел Настройки - Общие</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Перед включением сетевых служб необходимо настроить профиль безопасности, см. раздел Настройки - Общие</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' был заменен на '%2', так как содержал недопустимые символы.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; был заменен на &apos;%2&apos;, так как содержал недопустимые символы.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Инициализация...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Инициализация...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Начало работы в бэкенде...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Начало работы в бэкенде...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Бэкэнд остановлен.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Бэкэнд остановлен.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Не удалось установить соединение.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Не удалось установить соединение.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Это устройство GX вышло из системы Tailscale.
+        <translation>Это устройство GX вышло из системы Tailscale.
 
 Пожалуйста, подождите или проверьте подключение к Интернету.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Жду ответа от Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Жду ответа от Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Подключите это устройство GX к своей учетной записи Tailscale, открыв эту ссылку:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Подключите это устройство GX к своей учетной записи Tailscale, открыв эту ссылку:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Пожалуйста, подождите или проверьте подключение к Интернету.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Пожалуйста, подождите или проверьте подключение к Интернету.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Неизвестное состояние: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Неизвестное состояние: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Ошибка: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Ошибка: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Отключите Tailscale для редактирования этих настроек.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Отключите Tailscale для редактирования этих настроек.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Включить масштабирование хвостов</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Включить масштабирование хвостов</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Название машины</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Название машины</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Выход из учетной записи Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Выход из учетной записи Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Доступ к локальной сети</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Доступ к локальной сети</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Доступ к локальной сети ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Доступ к локальной сети ethernet</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Доступ к локальной сети WiFi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Доступ к локальной сети WiFi</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Пользовательская сеть(и)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Пользовательская сеть(и)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Пример: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Пример: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Объяснение:
+        <translation>Объяснение:
 
 Эта функция, называемая в Tailscale маршрутами подсети, позволяет получить удаленный доступ к другим устройствам в локальной сети (сетях).
 
-Поле "Пользовательские сети" принимает список подсетей в нотации CIDR, разделенный запятыми.
+Поле &quot;Пользовательские сети&quot; принимает список подсетей в нотации CIDR, разделенный запятыми.
 
 После добавления/включения новой сети необходимо один раз подтвердить ее в консоли администратора Tailscale.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Пользовательские аргументы "увеличения хвоста"</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Пользовательские аргументы &quot;увеличения хвоста&quot;</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Пользовательский URL-адрес сервера (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Пользовательский URL-адрес сервера (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Для управления этой генераторной установкой требуется вспомогательное реле, но вспомогательное реле не настроено. Пожалуйста, настройте реле 1 в разделе Настройки → Реле на "Подключенное вспомогательное реле генераторной установки".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Для управления этой генераторной установкой требуется вспомогательное реле, но вспомогательное реле не настроено. Пожалуйста, настройте реле 1 в разделе Настройки → Реле на &quot;Подключенное вспомогательное реле генераторной установки&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Сигнализация высокого напряжения стартерной батареи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Сигнализация высокого напряжения стартерной батареи</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Пропустить разминку генератора</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Пропустить разминку генератора</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Вверх, но без услуг (500 кбит/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Вверх, но без услуг (500 кбит/с)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Корневой пароль изменен на %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Корневой пароль изменен на %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Подключенное вспомогательное реле генераторной установки</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Подключенное вспомогательное реле генераторной установки</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Положение нагрузок переменного тока</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Положение нагрузок переменного тока</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Вход и выход переменного тока</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Вход и выход переменного тока</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Используйте этот параметр, если на входе преобразователя частоты/зарядного устройства присутствует нагрузка переменного тока. Используйте этот параметр, если не уверены.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Используйте этот параметр, если на входе преобразователя частоты/зарядного устройства присутствует нагрузка переменного тока. Используйте этот параметр, если не уверены.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Только выход переменного тока</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Только выход переменного тока</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Используйте эту опцию, если в системе используется сетевой счетчик, но все нагрузки переменного тока находятся на выходе инвертора/зарядного устройства.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Используйте эту опцию, если в системе используется сетевой счетчик, но все нагрузки переменного тока находятся на выходе инвертора/зарядного устройства.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Ежемесячно</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Ежемесячно</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>Зарядное устройство для электромобиля</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>Зарядное устройство для электромобиля</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Тепловой насос</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Тепловой насос</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Основные нагрузки</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Основные нагрузки</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Запуск и остановка генератора на основе настроенных условий автозапуска.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Запуск и остановка генератора на основе настроенных условий автозапуска.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Настройки генераторной установки постоянного тока</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Настройки генераторной установки постоянного тока</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Температура генератора</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Температура генератора</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Температура двигателя</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Температура двигателя</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Общее время работы</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Общее время работы</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Профиль сетевой безопасности</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Профиль сетевой безопасности</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Последние %1 дней</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Последние %1 дней</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Генератор остановится через %1, если не будут включены условия автозапуска, которые будут поддерживать его работу.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Генератор остановится через %1, если не будут включены условия автозапуска, которые будут поддерживать его работу.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Генератор будет работать до тех пор, пока не будет остановлен вручную, если только не включены условия автозапуска, которые поддерживают его работу.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Генератор будет работать до тех пор, пока не будет остановлен вручную, если только не включены условия автозапуска, которые поддерживают его работу.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Классический пользовательский интерфейс</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Классический пользовательский интерфейс</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Новый пользовательский интерфейс</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Новый пользовательский интерфейс</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Успешно изменили язык!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Ограничение мощности</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Успешно изменили язык!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Для устройств Multi-RS и HS19 настройки ESS доступны на странице продукта RS System.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Для устройств Multi-RS и HS19 настройки ESS доступны на странице продукта RS System.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Пуск/остановка генераторной установки</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Пуск/остановка генераторной установки</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Переключение версии прошивки невозможно без выбора "Профиля сетевой безопасности" в разделе "Настройки / Общие".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Переключение версии прошивки невозможно без выбора &quot;Профиля сетевой безопасности&quot; в разделе &quot;Настройки / Общие&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Длительность &lt;wbr&gt; (чч:мм)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Длительность &lt;wbr&gt; (чч:мм)</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Системные сигналы тревоги</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Системные сигналы тревоги</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Отсутствие системных сигналов тревоги</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Отсутствие системных сигналов тревоги</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Назад</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Назад</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Что нового</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Что нового</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>пропустить</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>пропустить</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Добро пожаловать!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Добро пожаловать!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Мы рады представить полностью переработанный интерфейс, который улучшает как удобство использования, так и эстетику вашего GX.
+        <translation>Мы рады представить полностью переработанный интерфейс, который улучшает как удобство использования, так и эстетику вашего GX.
 
 Благодаря оптимизированной навигации и свежему внешнему виду все, что вам нравится, теперь стало еще более доступным и визуально привлекательным.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Темный - светлый режим</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Темный - светлый режим</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>В разных условиях требуются разные настройки дисплея. Темный и светлый режимы обеспечивают наилучшие впечатления от просмотра, где бы вы ни находились.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>В разных условиях требуются разные настройки дисплея. Темный и светлый режимы обеспечивают наилучшие впечатления от просмотра, где бы вы ни находились.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Вся необходимая вам информация представлена в чистом и простом макете. Центральным элементом является настраиваемый виджет с изображением колец, обеспечивающий быстрый доступ к информации о системе с первого взгляда.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Вся необходимая вам информация представлена в чистом и простом макете. Центральным элементом является настраиваемый виджет с изображением колец, обеспечивающий быстрый доступ к информации о системе с первого взгляда.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Получите больше контроля с помощью обновленной панели обзора, на которой в режиме реального времени отображаются данные о системе - все в одном месте для удобного мониторинга.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Получите больше контроля с помощью обновленной панели обзора, на которой в режиме реального времени отображаются данные о системе - все в одном месте для удобного мониторинга.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Контролирует:</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Контролирует:</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Все повседневные элементы управления теперь объединены в новой панели Controls. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Все повседневные элементы управления теперь объединены в новой панели Controls. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Ватты и амперы</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Ватты и амперы</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Теперь вы можете переключаться между ваттами и амперами. Выберите единицу, которая лучше всего соответствует вашим предпочтениям.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Теперь вы можете переключаться между ваттами и амперами. Выберите единицу, которая лучше всего соответствует вашим предпочтениям.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Узнайте больше</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Узнайте больше</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Перейдите по ссылке ниже, чтобы узнать больше об обновленном пользовательском интерфейсе.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Перейдите по ссылке ниже, чтобы узнать больше об обновленном пользовательском интерфейсе.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Отсканируйте QR-код, чтобы узнать больше о Renewed UI.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Отсканируйте QR-код, чтобы узнать больше о Renewed UI.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Готово</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Готово</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Следующий</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Следующий</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Ошибка: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Ошибка: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Активная ошибка</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Активная ошибка</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Общее время работы генератора (часы)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Общее время работы генератора (часы)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Стартовая страница</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Стартовая страница</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Пользовательский интерфейс</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Пользовательский интерфейс</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Пользовательский интерфейс (удаленная консоль)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Пользовательский интерфейс (удаленная консоль)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 обновлено</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 обновлено</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>Пользовательский интерфейс переключится на %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>Пользовательский интерфейс переключится на %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 установлено на %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Этот фотоэлектрический инвертор поддерживает ограничение мощности. Отключите эту настройку, если она мешает нормальной работе.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 установлено на %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Нажмите "OK", чтобы перезагрузиться</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Нажмите &quot;OK&quot;, чтобы перезагрузиться</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Сброс настроек на заводские установки Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Сброс настроек на заводские установки Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Вы уверены, что хотите сбросить Node-RED к заводским настройкам? Это приведет к удалению всех ваших потоков.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Вы уверены, что хотите сбросить Node-RED к заводским настройкам? Это приведет к удалению всех ваших потоков.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Состояние соединения</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Состояние соединения</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Состояние соединения (канал HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Состояние соединения (канал HTTPS)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Состояние соединения (канал HTTP)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Состояние соединения (канал HTTP)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Состояние соединения (канал реального времени MQTT)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Состояние соединения (канал реального времени MQTT)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Состояние соединения (канал MQTT RPC)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Состояние соединения (канал MQTT RPC)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Автозапуск - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Автозапуск - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Значение деактивации</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Значение деактивации</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Не работает</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Не работает</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Потеря связи</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Потеря связи</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>Состояние SOC</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>Состояние SOC</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>Состояние нагрузки переменного тока</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>Состояние нагрузки переменного тока</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Текущее состояние батареи</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Текущее состояние батареи</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Состояние напряжения аккумулятора</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Состояние напряжения аккумулятора</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Состояние перегрузки инвертора</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Состояние перегрузки инвертора</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Зарядка/разрядка отключена</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Зарядка/разрядка отключена</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Заряд отключен</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Заряд отключен</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Разрядка отключена</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Разрядка отключена</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Краткое описание</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Брифинг (боковая стенка открыта)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Брифинг (боковая стенка открыта)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Обзор</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Уровни (резервуары)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Уровни (резервуары)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Уровни (окружающая среда)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Уровни (окружающая среда)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Список аккумуляторов</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Список аккумуляторов</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>Устройство GX было обновлено</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>Устройство GX было обновлено</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Через %n минут(ы)</numerusform>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Через %n минут(ы)</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Перейдите на эту страницу при запуске приложения.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Перейдите на эту страницу при запуске приложения.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Тайм-аут</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Тайм-аут</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Возврат на стартовую страницу, когда приложение неактивно.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Возврат на стартовую страницу, когда приложение неактивно.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>После одной минуты бездействия выберите текущую страницу в качестве начальной, если она есть в этом списке.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>После одной минуты бездействия выберите текущую страницу в качестве начальной, если она есть в этом списке.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Этот предел тока зафиксирован в конфигурации системы. Его нельзя отрегулировать.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Этот предел тока зафиксирован в конфигурации системы. Его нельзя отрегулировать.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Режим фиксируется в конфигурации системы. Его нельзя настроить.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Режим фиксируется в конфигурации системы. Его нельзя настроить.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Функция запуска/остановки генератора не включена, перейдите к настройкам реле и установите функцию "Запуск/остановка генераторной установки".</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Морокко, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Западная Центральная Африка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Южная Африка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Намибия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Египет, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Восточная Африка, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Аргентина, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Восточная Южная Америка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Гренландия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Монтевидео, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Ньюфайндленд, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Южная Америка, восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Атлантика, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Центральная Бразилия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Южная Америка, Тихий океан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Парагвай, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Южная Америка, западное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Венесуэла, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Южная Америка, Тихий океан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>США, восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Центральная Канада, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Центральная Америка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Центральное стандартное время (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Центральное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Горное стандартное время (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Горное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>США, горное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Тихоокеанское стандартное время (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Аляска, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Гавайи, Алеуты</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новая Зеландия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Западное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Западная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Юго-Восточная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Центральная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Западная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Восточная Африка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Южная Америка, Тихий океан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Южная Америка, западное стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Западная Европа, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Камчатка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Магадан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Владивосток, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Якутск, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Токио, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Корея, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Сингапур, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Улан-Батор, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Тайпей, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Северная Азия, восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Китай, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Юго-Восточная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Северная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Мьянма, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Северная Центральная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Центральная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Бангладеш, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Непал, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Шри-Ланка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Индия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Западная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Пакистан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Екатеринбург, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Грузия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Кавказ, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Азербайджан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Арабское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Афганистан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Иран, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Арабское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Арабское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Сирия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Средняя Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Иордан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Израиль, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Гринвич, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Азорские острова, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Кабо-Верде, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Тасмания, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Восточная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Восточная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Центральная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Центральная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Западная Австралия, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Средняя Атлантика, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Граница дат, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Центральная Европа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Центрально-европейское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Романское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Западная Европа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Восточная Европа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Белорусское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Российское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Турция, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Мавритания, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Остров Рождества, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Тонга, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Фиджи, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новая Зеландия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Западное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Самоа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Гавайское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Остров Пасхи, стандартное время</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Функция запуска/остановки генератора не включена, перейдите к настройкам реле и установите функцию &quot;Запуск/остановка генераторной установки&quot;.</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Неизвестно</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Выход солнечной энергии</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Вход постоянного тока</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC нагрузки</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">dcLoads</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Обзор</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Состояние</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">фотоэлектрический</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Общая выработка</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Выработка системы</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Только оповещения</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Тревоги &amp; предупреждения</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Предупреждение</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Без ошибок</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Без ошибок</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Неизвестная ошибка: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Неизвестная ошибка: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Без ошибок</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Без ошибок</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Ошибка инициализации батареи</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Ошибка инициализации батареи</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Батареи не подключены</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Батареи не подключены</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Неизвестная батарея</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Неизвестная батарея</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Разные типы батарей</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Разные типы батарей</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Количество батарей неверное</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Количество батарей неверное</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt не найден</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt не найден</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Ошибка измерения заряда батареи</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Ошибка измерения заряда батареи</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Ошибка внутреннего расчета</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Ошибка внутреннего расчета</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Количество послед. подключ. батарей неверное</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Количество послед. подключ. батарей неверное</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Ошибка аппаратных компонентов</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Ошибка аппаратных компонентов</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Ошибка устройства защиты</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Ошибка устройства защиты</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Перенапряжение</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Перенапряжение</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Недостаточное напряжение</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Недостаточное напряжение</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Перегрев</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Перегрев</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Недостаточная температура</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Недостаточная температура</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Режим ожидания при недостаточной зарядке</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Режим ожидания при недостаточной зарядке</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Ошибка АЦП</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Ошибка АЦП</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Ошибка связи батареи</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Ошибка связи батареи</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Ошибка предварительной зарядки</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Ошибка предварительной зарядки</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Ошибка контактора безопасности</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Ошибка контактора безопасности</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Ошибка обновления батареи</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Ошибка обновления батареи</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Ошибка кабеля BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Ошибка кабеля BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Сбой опорного напряжения</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Сбой опорного напряжения</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Неправильное напряжение системы</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Неправильное напряжение системы</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Таймаут предварительной зарядки</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Таймаут предварительной зарядки</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Сбой ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Сбой ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Данные калибровки потеряны</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Данные калибровки потеряны</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Неверные настройки</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Неверные настройки</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Интерлок</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Интерлок</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Аварийный выключатель</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Аварийный выключатель</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Таймаут связи</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Таймаут связи</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Предохранительный замок</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Предохранительный замок</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Перегрев терминала</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Перегрев терминала</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Без ошибок</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Высокая температура батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Высокое напряжение батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Не подключен датчик температуры</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Отсутствует датчик температуры</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Не подключен датчик напряжения</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Отсутствует датчик напряжения</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Большие потери в проводах к АКБ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Низкое напряжение батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Высокая пульсация напряжения батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Низкий уровень заряда батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Проблема напряжения средней точки батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Слишком низкая температура батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Высокая температура зарядного устройства</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Чрезмерный ток в зарядном устройстве</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Отрицательный ток в зарядном устройстве</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Время основной зарядки истекло</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Проблема с датчиком тока зарядного устройства</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Не подключен внутренний датчик температуры</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Отсутствует внутренний датчик температуры</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Вентилятор зарядного устройства не обнаружен</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Превышен ток вентилятора зарядного устройства</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Перегрев клемм зарядного устройства</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Короткое замыкание в зарядном устройстве</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Проблема стадии заряда устройства</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Защита от перезарядки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Высокое входящее напряжение</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Превышена входная сила тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Превышена входная мощность</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Проблема с полярностью на входе</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Отсутствует напряжение на входе</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Вход отключен (без повтора)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Вход отключен (повтор)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Внутренний сбой входа</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Сбой изоляции фотоэлектрической панели</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Зафиксирована неисправность заземления</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Перегрузка инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Слишком высокая темп. инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Пиковый ток инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Внутренний уровень постоянного тока инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Неправильный уровень выхода переменного тока инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Неисправность ступени питания инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Инвертор подключен к сети переменного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Сбой при тестировании реле ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Сбой при тестировании реле ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Устройство потеряно</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Несовместимое устройство</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Соединение с BMS потеряно</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Сеть неправильно настроена</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Изменение фазы</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Несколько входов переменного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Перегрузка фазы</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Ошибка записи в память</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Очень высокая температура процессора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Соединение потеряно</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Данные калибровки потеряны</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Несовместимая прошивка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Устройство несовместимо</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Неверные настройки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Ошибка номинального напряжения</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Неисправность тестера</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>История недействительна</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Счетчики кВт/ч недействительны</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Ошибка напряжения DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Ошибка датчика GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Ошибка питания 3В3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Ошибка питания 5В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Ошибка питания 12 В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Ошибка питания 15В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Отключение входа PV</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Установите переключатель в разблокированное положение, чтобы изменить настройки.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Использовать источник данных D-Bus: подключитесь к указанному адресу D-Bus.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>адрес</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Использовать источник данных D-Bus: подключиться к адресу D-Bus по умолчанию.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Использовать источник данных MQTT: подключитесь к указанному адресу брокера MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>адрес</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>Идентификатор портала устройства источника данных MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>portalId</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Осколок веб-хоста MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>осколок</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Имя пользователя источника данных MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Пользователь</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Пароль источника данных MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>проходить</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Токен источника данных MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Код токена</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Включить счетчик FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Пропустить заставку</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Используйте фиктивный источник данных для тестирования.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Устройство выключено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Смешаны старый/новый MK2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Ожидаемая ошибка устройств</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Других устройств не обнаружено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Перенапряжение на AC-out</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>DDC ошибка программы</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS без помощника</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Тест наземного реле не пройден</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Ошибка синхронизации системного времени</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Сбой теста реле сети</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Несоответствие конфигурации со 2м mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Ошибка передачи устройства</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Ожидание конфигурации или отсутствие ключа</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Отсутствует мастер фазы</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Произошло перенапряжение</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>У ведомого нет АС входа!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Устройство не может быть ведомым</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Инициирована защита системы</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Прошивка несовместима</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Внутренняя ошибка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Ошибка при проверке реле препятствует подключению</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Ошибка VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Неизвестная ошибка:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Внутренняя ошибка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Без ошибок</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Высокая температура батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Высокое напряжение батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Низкое напряжение батареи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Напряжение батареи превысило установленный максимум</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Высокая температура генератора переменного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Высокое число оборотов генератора переменного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Высокая температура ТЭНа полевого привода</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Отсутствует необходимый датчик</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Низкое напряжение генератора переменного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Смещение высокого напряжения генератора переменного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Напряжение генератора переменного тока превысило установленный максимум</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Высокое напряжение генератора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Батарея отключена</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Отключение батареи при высоком напряжении</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Выход аккумулятора за пределы диапазона</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Слишком много устройств BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Батарея скоро отключится</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Слишком много устройств для отслеживания</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Отключение батареи при низком напряжении</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Отключение батареи при высоком токе</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Отключение батареи при высокой температуре</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Отключение батареи при низкой температуре</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Соединение с BMS потеряно</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC отключен</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>Преобразователь постоянного тока не готов</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>Высокое первичное напряжение DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>Низкое первичное напряжение DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>Высокое вторичное напряжение DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>Низкое вторичное напряжение DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>Высокая температура DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>Неправильная конфигурация DC/DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Неисправен датчик температуры батареи</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Неизвестная ошибка:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Неизвестная ошибка:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Без ошибок</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Высокая температура батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Высокое напряжение батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Не подключен датчик температуры</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Отсутствует датчик температуры</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Не подключен датчик напряжения</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Отсутствует датчик напряжения</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Большие потери в проводах к АКБ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Низкое напряжение батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Высокая пульсация напряжения батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Низкий уровень заряда батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Проблема напряжения средней точки батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Слишком низкая температура батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Высокая температура зарядного устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Чрезмерный ток в зарядном устройстве</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Отрицательный ток в зарядном устройстве</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Время основной зарядки истекло</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Проблема с датчиком тока зарядного устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Не подключен внутренний датчик температуры</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Отсутствует внутренний датчик температуры</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Вентилятор зарядного устройства не обнаружен</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Превышен ток вентилятора зарядного устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Перегрев клемм зарядного устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Короткое замыкание в зарядном устройстве</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Проблема стадии заряда устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Защита от перезарядки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Высокое входящее напряжение</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Превышена входная сила тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Превышена входная мощность</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Проблема с полярностью на входе</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Отсутствует напряжение на входе</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Вход отключен (без повтора)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Вход отключен (повтор)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Внутренний сбой входа</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Сбой изоляции фотоэлектрической панели</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Зафиксирована неисправность заземления</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Перегрузка инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Слишком высокая темп. инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Пиковый ток инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Внутренний уровень постоянного тока инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Неправильный уровень выхода переменного тока инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Неисправность ступени питания инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Инвертор подключен к сети переменного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Сбой при тестировании реле ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Сбой при тестировании реле ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Устройство потеряно</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Несовместимое устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Соединение с BMS потеряно</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Сеть неправильно настроена</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Изменение фазы</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Несколько входов переменного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Перегрузка фазы</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Ошибка записи в память</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Очень высокая температура процессора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Соединение потеряно</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Данные калибровки потеряны</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Несовместимая прошивка</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Устройство несовместимо</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Неверные настройки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Ошибка номинального напряжения</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Неисправность тестера</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>История недействительна</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Счетчики кВт/ч недействительны</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Ошибка напряжения DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Ошибка датчика GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>Ошибка питания 3В3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>Ошибка питания 5В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>Ошибка питания 12 В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>Ошибка питания 15В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Отключение входа PV</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Неизвестная ошибка:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Неизвестная ошибка:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Неизвестная ошибка:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Неизвестная ошибка:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Без ошибок</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>AC напряжение L1 слишком низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>AC напряжение слишком низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Напряжение переменного тока L1 слишком высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Напряжение переменного тока слишком высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Частота переменного тока L1 слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Частота переменного тока слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Частота переменного тока L1 слишком высока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Частота переменного тока слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC ток L1 слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>AC ток слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Мощность переменного тока L1 слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>AC мощность слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Аварийный выключатель</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Ток системы автоматического регулирования слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Давление масла слишком низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Давление масла слишком высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Температура двигателя слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Температура двигателя слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Температура обмотки слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Температура обмотки слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Температура выхлопа слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Температура выхлопа слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Низкая электронная температура</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Высокая температура электроники</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Слишком низкое напряжение стартера</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Ток стартера слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Слишком низкое напряжение накала</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Ток накала слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Слишком высокое напряжение системы Cold-Start-Aid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Слишком высокий ток холодного пуска-помощи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Слишком низкое напряжение магнита удержания топлива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Ток топливного удерживающего магнита слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Слишком низкое напряжение удерживающей катушки электромагнита останова</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Ток обмотки удержания электроклапана остановки слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Слишком низкое напряжение тяговой катушки электромагнита останова </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Ток обмотки притягивания электроклапана остановки слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Слишком низкое напряжение вентилятора/водяного насоса</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Слишком высокий ток вентилятора/водяного насоса</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Низкое напряжение датчика тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Высокий ток датчика тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Слишком низкое выходное напряжение буста</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Выходной ток наддува слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Слишком низкое напряжение питания шины</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Слишком высокий ток питания шины</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Напряжение стартерной батареи слишком низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Напряжение стартерной батареи слишком высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Вращение слишком медленное</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Вращение слишком быстрое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Неожиданная остановка/проблема с подачей топлива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Слишком низкое напряжение силового контактора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Ток контактора мощности слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>AC напряжение L2 слишком низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Напряжение переменного тока L2 слишком высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>AC частота L2 слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Частота переменного тока L2 слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>Переменный ток L2 слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>AC мощность L2 слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Напряжение переменного тока L3 слишком низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>AC напряжение L3 слишком высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Частота переменного тока L3 слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Частота переменного тока L3 слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC ток L3 слишком высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>AC мощность L3 слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Слишком низкое выходное напряжение преобразователя частоты</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Слишком большой выходной ток инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Слишком низкое напряжение универсального выхода (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Слишком большой ток универсального выхода (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Слишком низкое напряжение универсального выхода (5A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Слишком высокий ток универсального выхода (5A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Напряжение постоянного тока AGT 1 низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Напряжение постоянного тока AGT 1 высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT Постоянный ток 1 низкий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT Постоянный ток 1 высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Напряжение постоянного тока AGT 2 низкое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Напряжение постоянного тока AGT 2 высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>Постоянный ток AGT 2 низкий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>Постоянный ток AGT 2 высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Низкий радиатор AGT B6</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>Кулер AGT B6 высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 рельс (-) низкий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 рельс (-) высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 рельс (+) низкий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 рельс (+) высокий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Температура топлива слишком низкая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Температура топлива слишком высокая</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Уровень топлива слишком низкий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Блок управления потерян</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Потерянная панель</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Требуется обслуживание</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Потерянный 3-фазный модуль</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>AGT модуль потерян</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Сбой синхронизации</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Потерянный внешний ЭБУ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Фильтр впускного воздуха</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Диагностическое сообщение (ЭБУ)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Потерянный модуль синхронизации</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Сбой баланса нагрузки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Режим синхронизации отключен</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Красный стоп-сигнал (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Янтарная предупреждающая лампа (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Индикаторная лампа неисправности (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Защитная лампа (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Поле вращения неверное</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Потерян датчик уровня топлива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Запуск без инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Автобус №1 погиб</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Запрос на запуск отклонен</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Дистанционный запуск запрещен</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Принудительное отключение реле нагрузки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Модуль синхронизации отключен</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Потерянный BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Преобразователь Напряжение звена постоянного тока низкое/обратное</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Низкий ток звена постоянного тока преобразователя</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Низкое напряжение предварительного заряда преобразователя постоянного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Преобразователь постоянного тока Напряжение предварительного заряда высокое</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Ошибка драйвера преобразователя IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Ошибка преобразователя Контур управления питанием</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Определение частоты переменного тока преобразователя</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Сбой управляющего значения преобразователя</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Заводская настройка изменена</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Изменение параметров в режиме администратора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Ручное вмешательство (внешняя система)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Сбой инициализации</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Устройство защиты</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Высокая температура преобразователя L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Высокая температура преобразователя L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Высокая температура преобразователя L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Высокая температура преобразователя Звено постоянного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Перегрузка инвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Потеря связи с инвертором</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Перегрузка DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Перенапряжение постоянного тока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Нет связи</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Без ошибок</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Неизвестная ошибка: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Неизвестная ошибка:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Давление масла</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Перегрев головки блока цилиндров</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Контроль заряда</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Скорость выше ожидаемой</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Превышение скорости</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Температура воздуха выше, чем ожидалось</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Обрыв цепи / короткое замыкание на питание</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Замыкание на землю при перегреве</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Высокий уровень аналоговой уставки / короткое замыкание на питание</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Низкий уровень аналоговой уставки / замыкание на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Таймаут приема сообщений TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Таймаут приема сообщений CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Высокое напряжение аккумулятора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Низкое напряжение аккумулятора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Искажение сигнала скорости</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Высокий уровень питания внутреннего датчика 5 В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Низкий уровень напряжения питания внутреннего датчика 5 В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Высокое барометрическое давление</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Низкое барометрическое давление</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Короткое замыкание выходного топливного насоса на питание</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Короткое замыкание выходного топливного насоса на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Короткое замыкание выходной свечи накаливания на питание</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Короткое замыкание свечи накаливания на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Обрыв цепи инжектора/короткое замыкание нижней стороны на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Внутреннее короткое замыкание катушки инжектора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Короткое замыкание низкой стороны инжектора на питание</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Истекли часы обслуживания</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Сбой процессора</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Неизвестная ошибка:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Батарея</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Батарея</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Холодильник</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Холодильник</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Общий</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Общий</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Номер</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Номер</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>На улице</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>На улице</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Водонагреватель</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Водонагреватель</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Морозильная камера</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Морозильная камера</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Неизвестная ошибка:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Без ошибок</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>AC напряжение L1 слишком низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>AC напряжение слишком низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>Напряжение переменного тока L1 слишком высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>Напряжение переменного тока слишком высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>Частота переменного тока L1 слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>Частота переменного тока слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>Частота переменного тока L1 слишком высока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>Частота переменного тока слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC ток L1 слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>AC ток слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>Мощность переменного тока L1 слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>AC мощность слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Аварийный выключатель</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Ток системы автоматического регулирования слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Давление масла слишком низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Давление масла слишком высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Температура двигателя слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Температура двигателя слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Температура обмотки слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Температура обмотки слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Температура выхлопа слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Температура выхлопа слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Низкая электронная температура</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Высокая температура электроники</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Слишком низкое напряжение стартера</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Ток стартера слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Слишком низкое напряжение накала</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Ток накала слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Слишком высокое напряжение системы Cold-Start-Aid</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Слишком высокий ток холодного пуска-помощи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Слишком низкое напряжение магнита удержания топлива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Ток топливного удерживающего магнита слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Слишком низкое напряжение удерживающей катушки электромагнита останова</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Ток обмотки удержания электроклапана остановки слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Слишком низкое напряжение тяговой катушки электромагнита останова </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Ток обмотки притягивания электроклапана остановки слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Слишком низкое напряжение вентилятора/водяного насоса</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Слишком высокий ток вентилятора/водяного насоса</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Низкое напряжение датчика тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Высокий ток датчика тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Слишком низкое выходное напряжение буста</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Выходной ток наддува слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Слишком низкое напряжение питания шины</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Слишком высокий ток питания шины</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Напряжение стартерной батареи слишком низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Напряжение стартерной батареи слишком высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Вращение слишком медленное</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Вращение слишком быстрое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Неожиданная остановка/проблема с подачей топлива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Слишком низкое напряжение силового контактора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Ток контактора мощности слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>AC напряжение L2 слишком низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>Напряжение переменного тока L2 слишком высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>AC частота L2 слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>Частота переменного тока L2 слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>Переменный ток L2 слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>AC мощность L2 слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>Напряжение переменного тока L3 слишком низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>AC напряжение L3 слишком высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>Частота переменного тока L3 слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>Частота переменного тока L3 слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC ток L3 слишком высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>AC мощность L3 слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Слишком низкое выходное напряжение преобразователя частоты</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Слишком большой выходной ток инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Слишком низкое напряжение универсального выхода (1A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Слишком большой ток универсального выхода (1A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Слишком низкое напряжение универсального выхода (5A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Слишком высокий ток универсального выхода (5A)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>Напряжение постоянного тока AGT 1 низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>Напряжение постоянного тока AGT 1 высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT Постоянный ток 1 низкий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT Постоянный ток 1 высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Напряжение постоянного тока AGT 2 низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Напряжение постоянного тока AGT 2 высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>Постоянный ток AGT 2 низкий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>Постоянный ток AGT 2 высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>Низкий радиатор AGT B6</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>Кулер AGT B6 высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 рельс (-) низкий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 рельс (-) высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 рельс (+) низкий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 рельс (+) высокий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Температура топлива слишком низкая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Температура топлива слишком высокая</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Уровень топлива слишком низкий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Блок управления потерян</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Потерянная панель</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Требуется обслуживание</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Потерянный 3-фазный модуль</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>AGT модуль потерян</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Сбой синхронизации</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Потерянный внешний ЭБУ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Фильтр впускного воздуха</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Диагностическое сообщение (ЭБУ)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Потерянный модуль синхронизации</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Сбой баланса нагрузки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Режим синхронизации отключен</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Красный стоп-сигнал (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Янтарная предупреждающая лампа (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Индикаторная лампа неисправности (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Защитная лампа (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Поле вращения неверное</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Потерян датчик уровня топлива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Запуск без инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Автобус №1 погиб</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Запрос на запуск отклонен</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Дистанционный запуск запрещен</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Принудительное отключение реле нагрузки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Модуль синхронизации отключен</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>Потерянный BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Преобразователь Напряжение звена постоянного тока низкое/обратное</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Низкий ток звена постоянного тока преобразователя</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Низкое напряжение предварительного заряда преобразователя постоянного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Преобразователь постоянного тока Напряжение предварительного заряда высокое</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Ошибка драйвера преобразователя IGBT/MOSFET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Ошибка преобразователя Контур управления питанием</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Определение частоты переменного тока преобразователя</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Сбой управляющего значения преобразователя</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Заводская настройка изменена</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Изменение параметров в режиме администратора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Ручное вмешательство (внешняя система)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Сбой инициализации</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Устройство защиты</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Высокая температура преобразователя L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Высокая температура преобразователя L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Высокая температура преобразователя L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Высокая температура преобразователя Звено постоянного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Перегрузка инвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Потеря связи с инвертором</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>Перегрузка DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>Перенапряжение постоянного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Нет связи</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Без ошибок</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Неизвестная ошибка: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Неизвестная ошибка:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Давление масла</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Перегрев головки блока цилиндров</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Контроль заряда</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Скорость выше ожидаемой</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Превышение скорости</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Температура воздуха выше, чем ожидалось</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Обрыв цепи / короткое замыкание на питание</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Замыкание на землю при перегреве</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Высокий уровень аналоговой уставки / короткое замыкание на питание</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Низкий уровень аналоговой уставки / замыкание на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Таймаут приема сообщений TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Таймаут приема сообщений CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Высокое напряжение аккумулятора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Низкое напряжение аккумулятора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Искажение сигнала скорости</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Высокий уровень питания внутреннего датчика 5 В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Низкий уровень напряжения питания внутреннего датчика 5 В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Высокое барометрическое давление</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Низкое барометрическое давление</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Короткое замыкание выходного топливного насоса на питание</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Короткое замыкание выходного топливного насоса на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Короткое замыкание выходной свечи накаливания на питание</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Короткое замыкание свечи накаливания на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Обрыв цепи инжектора/короткое замыкание нижней стороны на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Внутреннее короткое замыкание катушки инжектора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Короткое замыкание низкой стороны инжектора на питание</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Истекли часы обслуживания</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Сбой процессора</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Установите переключатель в разблокированное положение, чтобы изменить настройки.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Использовать источник данных D-Bus: подключитесь к указанному адресу D-Bus.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>адрес</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Использовать источник данных D-Bus: подключиться к адресу D-Bus по умолчанию.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Использовать источник данных MQTT: подключитесь к указанному адресу брокера MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>адрес</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>Идентификатор портала устройства источника данных MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>portalId</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Осколок веб-хоста MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>осколок</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Имя пользователя источника данных MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Пользователь</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Пароль источника данных MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>проходить</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Токен источника данных MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Код токена</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Включить счетчик FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Пропустить заставку</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Используйте фиктивный источник данных для тестирования.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Морокко, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Западная Центральная Африка, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Южная Африка, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Намибия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Египет, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Восточная Африка, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Аргентина, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Восточная Южная Америка, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Гренландия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Монтевидео, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Ньюфайндленд, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Южная Америка, восточное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Атлантика, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Центральная Бразилия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Южная Америка, Тихий океан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Парагвай, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Южная Америка, западное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Венесуэла, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Восточное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Южная Америка, Тихий океан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>США, восточное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Центральная Канада, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Центральная Америка, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Центральное стандартное время (Мексика)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Центральное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Горное стандартное время (Мексика)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Горное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>США, горное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Тихоокеанское стандартное время (Мексика)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Аляска, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Гавайи, Алеуты</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Новая Зеландия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Центральное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Западное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Западная Австралия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Юго-Восточная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Центральная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Западная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Восточная Африка, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Южная Америка, Тихий океан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Южная Америка, западное стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Западная Европа, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Камчатка, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Магадан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Владивосток, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Якутск, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Токио, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Корея, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Сингапур, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Улан-Батор, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Тайпей, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Северная Азия, восточное стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Китай, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Юго-Восточная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Северная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Мьянма, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Северная Центральная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Центральная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Бангладеш, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Непал, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Шри-Ланка, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Индия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Западная Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Пакистан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Екатеринбург, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Грузия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Кавказ, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Азербайджан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Арабское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Афганистан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Иран, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Арабское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Арабское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Сирия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Средняя Азия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Иордан, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Израиль, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Гринвич, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Азорские острова, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Кабо-Верде, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Тасмания, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Восточная Австралия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Восточная Австралия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Центральная Австралия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Центральная Австралия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Западная Австралия, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Средняя Атлантика, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Граница дат, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>GMT, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Центральная Европа, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Центрально-европейское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Романское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Западная Европа, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Восточная Европа, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>FLE, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>GTB, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Белорусское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Российское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Турция, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Мавритания, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Остров Рождества, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Тонга, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Фиджи, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Новая Зеландия, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Центральное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Западное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Самоа, стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Гавайское стандартное время</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Остров Пасхи, стандартное время</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Внутренняя ошибка</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Неизвестная ошибка:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Внутренняя ошибка</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Без ошибок</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Высокая температура батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Высокое напряжение батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Низкое напряжение батареи</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Напряжение батареи превысило установленный максимум</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Высокая температура генератора переменного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Высокое число оборотов генератора переменного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Высокая температура ТЭНа полевого привода</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Отсутствует необходимый датчик</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Низкое напряжение генератора переменного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Смещение высокого напряжения генератора переменного тока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Напряжение генератора переменного тока превысило установленный максимум</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Высокое напряжение генератора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Батарея отключена</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Отключение батареи при высоком напряжении</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Выход аккумулятора за пределы диапазона</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Слишком много устройств BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Батарея скоро отключится</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Слишком много устройств для отслеживания</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Отключение батареи при низком напряжении</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Отключение батареи при высоком токе</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Отключение батареи при высокой температуре</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Отключение батареи при низкой температуре</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Соединение с BMS потеряно</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC отключен</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>Преобразователь постоянного тока не готов</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>Высокое первичное напряжение DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>Низкое первичное напряжение DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>Высокое вторичное напряжение DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>Низкое вторичное напряжение DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>Высокая температура DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>Неправильная конфигурация DC/DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Неисправен датчик температуры батареи</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_sv.ts
+++ b/i18n/venus-gui-v2_sv.ts
@@ -1,7382 +1,8024 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="sv">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Inaktiverad</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Inaktiverad</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Växelriktare överbelastning</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Växelriktare överbelastning</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Effekt</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Effekt</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Av</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Av</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Automatisk</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Automatisk</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Batteri</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Ansluten</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Frånkopplad</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Generator</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Hög batterispänning</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Hög batterispänning</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Växelriktare/ laddare</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Växelriktare/ laddare</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Låg batterispänning</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Låg batterispänning</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manual</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manual</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Ingen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Ingen</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Position</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Position</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Hastighet</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Hastighet</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Status</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Status</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installerar %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installerar %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Okänt fel</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Okänt fel</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Lägsta SOC</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Lägsta SOC</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Okänd</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Ange lösenord</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Ange lösenord</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Tryck för att söka</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Tryck för att söka</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Nät</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Nät</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Solcellsproduktion</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Solcellsproduktion</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Extern kontroll</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Extern kontroll</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Tankar</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Tankar</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Miljö</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Miljö</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Inga befintliga varningar</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Inga befintliga varningar</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Allmänt</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Allmänt</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Maskinvara</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Maskinvara</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Datum &amp; tid</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Datum &amp; tid</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Systeminstallation</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Systeminstallation</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Display &amp; språk</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Display &amp; språk</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM online portal</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM online portal</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Energimätare</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Energimätare</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>Solcellsväxelriktare</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>Solcellsväxelriktare</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM-modem</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM-modem</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Generator start/stopp</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Generator start/stopp</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Tankpump</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Tankpump</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Kundtjänst</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Kundtjänst</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Venus OS Large funktioner</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Venus OS Large funktioner</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Battery life-gräns: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Battery life-gräns: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Autostart inaktiveras och generatorn startar inte automatiskt baserat på de inställda villkoren.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Autostart inaktiveras och generatorn startar inte automatiskt baserat på de inställda villkoren.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Manuellt stopp</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Manuellt stopp</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Manuel start</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Manuel start</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Position</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Autostart</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Autostart</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Brytare</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Brytare</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Åtkomstnivå</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Åtkomstnivå</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Användare</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Användare</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Användare &amp; Installatör</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Användare &amp; Installatör</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Superanvändare</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Superanvändare</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Konfigurerbar tjänst: {name}</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Konfigurerbar tjänst: {name}</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Se till att även återställa VE.Bus-systemet efter att ha inaktiverat DVCC</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Se till att även återställa VE.Bus-systemet efter att ha inaktiverat DVCC</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Gräns laddningsström</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Gräns laddningsström</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Maximal laddningsström</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Maximal laddningsström</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Använd %1 värde för start/stopp</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Använd %1 värde för start/stopp</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Starta när %1 är högre än</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Starta när %1 är högre än</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Starta när %1 är lägre än</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Starta när %1 är lägre än</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Stoppa när %1 är högre än</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Stoppa när %1 är högre än</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Stoppa när %1 är lägre än</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Stoppa när %1 är lägre än</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Ta bort IP-adress?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Ta bort IP-adress?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Anslutning</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Anslutning</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Produkt</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Produkt</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Namn</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Namn</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>Produkt-id</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>Produkt-id</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Maskinvaruversion</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Maskinvaruversion</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Enhetsnamn</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Enhetsnamn</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Fjärrbrytarkontroll inaktiverad</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Fjärrbrytarkontroll inaktiverad</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Generator i felläge</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Generator i felläge</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Generatorn hittades  inte vid AC-ingången</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Generatorn hittades  inte vid AC-ingången</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Sammanlagd drifttid sedan senaste provdrift</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Sammanlagd drifttid sedan senaste provdrift</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Tid till nästa provdrift</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Tid till nästa provdrift</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>I drift nu</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>I drift nu</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Manuel start</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Manuel start</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Starta generator</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Starta generator</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Daglig drift</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Daglig drift</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Värdet måste vara högre än stoppvärdet</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Värdet måste vara högre än stoppvärdet</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Värdet måste vara lägre än startvärdet</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Värdet måste vara lägre än startvärdet</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>AC-utgång</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>AC-utgång</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">AC-utgång</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Använd AC-belastning för att starta/stoppa</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Använd AC-belastning för att starta/stoppa</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Mätning</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Mätning</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Total förbrukning</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Total förbrukning</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Växelriktare total AC-ut</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Växelriktare total AC-ut</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Växelriktare AC-ut högsta fas</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Växelriktare AC-ut högsta fas</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Starta när effekten är högre än</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Starta när effekten är högre än</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Stoppa när effekten är lägre än</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Stoppa när effekten är lägre än</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Batteriövervakare</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Batteriövervakare</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Övervakare ej tillgänglig, ställ in en annan</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Övervakare ej tillgänglig, ställ in en annan</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Batteriövervakare</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Övervakare ej tillgänglig, ställ in en annan</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Vid kommunikationsförlust</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Vid kommunikationsförlust</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Stoppa generator</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Stoppa generator</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Håll generator i drift</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Håll generator i drift</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Stoppa generator när AC-ingång är tillgänglig</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Stoppa generator när AC-ingång är tillgänglig</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>Batteri SOC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>Batteri SOC</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Hög temp. växelriktare</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Hög temp. växelriktare</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Hög temp. växelriktare</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Starta vid varning om hög temperatur</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Starta vid varning om hög temperatur</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Starta vid överbelastningsvarning</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Starta vid överbelastningsvarning</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Periodisk drift</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Periodisk drift</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Driftintervall</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Driftintervall</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 dag(ar)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 dag(ar)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Skippa drift om den harvarit igång i</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Skippa drift om den harvarit igång i</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Starta alltid</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Starta alltid</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Startdatum driftintervall</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Startdatum driftintervall</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Drifttid (hh:mm)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Drifttid (hh:mm)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Kör tills att batteriet är fulladdat.</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Kör tills att batteriet är fulladdat.</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (fix)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (fix)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS ansluten, men ingen GPS fix</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS ansluten, men ingen GPS fix</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Ingen GPS ansluten</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Ingen GPS ansluten</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Latitud</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Latitud</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Longitud</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Longitud</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 km/h</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Kurs</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Kurs</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Driftshöjd</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Driftshöjd</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Antal satelliter</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Antal satelliter</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Börvärde nät</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Börvärde nät</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Börvärde AC-in</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Börvärde AC-in</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Ström: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Ström: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Spänning: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Spänning: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Gränser (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Gränser (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Laddning: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Laddning: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Urladdning: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Urladdning: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Gränser (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Gränser (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Synlig</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Synlig</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Dold</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Dold</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (hjälpmätningar)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (hjälpmätningar)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Utgång %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Utgång %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Aktiv batteriövervakare</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Aktiv batteriövervakare</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Namn</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Ange namn</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Ange namn</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Ange namn</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Kontinuerlig skanning</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Kontinuerlig skanning</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Bluetooth-adaptrar</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Bluetooth-adaptrar</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Pinkod</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Pinkod</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Det kan vara nödvändigt att ta bort befintlig parningsinformation innan du ansluter.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Det kan vara nödvändigt att ta bort befintlig parningsinformation innan du ansluter.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Fastyp</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Fastyp</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Enfas</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Enfas</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Flerfas</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Flerfas</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>PV-växelriktare i fas 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>PV-växelriktare i fas 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>Positin för PV-växelriktare i fas 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>Positin för PV-växelriktare i fas 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>CAN-busprofil</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>CAN-busprofil</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Inaktiverad</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Aktiv men inga tjänster (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Aktiv men inga tjänster (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Enheter</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Enheter</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000-out</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000-out</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Väljare av unikt identitetsnummer</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Väljare av unikt identitetsnummer</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Vänligen vänta, det tar en stund att ändra och kontrollera det unika numret</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Vänligen vänta, det tar en stund att ändra och kontrollera det unika numret</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Väljaren ovan fastställer vilket block av unika identitetsnummer som ska användas för de unika identitetsnumren NAME i fältet PGN 60928 NAME. Ändra endast det när du använder flera GX-enheter i ett VE.Can-nät.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Väljaren ovan fastställer vilket block av unika identitetsnummer som ska användas för de unika identitetsnumren NAME i fältet PGN 60928 NAME. Ändra endast det när du använder flera GX-enheter i ett VE.Can-nät.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Väljaren ovan fastställer vilket block av unika identitetsnummer som ska användas för serienumren i fältet DGN 60928 ADDRESS_CLAIM. Ändra endast det när du använder flera GX-enheter i ett RV-C-nät.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Väljaren ovan fastställer vilket block av unika identitetsnummer som ska användas för serienumren i fältet DGN 60928 ADDRESS_CLAIM. Ändra endast det när du använder flera GX-enheter i ett RV-C-nät.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Kontrollera unika ID-nummer</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Kontrollera unika ID-nummer</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Tryck för att söka</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Det finns en annan ansluten enhet med samma unika nummer, vänligen välj ett annat nummer.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Det finns en annan ansluten enhet med samma unika nummer, vänligen välj ett annat nummer.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: Ingen annan enhet är kopplad till detta unika nummer.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: Ingen annan enhet är kopplad till detta unika nummer.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Nätverksstatus</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Nätverksstatus</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Anpassningsbar ljusstyrka</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Anpassningsbar ljusstyrka</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Ljusstyrka</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Ljusstyrka</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Tid skärmsläckning</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Tid skärmsläckning</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 sek</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 sek</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 sek</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 sek</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 min</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 min</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 min</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Aldrig</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Aldrig</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Visningsläge</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Visningsläge</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Mörk</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Mörk</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Ljus</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Ljus</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Översiktliga nivåer</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Översiktliga nivåer</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Språk</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Språk</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Byter språk</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Byter språk</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Elektrisk effektindikator</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Elektrisk effektindikator</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Effekt (Watt)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Effekt (Watt)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Ström (Amp)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Ström (Amp)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Enheter</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Enheter</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Nivå %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Nivå %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Celsius (°C)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Celsius (°C)</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit (F)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit (F)</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;OBS:&lt;/b&gt; Läs manualen innan justering</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;OBS:&lt;/b&gt; Läs manualen innan justering</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Gräns laddningsspänning reglerat batteri</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Gräns laddningsspänning reglerat batteri</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Maximal laddningsspänning</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Maximal laddningsspänning</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - delad spänningssensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - delad spänningssensor</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Shared temperature sense (delad temperatursensor)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Shared temperature sense (delad temperatursensor)</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Sensor ej tillgänglig, ställ in en annan</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Sensor ej tillgänglig, ställ in en annan</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Sensor ej tillgänglig, ställ in en annan</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Använd sensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Använd sensor</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - delad spänningssensor</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - delad spänningssensor</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>SCS-status</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>SCS-status</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Avaktiverad (extern kontroll)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Avaktiverad (extern kontroll)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Inaktiverad (inga laddare)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Inaktiverad (inga laddare)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Avaktiverad (ingen batteriövervakare)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Avaktiverad (ingen batteriövervakare)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Automatiskt val</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Automatiskt val</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Ingen BMS Control</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Ingen BMS Control</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Styr BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Styr BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Ej tillgänglig, ställ in en annan</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Ej tillgänglig, ställ in en annan</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Autovald</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Autovald</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Ingen</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Tillv. datum/tid</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Tillv. datum/tid</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Onlineuppdateringar</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Onlineuppdateringar</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Installera fast programvara från SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Installera fast programvara från SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Sparad kopia av fast programvara</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Sparad kopia av fast programvara</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Sök efter uppdateringar på SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Sök efter uppdateringar på SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Programvara hittad</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Programvara hittad</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Installerar %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Installerar %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Tryck för att uppdatera till %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Tryck för att uppdatera till %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Tryck för att uppdatera till %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Programvara skapad datum/tid</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Programvara skapad datum/tid</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Automatisk uppdatering</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Automatisk uppdatering</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Enbart sökning</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Enbart sökning</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Enbart sökning och nedladdning</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Enbart sökning och nedladdning</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Sökning och uppdatering</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Sökning och uppdatering</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Uppdateringsflöde</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Uppdateringsflöde</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Bildtyp</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Bildtyp</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>vanlig</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>vanlig</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Stor</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Stor</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Sök efter uppdateringar</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Sök efter uppdateringar</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Uppdatering tillgänglig</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Uppdatering tillgänglig</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Installerar %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Installerar %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Installerar %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Uppdatera tillv. datum/tid</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Uppdatera tillv. datum/tid</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Växelriktare</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Växelriktare</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Hitta solcellsväxelriktare</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Hitta solcellsväxelriktare</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Hittade IP-adress</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Hittade IP-adress</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Lägg till IP-adress manuellt</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Lägg till IP-adress manuellt</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>TCP port</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>TCP port</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Flerfas</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Flerfas</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Delad fas (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Delad fas (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Visa</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Visa</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Söka efter IP-adresser på nytt?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Söka efter IP-adresser på nytt?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Skanna igen</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Skanna igen</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH på LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH på LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Fjärrsupport</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Fjärrsupport</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Fjärrsupporttunnel</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Fjärrsupporttunnel</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>Fjärrstödd IP och port</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>Fjärrstödd IP och port</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Logga ut nu</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Starta om nu</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Starta om nu</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Enheten har startats om.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Ljudlarm</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Ljudlarm</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Demoinställning</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Demoinställning</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS-demo</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS-demo</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Båt/Husbil demo 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Båt/Husbil demo 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Båt/husbil demo 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Båt/husbil demo 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Vid start av demoläge kommer några inställningar att ändras och användargränssnittet blockeras under en stund.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Vid start av demoläge kommer några inställningar att ändras och användargränssnittet blockeras under en stund.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Villkor</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Villkor</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Minsta drifttid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Minsta drifttid</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Uppvärmningstid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Uppvärmningstid</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Nedkylningstid</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Nedkylningstid</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Hitta generator vid AC-ingång</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Hitta generator vid AC-ingång</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Ingen av AC-ingångarna är inställda på generator. Gå till sidan för systeminställningar och ställ in rätt AC-ingång pål generatorn för att aktivera den här funktionen.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Ingen av AC-ingångarna är inställda på generator. Gå till sidan för systeminställningar och ställ in rätt AC-ingång pål generatorn för att aktivera den här funktionen.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Ett larm utlöses när ingen ström känns av vid växelriktarens AC-ingång. Säkerställ att rätt AC-ingång är inställd på generator på sidan för systeminställningar.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Ett larm utlöses när ingen ström känns av vid växelriktarens AC-ingång. Säkerställ att rätt AC-ingång är inställd på generator på sidan för systeminställningar.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Starttid tysta timmar</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Starttid tysta timmar</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Sluttid tysta timmar</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Sluttid tysta timmar</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Drifttid och service</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Drifttid och service</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Återställ räknare för daglig drift</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Återställ räknare för daglig drift</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Räknaren för daglig drift har återställts</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Räknaren för daglig drift har återställts</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Det går inte att ändra räknarna när generatorn är i drift</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Det går inte att ändra räknarna när generatorn är i drift</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Generatorserviceintervall (timmar)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Generatorserviceintervall (timmar)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Servicetidsintervall inställt till %1t. Använd knappen ”Återställa servicetimer” för att återställa servicetimern.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Servicetidsintervall inställt till %1t. Använd knappen ”Återställa servicetimer” för att återställa servicetimern.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Återställa servicetimer</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Återställa servicetimer</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>GPS-inställningar</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>GPS-inställningar</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Format</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Format</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Hastighetsenhet'</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Hastighetsenhet&apos;</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Kilometer per timme</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Kilometer per timme</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Meter per sekund</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Meter per sekund</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Miles per timme</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Miles per timme</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Knop</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Knop</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>Inget GSM-modem anslutet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>Inget GSM-modem anslutet</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Operatör</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Operatör</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Det kan vara nödvändigt att konfigurera APN-inställningarna längre ned på denna sida. Kontakta din operatör för detaljer.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Det kan vara nödvändigt att konfigurera APN-inställningarna längre ned på denna sida. Kontakta din operatör för detaljer.
 Om det inte fungerar, testa simkortet i en telefon för att säkerställa att det finns saldo och/eller att det är registrerat för datatrafik.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Tillåt roaming</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Tillåt roaming</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Sim status</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Sim status</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM-kortet är inte inmatat</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM-kortet är inte inmatat</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN-kod krävs</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN-kod krävs</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK-kod krävs</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK-kod krävs</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>SIM-fel</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>SIM-fel</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM upptaget</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM upptaget</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Fel SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Fel SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Fel PIN-kod</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Fel PIN-kod</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Redo</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Redo</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Okänt fel</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Standard</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Standard</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Använd standard APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Använd standard APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>APN namn</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>APN namn</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Använd verifiering</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Använd verifiering</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Användarnamn</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Användarnamn</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Egenkonsumtion</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Egenkonsumtion</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Ingen ESS-assistent hittades</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Ingen ESS-assistent hittades</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Nätmätning</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Nätmätning</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Extern mätare</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Extern mätare</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Växelriktare/laddare</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Växelriktare/laddare</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Växelriktarens AC-utgång används</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Växelriktarens AC-utgång används</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Flerfasreglering</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Flerfasreglering</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Totalt för alla faser</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Totalt för alla faser</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Individuell fas</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Individuell fas</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Varje fas regleras för att individuellt uppnå nätets börvärde (systemeffektiviteten minskas).
+        <translation>Varje fas regleras för att individuellt uppnå nätets börvärde (systemeffektiviteten minskas).
 
 VARNING: Använd endast om det krävs av elleverantören.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Summan av alla faser regleras intelligent för att uppnå börvärdet för nätet (systemeffektiviteten optimeras).
+        <translation>Summan av alla faser regleras intelligent för att uppnå börvärdet för nätet (systemeffektiviteten optimeras).
 
 Använd såvida det inte är förbjudet av elleverantören.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Inaktiv</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamiskt ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Lägsta SoC (om inte nätet felar)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Lägsta SoC (om inte nätet felar)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Nuvarande SoC-gräns</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Nuvarande SoC-gräns</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Upprätthålla</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Laddar</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Topplastutjämning</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Topplastutjämning</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Endast över lägsta SoC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Endast över lägsta SoC</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Alltid</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Alltid</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Urladdning inaktiverad</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Urladdning inaktiverad</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Långsam laddning</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Långsam laddning</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Upprätthålla</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Upprätthålla</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Laddar</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Laddar</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Gräns laddningsström</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Gräns laddningsström</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Maximal laddningsström</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Maximal laddningsström</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Gräns växelriktareffekt</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Gräns växelriktareffekt</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Högsta växelriktareffekt</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Högsta växelriktareffekt</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Börvärde nät</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Börvärde nät</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Nätinmatning</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Nätinmatning</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>AC-kopplad PV – matning i överflöd</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>AC-kopplad PV – matning i överflöd</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>DC-kopplad solcell – matning i överflöd</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>DC-kopplad solcell – matning i överflöd</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Begränsa systemets inmatning</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Begränsa systemets inmatning</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Maximal inmatning</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Maximal inmatning</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Inmatningsbegränsning aktiv</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Inmatningsbegränsning aktiv</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Analoga ingångar</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Analoga ingångar</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Digitala ingångar</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Digitala ingångar</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Digital ingång %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Digital ingång %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Pulsmätare</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Pulsmätare</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Dörrlarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Dörrlarm</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Länspump</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Länspump</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Länspumpslarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Länspumpslarm</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Inbrottslarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Inbrottslarm</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Röklarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Röklarm</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Brandlarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Brandlarm</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>CO2-larm</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>CO2-larm</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Bluetooth-sensorer</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Bluetooth-sensorer</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Observera att dessa funktioner inte officiellt stöds av Victron. Vänd dig till community.victronenergy.com för frågor.
+        <translation>Observera att dessa funktioner inte officiellt stöds av Victron. Vänd dig till community.victronenergy.com för frågor.
 
 Documentation på https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Aktiverad (säkert läge)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Aktiverad (säkert läge)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Fördröjd med %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Fördröjd med %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>VRM-portal-id</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>VRM-portal-id</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Loggningsintervall</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Loggningsintervall</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 min</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 min</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 min</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 timme</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 timme</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 timmar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 timmar</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 timmar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 timmar</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 timmar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 timmar</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 dag</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 dag</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Använd säker anslutning (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Använd säker anslutning (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Senaste kontakt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Senaste kontakt</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Oväntad responstext</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Oväntad responstext</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Oväntad HTTP-respons</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Oväntad HTTP-respons</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Anslutningsuppehåll</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Anslutningsuppehåll</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Anslutningsfel</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Anslutningsfel</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 DNS-fel</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154&#xa0;DNS-fel</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Dirigeringsfel</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Dirigeringsfel</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM ej tillgänglig</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM ej tillgänglig</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Okänt fel</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Okänt fel</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Felmeddelande: 
+        <translation>Felmeddelande: 
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Starta om enheten om ingen kontakt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Starta om enheten om ingen kontakt</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Återställningsfördröjning om ingen kontakt (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Återställningsfördröjning om ingen kontakt (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Förvaringsplats</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Förvaringsplats</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Ingen buffert aktiv</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Ingen buffert aktiv</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Intern förvaring</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Intern förvaring</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Överför</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Överför</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Extern förvaring</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Extern förvaring</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Okänt fel</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Inget fel</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Inget fel</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Inget utrymme kvar för förvaring</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Inget utrymme kvar för förvaring</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>IO fel</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>IO fel</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Monteringsfel</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Monteringsfel</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Innehåller firmware bild. Används inte.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Innehåller firmware bild. Används inte.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD-kort/ USB-minne inte skrivbart</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD-kort/ USB-minne inte skrivbart</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Fritt diskutrymme</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Fritt diskutrymme</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>byte</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>byte</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bytes</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bytes</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Sparade poster</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Sparade poster</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 poster</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 poster</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Äldsta poster</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Äldsta poster</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Aktivera Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Aktivera Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Inga fel rapporterade</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Inga fel rapporterade</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Tidpunkt för senaste fel</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Tidpunkt för senaste fel</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Tillgängliga tjänster</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Tillgängliga tjänster</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>Enhets-id: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>Enhets-id: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Funktion (Relä 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Funktion (Relä 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Funktion</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Funktion</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Larmrelä</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Larmrelä</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Tankpump</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Polaritet larmrelä</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Polaritet larmrelä</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normalt öppen</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normalt öppen</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normalt stängd</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normalt stängd</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Relä 1 På</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Relä 1 På</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Relä På</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Relä På</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Funktion (Relä 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Funktion (Relä 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Relä 2 På</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Relä 2 På</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Kontrollregler temperatur</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Kontrollregler temperatur</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Reläaktivering på temperatur</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Reläaktivering på temperatur</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Inget relä är inställt för att aktiveras på grund av temperatur. Gå till reläinställningssidan som finns i huvudmenyn för inställningar och ställ in reläfunktionen på "Temperatur".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Inget relä är inställt för att aktiveras på grund av temperatur. Gå till reläinställningssidan som finns i huvudmenyn för inställningar och ställ in reläfunktionen på &quot;Temperatur&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Detta val ger dig möjlighet att växla mellan den nuvarande och den tidigare programvaruversionen. Inget internet eller sd-kort krävs.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Detta val ger dig möjlighet att växla mellan den nuvarande och den tidigare programvaruversionen. Inget internet eller sd-kort krävs.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Fast programvara %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Fast programvara %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Tryck för att starta</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Tryck för att starta</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Fast programvara %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Startar om till %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Startar om till %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Det är inte möjligt att ändra fast programvaruversion när automatisk uppdatering är inställd på "Check and update\” (kontrollera och uppdatera). Ställ in den automatiska uppdateringen på "Disabled" (inaktiv) eller "Check only\” (Endast kontroll) för att aktivera det alternativet.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Det är inte möjligt att ändra fast programvaruversion när automatisk uppdatering är inställd på &quot;Check and update\” (kontrollera och uppdatera). Ställ in den automatiska uppdateringen på &quot;Disabled&quot; (inaktiv) eller &quot;Check only\” (Endast kontroll) för att aktivera det alternativet.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Kopia på fast programvara ej tillgänglig</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Kopia på fast programvara ej tillgänglig</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Konsol på VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-bus över TCP/IP (Felsök)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-bus över TCP/IP (Felsök)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Landström</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Landström</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Fordon</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Fordon</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Båt</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Båt</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Systemnamn</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Systemnamn</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Automatisk</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Automatisk</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Nät</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Automatisk</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Användardefinerad</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Användardefinerad</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Användardefinierat namn</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Användardefinierat namn</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>AC-ingång 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>AC-ingång 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>AC-ingång 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>AC-ingång 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Övervakare för nätfel</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Övervakare för nätfel</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Övervakare för bortkoppling landström</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Övervakare för bortkoppling landström</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Autovald</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Autovald</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Har DC-system</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Har DC-system</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Synkronisera VE.Bus SOC med batteri</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Synkronisera VE.Bus SOC med batteri</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>Använd solcellsladdarström för att förbättra VE.Bus-laddningsstatus</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Använd solcellsladdarström för att förbättra VE.Bus-laddningsstatus</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Solcellsladdare spänningskontroll</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Solcellsladdare spänningskontroll</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Solcellsladdare strömkontroll</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Solcellsladdare strömkontroll</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS-kontroll</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS-kontroll</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS-kontroll</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Tankpumpens start-/stoppfunktion är inte aktiv. Gå till reläinställningarna och ställ in funktionen på "Tankpump\”</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Tankpumpens start-/stoppfunktion är inte aktiv. Gå till reläinställningarna och ställ in funktionen på &quot;Tankpump\”</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Pumpstatus</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Pumpstatus</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Automatisk</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Tanksensor</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Tanksensor</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Startnivå</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Startnivå</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Stoppnivå</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Stoppnivå</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Anslutning förlorad</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Anslutning förlorad</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Urkopplad</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Urkopplad</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Dold]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Dold]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Anslutning till nätverk?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Anslutning till nätverk?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Begär åtkomst</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Begär åtkomst</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Glöm nätverk?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Glöm nätverk?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Glöm</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Glöm</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Är du säker på att du vill ta bort detta nätverk?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Är du säker på att du vill ta bort detta nätverk?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC-adress</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC-adress</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>IP-konfigurering</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>IP-konfigurering</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manual</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Av</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Fast</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Fast</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Nätmask</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Nätmask</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Gateway</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Gateway</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS-server</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS-server</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Link-local IP-adress</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Link-local IP-adress</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Försiktighet! För ESS-system såväl som för system med ett hanterat batteri, måste CAN-buss-enhetens instans förbli konfigurerad till 0. Se GX-manual för mer information.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Försiktighet! För ESS-system såväl som för system med ett hanterat batteri, måste CAN-buss-enhetens instans förbli konfigurerad till 0. Se GX-manual för mer information.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Enhetsinstans</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Enhetsinstans</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Nätverksadress</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Nätverksadress</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>VE.Can-enheter</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>VE.Can-enheter</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Enhet# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Enhet# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Inga åtkomstpunkter</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Inga åtkomstpunkter</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Ingen Wi-Fi adapter ansluten</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Ingen Wi-Fi adapter ansluten</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Skapa åtkomstpunkt</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Skapa åtkomstpunkt</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Wi-Fi-nätverk</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Wi-Fi-nätverk</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Är du säker på att du vill inaktivera åtkomstpunkten?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Är du säker på att du vill inaktivera åtkomstpunkten?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Datum/tid UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Datum/tid UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Datum/tid lokal</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Datum/tid lokal</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Tidszon</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Tidszon</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afrika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afrika</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Amerika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Amerika</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antarktis</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antarktis</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Arktis</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Arktis</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asien</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlanten</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlanten</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Australien</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Australien</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Europa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Indisk</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Indisk</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Stilla havstid</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Stilla havstid</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Ej ansluten %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Ej ansluten %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Starta om nu?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Starta om nu?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Ändringar på VRM-instans kommer inte att tillämpas förrän enheten startas om.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Ändringar på VRM-instans kommer inte att tillämpas förrän enheten startas om.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Enheten startar om ...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Enheten startar om ...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Enheten har startats om.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Enheten har startats om.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Larm låg batterispänning</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Larm låg batterispänning</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Larm hög batterispänning</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Larm hög batterispänning</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Senaste fel</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Senaste fel</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2:a senaste fel</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2:a senaste fel</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3:e senaste fel</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3:e senaste fel</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>4:e senaste fel</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>4:e senaste fel</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Nätverkad</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Nätverkad</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Lägesinställning</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Lägesinställning</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Fristående</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Fristående</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Fristående</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Belastning</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Belastning</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Extern kontroll</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Laddning &amp; HUBB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Laddning &amp; HUBB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Laddning &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Laddning &amp; BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Extern kontroll &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Extern kontroll &amp; BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Laddning, hubb-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Laddning, hubb-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Masterinställning</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Masterinställning</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Slav</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Slav</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Slav</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Gruppmaster</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Gruppmaster</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Laddningsmaster</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Laddningsmaster</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Grupp - &amp; laddningsmaster</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Grupp - &amp; laddningsmaster</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Laddningsspänning</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Laddningsspänning</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Återställ</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Återställ</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>BMS Control aktiveras automatiskt när det finns en BMS. Återställ om systemkonfigureringen ändrades eller om det inte finns någon BMS.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>BMS Control aktiveras automatiskt när det finns en BMS. Återställ om systemkonfigureringen ändrades eller om det inte finns någon BMS.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Total solcellseffekt</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Belastning</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Belastning</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 hittad</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 hittad</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Historik</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Historik</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Historik</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Nätverksdrift</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Nätverksdrift</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Tabellvy</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Tabellvy</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Diagram</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Diagram</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Varning</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Varning</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Larm</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Larm</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Larm</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Volym</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Volym</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Kortsluten</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Kortsluten</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Omvänd polaritet</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Omvänd polaritet</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>EV Charging Stations</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>EV Charging Stations</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Session</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Session</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Tid</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Tid</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Laddningsläge</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Laddningsläge</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Starta och stoppa processen själv. Använd det här för snabba ändringar och nära övervakning.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Starta och stoppa processen själv. Använd det här för snabba ändringar och nära övervakning.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Startar och stoppar baserat på batteriets laddningsnivå. Utmärkt för laddningar över natten eller andra långa laddningar för att undvika överladdning.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Startar och stoppar baserat på batteriets laddningsnivå. Utmärkt för laddningar över natten eller andra långa laddningar för att undvika överladdning.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Lägre elpris under timmar med lägre belastning eller om du vill säkerställa att din elbil är fulladdad och körklar vid en viss tid.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Lägre elpris under timmar med lägre belastning eller om du vill säkerställa att din elbil är fulladdad och körklar vid en viss tid.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Aktivera laddning</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Aktivera laddning</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Lås laddarskärm</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Lås laddarskärm</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Källadress</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Källadress</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Inställning</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Inställning</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Linjeinstans #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Linjeinstans #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Linjeinstans</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Linjeinstans</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Laddarinstans</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Laddarinstans</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Växelriktarinstans</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Växelriktarinstans</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Instans för DC-källa #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Instans för DC-källa #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>DC-källinstans</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>DC-källinstans</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Prioritet för DC-källa #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Prioritet för DC-källa #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>DC-källinstans prioritet</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>DC-källinstans prioritet</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Tankinstans</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Tankinstans</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>RV-C-enheter</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>RV-C-enheter</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Aktivera bildrutevisualiserare</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Aktivera bildrutevisualiserare</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Stöds ej</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Stöds ej</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Ta bort ej anslutna enheter</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Ta bort ej anslutna enheter</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Enhet som ej stöds har hittats</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Enhet som ej stöds har hittats</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Reläfunktion</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Reläfunktion</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Larm</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Laddare eller generator start/stopp</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Laddare eller generator start/stopp</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Manuell styrning</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Säkring gått</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Manuell styrning</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Manuell styrning</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Alltid öppen (använd inte reläet)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Alltid öppen (använd inte reläet)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Observera att om du ändrar inställningen för "låg laddningsstatus" ändrar du även inställningen för "urladdningsgräns för tid kvar" i batterimenyn</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Observera att om du ändrar inställningen för &quot;låg laddningsstatus&quot; ändrar du även inställningen för &quot;urladdningsgräns för tid kvar&quot; i batterimenyn</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Säkring gått</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Säkring gått</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Status LED-lampor</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Status LED-lampor</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Ingen</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Huvudbrytare</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Huvudbrytare</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Värmare</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Värmare</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Invändig fläkt</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Invändig fläkt</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Varningsflaggor</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Varningsflaggor</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Larmflaggor</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Larmflaggor</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Brytare</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Brytare</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Initierar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Initierar</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Avstängning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Avstängning</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Uppdaterar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Uppdaterar</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Kommer att köras</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Kommer att köras</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Förladdning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Förladdning</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Kontroll kontaktdon</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Kontroll kontaktdon</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Hälsostatus</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Hälsostatus</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Batteritemperatur</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Batteritemperatur</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Lufttemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Lufttemperatur</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Starterspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Starterspänning</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Busspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Busspänning</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Spänning toppsektion</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Spänning toppsektion</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Kommunikationsfel</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Hälsostatus</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Busspänning</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Spänning bottensektion</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Spänning bottensektion</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Avvikelse mittpunkt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Avvikelse mittpunkt</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Förbrukade amp-timmar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Förbrukade amp-timmar</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Tid kvar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Tid kvar</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Uppgifter</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Uppgifter</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Larm för modulnivå</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Larm för modulnivå</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Diagnostik</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostik</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Säkringar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Säkringar</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>System</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>System</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parametrar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parametrar</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Detektera batteri på nytt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Detektera batteri på nytt</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Tryck för att detektera på nytt</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Tryck för att detektera på nytt</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Tryck för att detektera på nytt</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Detekteringen av batteriet kan ta upp till 60 sekunder. Under tiden kan batteriets namn visas inkorrekt.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Detekteringen av batteriet kan ta upp till 60 sekunder. Under tiden kan batteriets namn visas inkorrekt.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Hög laddningsström</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Hög laddningsström</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Hög urladdningsström</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Hög urladdningsström</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Låg SOC</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Låg SOC</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Hög batterispänning</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Låg SOC</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Låg starterspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Låg starterspänning</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Hög starterspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Hög starterspänning</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Batteritemperatursensor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Batteritemperatursensor</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Spänning mittpunkt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Spänning mittpunkt</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Säkring gått</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Hög invändig temperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Hög invändig temperatur</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Låg laddningstemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Låg laddningstemperatur</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Hög laddningstemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Hög laddningstemperatur</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Internt fel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Internt fel</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Automatsäkring utlöst</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Automatsäkring utlöst</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Cellobalans</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Cellobalans</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Låg cellspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Låg cellspänning</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Lägsta cellspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Lägsta cellspänning</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Högsta cellspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Högsta cellspänning</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Lägsta celltemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Lägsta celltemperatur</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Högsta celltemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Högsta celltemperatur</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Batterimoduler</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Batterimoduler</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Antal moduler som blockerar laddning/ urladdning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Antal moduler som blockerar laddning/ urladdning</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Installerad/ Tillgänglig kapacitet</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Installerad/ Tillgänglig kapacitet</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Djupaste urladdning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Djupaste urladdning</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Senaste urladdning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Senaste urladdning</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Genomsnittlig urladdning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Genomsnittlig urladdning</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Totalt antal laddningscykler</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Totalt antal laddningscykler</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Antal kompletta urladdningar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Antal kompletta urladdningar</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Kumulativt dragna ampere</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Kumulativt dragna ampere</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Lägsta  cellspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Lägsta  cellspänning</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Högsta cellspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Högsta cellspänning</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Tid sedan senaste fulladdning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Tid sedan senaste fulladdning</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Synkroniseringsräkning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Synkroniseringsräkning</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Larm om låg startbatterispänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Larm om låg startbatterispänning</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Lägsta startbatterispänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Lägsta startbatterispänning</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Högsta startbatterispänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Högsta startbatterispänning</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Urladdad energi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Urladdad energi</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Laddad energi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Laddad energi</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Laddningsspänningsgräns (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Laddningsspänningsgräns (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Laddningsströmgräns (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Laddningsströmgräns (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Urladdningsströmgräns (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Urladdningsströmgräns (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Avstänging låg spänning (ignoreras alltid)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Avstänging låg spänning (ignoreras alltid)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Batteribank</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Batteribank</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Relä (på batteriövervakare)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Relä (på batteriövervakare)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Återställ fabriksinställningar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Återställ fabriksinställningar</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Tryck för att återställa</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Tryck för att återställa</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Återställ till fabriksinställningar?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Återställ till fabriksinställningar?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth aktiv</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth aktiv</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Nominell spänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Nominell spänning</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Kapacitet</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Kapacitet</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapacitet</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Laddad spänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Laddad spänning</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Svansström</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Svansström</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Laddad detekteringstid</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Laddad detekteringstid</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Peukerts exponent</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Peukerts exponent</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Laddningseffektivitetsfaktor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Laddningseffektivitetsfaktor</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Nuvarande tröskelvärde</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Nuvarande tröskelvärde</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Medelvärde kvarvarande tid</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Medelvärde kvarvarande tid</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Kvarvarande urladdningsgolv</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Kvarvarande urladdningsgolv</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Nuvarande offset</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Nuvarande offset</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Synkroniseringstillstånd för laddning till 100 %</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Synkroniseringstillstånd för laddning till 100 %</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Tryck för att synkronisera</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Tryck för att synkronisera</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Kalibrera nollström</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Kalibrera nollström</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Tryck för att ställa in 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Tryck för att ställa in 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Återförsäljare %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Återförsäljare %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Ingen ström på skena</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Ingen ström på skena</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Anslutning förlorad</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n säkring(ar) har gått</numerusform>
-        <numerusform>%n säkring(ar) har gått</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n säkring(ar) har gått</numerusform>
+            <numerusform>%n säkring(ar) har gått</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Ingen information tillgänglig, se tidigare sida för Distributor-status.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Ingen information tillgänglig, se tidigare sida för Distributor-status.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Säkring %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Säkring %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Används inte</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Används inte</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Har gått</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Har gått</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Avstängning på grund av fel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Avstängning på grund av fel</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Senaste fel</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">2:a senaste fel</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">3:e senaste fel</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">4:e senaste fel</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Systemomkopplare</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Systemomkopplare</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Utvändigt relä</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Utvändigt relä</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Programmerbar kontakt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Programmerbar kontakt</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Batterier</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Batterier</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapacitet</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Batterier</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Parallell</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Parallell</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Serier</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Serier</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Lägsta/högsta cellspänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Lägsta/högsta cellspänning</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Lägsta/högsta celltemperatur</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Lägsta/högsta celltemperatur</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Balansering</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Balansering</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Balansering</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Okänd</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Utgång</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Utgång</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Fältdrift</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Fältdrift</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Motorvarvtal</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Motorvarvtal</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Aux-spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Aux-spänning</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>inga larm</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>inga larm</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Låg spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Låg spänning</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Högspänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Högspänning</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Låg aux-spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Låg aux-spänning</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Hög aux-spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Hög aux-spänning</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Larm låg aux-spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Larm låg aux-spänning</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Larm hög aux-spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Larm hög aux-spänning</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Lägsta aux-spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Lägsta aux-spänning</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Högsta aux-spänning</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Högsta aux-spänning</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Producerad energi</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Producerad energi</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Förbrukad energi</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Förbrukad energi</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Aktivera larm</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Aktivera larm</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Aktiv nivå</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Aktiv nivå</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Återställ nivå</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Återställ nivå</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Fördröjning</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Fördröjning</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Nivå</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Nivå</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Återstående</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Återstående</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Sensorbatteri</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Sensorbatteri</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Sensorbatteri</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Sensortyp</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Sensortyp</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Standard</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Standard</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Europeisk (0 till 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Europeisk (0 till 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>USA (240 till 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>USA (240 till 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Anpassa</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Anpassa</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Anpassa</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Sensorvärde när tom</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Sensorvärde när tom</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Vätsketyp</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Vätsketyp</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Butanproportion</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Butanproportion</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Anpassad form</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Anpassad form</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Genomsnittlig tid</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Genomsnittlig tid</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Sensorvärde</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Sensorvärde</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Ingen kundanpassning definierad. Du kan definiera en med upp till tio punkter. Observera att 0 % och 100 % är implicita.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Ingen kundanpassning definierad. Du kan definiera en med upp till tio punkter. Observera att 0 % och 100 % är implicita.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Punkt %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Lägg till punkt</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Lägg till punkt</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Sensornivå</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Sensornivå</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Volym</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Dubbletter av sensornivåvärden är inte tillåtna.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Dubbletter av sensornivåvärden är inte tillåtna.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Volymvärden måste öka.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Volymvärden måste öka.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Vakthund</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Vakthund</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Olåst (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Olåst (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Olåst (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Olåst (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Olåst (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Olåst (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Låst</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Låst</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Faskonfiguration</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Faskonfiguration</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Brytarläge</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Brytarläge</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Enfas</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>Tvåfas</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>Tvåfas</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>Trefas</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>Trefas</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Enheter</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Hastighet</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Belastning</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Kylmedelstemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Kylmedelstemperatur</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Avgastemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Avgastemperatur</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Spolningstemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Spolningstemperatur</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Startbatterispänning</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Startbatterispänning</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Antal starter</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Antal starter</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS-kontroll</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Frontväljare låst (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Frontväljare låst (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Inget fel (%1</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Inget fel (%1</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC totalt</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC totalt</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energi L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Energi L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Fassekvens</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Fassekvens</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Datahanteringsversion</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Datahanteringsversion</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Ingen</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Blinkande LED indikerar denna CT</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Blinkande LED indikerar denna CT</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Smappee-bussenheter</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Smappee-bussenheter</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>Solcellsladdare</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>Solcellsladdare</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Den här inställningen är inaktiv när en Digital Multi Control är ansluten.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Den här inställningen är inaktiv när en Digital Multi Control är ansluten.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Den här inställningen är inaktiv när en VE.Bus BMS är ansluten.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Den här inställningen är inaktiv när en VE.Bus BMS är ansluten.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC in %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC in %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Omvänd</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Omvänd</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Aktivera larm</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Omvänd</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Växla larmlogik</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Växla larmlogik</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Strålning</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Strålning</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Celltemperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Celltemperatur</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Utvändig temperatur (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Utvändig temperatur (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Extern temperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Extern temperatur</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Utvändig temperatur (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Utvändig temperatur (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Vindhastighet</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Vindhastighet</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Automatisk avkänning</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Automatisk avkänning</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Vindhastighetsgivare</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Vindhastighetsgivare</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Extern temperaturgivare</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Extern temperaturgivare</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Aggregat</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Aggregat</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Multiplicera</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Multiplicera</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Återställ räknare</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Återställ räknare</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Kortsluten</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Omvänd polaritet</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Sensorbatteri lågt</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Sensorbatteri lågt</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Luftfuktighet</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Luftfuktighet</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Tryck</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Tryck</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Låg</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Offset</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Skala</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Skala</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Sensorspänning</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Sensorspänning</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Total solcellseffekt</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Total solcellseffekt</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Produktsida</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Produktsida</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>AC-sensor %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>AC-sensor %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>En ny MK3-version finns tillgänglig.
+        <translation>En ny MK3-version finns tillgänglig.
 OBS: Uppdateringen kan tillfälligt stoppa systemet.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Uppdatera MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Uppdatera MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Tryck för att uppdatera</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Tryck för att uppdatera</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Uppdaterar MK3, värden visar åter efter att uppdateringen har slutförts</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Uppdaterar MK3, värden visar åter efter att uppdateringen har slutförts</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Laddning av batteriet till 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Laddning av batteriet till 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Laddning av batteriet till 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Avancerad</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>Pågående</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>Pågående</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Tryck för att stoppa</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Tryck för att stoppa</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Tryck för att starta</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Tryck för att starta</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Ladda batteriet till 100%.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Ladda batteriet till 100%.</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Systemet kommer att återgå till normal drift och prioritera förnybar energi.
+        <translation>Systemet kommer att återgå till normal drift och prioritera förnybar energi.
 Vill du fortsätta?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Landström kommer att användas när den är tillgänglig och alternativet "Sol- och vindprioritet" kommer att ignoreras.
+        <translation>Landström kommer att användas när den är tillgänglig och alternativet &quot;Sol- och vindprioritet&quot; kommer att ignoreras.
 Vill du fortsätta?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Landström används för att slutföra en full batteriladdning under en tid.
+        <translation>Landström används för att slutföra en full batteriladdning under en tid.
 När laddningen är klar återgår systemet till normal drift och prioriterar sol- och vindenergi.
 Vill du fortsätta?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>DC-spänning</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>DC-spänning</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>DC-ström</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>DC-ström</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Avancerad</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Avancerad</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Larminställning</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Larminställning</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>Ett VE.Bus BMS stänger automatiskt av systemet vid behov för att skydda batteriet. Att styra systemet från Color Control är därför inte möjligt.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>Ett VE.Bus BMS stänger automatiskt av systemet vid behov för att skydda batteriet. Att styra systemet från Color Control är därför inte möjligt.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>En BMS-assistent har installerats och konfigurerats för en VE.Bus BMS, men VE-Bus BMS hittas inte!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>En BMS-assistent har installerats och konfigurerats för en VE.Bus BMS, men VE-Bus BMS hittas inte!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Varning: Aktivering av utjämning i ett ESS-system med solcellsladdare kan leda till att batteriet laddas vid hög spänning med för hög ström.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Varning: Aktivering av utjämning i ett ESS-system med solcellsladdare kan leda till att batteriet laddas vid hög spänning med för hög ström.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Systemet slår automatiskt över till float när utjämningsladdningen har slutförts.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Systemet slår automatiskt över till float när utjämningsladdningen har slutförts.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Avbryt utjämning</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Avbryt utjämning</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Utjämning</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Utjämning</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Avbryter ...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Avbryter ...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Startar...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Startar...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Startar...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Tryck för att avbryta</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Tryck för att avbryta</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Avbryt och återstarta absorption</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Avbryt och återstarta absorption</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Avbryt och gå till float</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Avbryt och gå till float</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Avbryt</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Avbryt</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Avbryt inte</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Avbryt inte</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Återupptäck VE.Bus-systemet</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Återupptäck VE.Bus-systemet</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Detekterar på nytt...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Detekterar på nytt...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Starta om VE.Bus-systemet</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Starta om VE.Bus-systemet</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Startar om...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Startar om...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Tryck för att starta om</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Tryck för att starta om</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>AC-ingång 1 ignorerad</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>AC-ingång 1 ignorerad</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>AC-ingång 2 ignorerad</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>AC-ingång 2 ignorerad</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>ESS-relätest</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>ESS-relätest</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Avslutad</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Avvaktar</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Avslutad</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Avslutad</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Avvaktar</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Avvaktar</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>VE.Bus diagnostik</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>VE.Bus diagnostik</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Nätverkskvalitetsräknare Fas L%1, enhet %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Nätverkskvalitetsräknare Fas L%1, enhet %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.Bus-fel 8 / 11 rapport</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.Bus-fel 8 / 11 rapport</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Enbart larm</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Enbart larm</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Larm &amp; varningar</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Larm &amp; varningar</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>BMS-fel</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>BMS-fel</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Serienummer</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Serienummer</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Senaste VE.Bus-fel 11 rapport #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Senaste VE.Bus-fel 11 rapport #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>BF-säkerhetstest utförs</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>BF-säkerhetstest utförs</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>BF-säkerhetstest OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>BF-säkerhetstest OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Avvikelse AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Avvikelse AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Kommunikationsfel</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Kommunikationsfel</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>GND-reläfel</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>GND-reläfel</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Avvikelse nät</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Avvikelse nät</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Avvikelse Period Tid</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Avvikelse Period Tid</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Avvikelse i styrning av BF-relä</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Avvikelse i styrning av BF-relä</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Fel: PE2 öppen</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Fel: PE2 öppen</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Fel: PE2 stängd</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Fel: PE2 stängd</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Felande steg: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Felande steg: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Fas L%1, enhet %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Fas L%1, enhet %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>VE.Bus fel 11 rapportering kräver minst VE.Bus-fast programvaruversion 454</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>VE.Bus fel 11 rapportering kräver minst VE.Bus-fast programvaruversion 454</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus problem</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus problem</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Energi</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Energi</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Effekt</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Effekt</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Spänning</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Spänning</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Ström</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Ström</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Plats</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Plats</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Fas</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Fas</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Aktiv AC-ingång</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Aktiv AC-ingång</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Hög rippelström</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Hög rippelström</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Hög DC-spänning</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Hög DC-spänning</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Hög DC-ström</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Hög DC-ström</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Fel temperaturavkänning</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Fel temperaturavkänning</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Fel spänningsavkänning</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Fel spänningsavkänning</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Överbelastning</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Överbelastning</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>DC Rippelström</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>DC Rippelström</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Spänningssensor</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Spänningssensor</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Fasrotation</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Fasrotation</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Fasrotation</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>VE.Bus-version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>VE.Bus-version</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2-enhet</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2-enhet</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>MK2-version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>MK2-version</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Multikontroll version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Multikontroll version</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>VE.Bus BMS version</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>VE.Bus BMS version</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Om inte nätet slutar fungerar</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Om inte nätet slutar fungerar</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>AC-ingång</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>AC-ingång</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC-ingång</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC-ingång</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>AC-ingång 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>AC-ingång 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>AC-ingång 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>AC-ingång 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Roll</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Roll</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC-belastning</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC-belastning</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>AC Out</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>AC Out</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>AC-utgång</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>AC-utgång</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC-fas L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC-fas L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>AC-sensor %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>AC-sensor %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>AC-sensorer</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>AC-sensorer</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Aktiv</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Aktiv</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Larm</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Överbelastning</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Larmstatus</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Larmstatus</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Larm</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Larm</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Tillåt laddning</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Tillåt laddning</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Tillåt urladdning</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Tillåt urladdning</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Automatisk skanning</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Automatisk skanning</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Batteri</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Batteriström</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Batteriström</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>batterispänning</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>batterispänning</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Laddningsström</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Laddningsström</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Laddar</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Laddar</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Rensa fel</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Rensa fel</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Stängd</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Stängd</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Ansluten</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Ansluten</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Ström</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Ström</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Strömtransformatorer</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Strömtransformatorer</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Anpassat namn</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Anpassat namn</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Felsöka</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Felsöka</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Enhet</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Enhet</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Inaktiverad</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>laddar ur</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>laddar ur</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Frånkopplad</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Frånkopplad</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Aktivera</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Aktivera</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Aktiverad</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Aktiverad</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Energi</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Energi</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Fel</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Fel</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Fel:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Fel:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Felkod</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Felkod</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Programvaruversion</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Programvaruversion</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Generator</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Hög batteritemperatur</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Hög batteritemperatur</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Larm hög nivå</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Larm hög nivå</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Hög startbatterispänning</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Hög startbatterispänning</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Hög temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Hög temperatur</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Högspänningslarm</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Högspänningslarm</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Historik</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Historik</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 timme(timmar)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 timme(timmar)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Viloläge</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Viloläge</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Inaktiv</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Inaktiv</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Växelriktare/ laddare</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP-adress</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP-adress</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Låg batteritemperartur</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Låg batteritemperartur</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Larm låg nivå</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Larm låg nivå</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Låg startbatterispänning</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Låg startbatterispänning</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Lågt laddningsstatus</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Lågt laddningsstatus</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Låg temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Låg temperatur</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Lågspänningslarm</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Lågspänningslarm</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Tillverkare</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Tillverkare</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Högsta temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Högsta temperatur</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Maximal spänning</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Maximal spänning</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Lägsta temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Lägsta temperatur</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Minimispänning</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Minimispänning</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Läge</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Läge</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Modellnamn</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Modellnamn</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Nej</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Nej</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Inget fel</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Inget fel</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Inte tillgänglig</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Inte tillgänglig</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Ej ansluten</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Ej ansluten</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Offline</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Offline</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>Ok</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>Ok</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>På</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>På</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Öppen</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Öppen</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Lösenord</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Lösenord</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Fas</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Fas</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Tryck för att rensa</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Tryck för att rensa</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Tryck för återställning</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Tryck för återställning</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Tryck för att skanna</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Tryck för att skanna</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>Solcellsväxelriktare</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>Solcellsväxelriktare</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>Solcellsenergi</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>Solcellsenergi</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Tysta timmar</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Tysta timmar</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Relä</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Relä</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Omstart</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Omstart</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Ta bort</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Ta bort</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>I drift</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>I drift</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Skannar %1 %</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Skannar %1 %</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Serienummer</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Serienummer</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Inställningar</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Inställningar</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Inställning</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Inställning</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Signalstyrka</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Signalstyrka</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Standby</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Standby</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Starta efter att villkoret har uppnåtts i</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Starta efter att villkoret har uppnåtts i</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Starttid</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Starttid</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Starta värde under tysta timmar</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Starta värde under tysta timmar</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Starta när varningen har varit aktiv i</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Starta när varningen har varit aktiv i</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Laddningsstatus</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Laddningsstatus</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Status</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Status</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Start (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Start (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Stoppa värde under tysta timmar</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Stoppa värde under tysta timmar</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Stoppa när villkoret har uppnåtts i</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Stoppa när villkoret har uppnåtts i</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Stoppad</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Stoppad</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Temperatur</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Temperatursensor</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Temperatursensor</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Idag</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Idag</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Totalt</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Totalt</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Övervakning</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Övervakning</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Sort</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Sort</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Unikt identitetsnummer</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Unikt identitetsnummer</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Okänd</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Okänd</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Fel VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Fel VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Spänning</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Spänning</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>VRM-instans</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>VRM-instans</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>När varning försvinner, stoppa efter</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>När varning försvinner, stoppa efter</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Ja</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Ja</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Igår</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Igår</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Utbyte</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Utbyte</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Strömbegränsning noll inmatning</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Strömbegränsning noll inmatning</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Ställ in datum</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Ställ in datum</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Starta nu</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Starta nu</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Klockad drift</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Klockad drift</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Stoppa nu</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Stoppa nu</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Total drifttid</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Total drifttid</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Ställ in tid %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Ställ in tid %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Generatorn fortsätter att vara i drift om villkoren för autostart uppfylls.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Generatorn fortsätter att vara i drift om villkoren för autostart uppfylls.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Växelriktare/ laddarläge</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Växelriktare/ laddarläge</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Sept</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Sept</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Avbryt</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Stäng</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Stäng</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Ställ in tid</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Ställ in tid</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Används redan</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Används redan</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Utbytesfel</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Utbytesfel</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Utbyte slutfört</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Utbyte slutfört</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Byter enhetsinstanser ...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Byter enhetsinstanser ...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Enhetsinstans %1 används redan av ”%3”. Byta enhetsinstanser och tilldela den till %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Enhetsinstans %1 används redan av ”%3”. Byta enhetsinstanser och tilldela den till %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Enhetsinstans %1 används redan av en annan enhet av samma sort. Byta enhetsinstanser och tilldela den till %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Enhetsinstans %1 används redan av en annan enhet av samma sort. Byta enhetsinstanser och tilldela den till %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Kan inte byta enhetsinstanser: operationen dröjde för länge.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Kan inte byta enhetsinstanser: operationen dröjde för länge.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Nya enhetsinstanser aktiveras vid omstart.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Nya enhetsinstanser aktiveras vid omstart.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Byta</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Byta</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Fel vid sökning av uppdateringar av fast programvara</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Fel vid sökning av uppdateringar av fast programvara</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Laddar ner och installerar fast programvara %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Laddar ner och installerar fast programvara %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Installerar fast programvara...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Installerar fast programvara...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Fel under installationen av fast programvara</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Fel under installationen av fast programvara</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Ingen nyare version tillgänglig</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Ingen nyare version tillgänglig</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Ingen programvara hittades</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Ingen programvara hittades</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Bränsle</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Bränsle</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Färskvatten</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Färskvatten</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Spillvatten</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Spillvatten</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Vattentank</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Vattentank</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Olja</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Olja</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>SVARTVATTEN</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>SVARTVATTEN</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Bensin</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Bensin</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Diesel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Diesel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Hydraulolja</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Hydraulolja</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Råvatten</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Råvatten</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Inställning låst för åtkomstnivå</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Inställning låst för åtkomstnivå</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Felaktigt lösenord</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Felaktigt lösenord</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Sammanfattning</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Sammanfattning</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Översikt</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Översikt</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Nivåer</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Nivåer</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Meddelanden</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Meddelanden</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Nu</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Nu</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1m sen</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1m sen</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1t %2m sen</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1t %2m sen</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Varje dag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Varje dag</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Veckodagar</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Veckodagar</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Helger</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Helger</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Måndag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Måndag</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Tisdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Tisdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Onsdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Onsdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Torsdag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Torsdag</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Fredag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Fredag</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Lördag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Lördag</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Söndag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Söndag</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 eller %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 eller %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Schema %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Schema %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Dag</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Dag</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Ej inställt</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Ej inställt</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Laddningstatusgräns</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Laddningstatusgräns</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Egenförbrukning över gräns</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Egenförbrukning över gräns</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>Solceller och batteri</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>Solceller och batteri</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Söker...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Söker...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Larmtillstånd</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Larmtillstånd</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Larm</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Rensa historik</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Rensa historik</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Rensar</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Rensar</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Forcerad på</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Forcerad på</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Forcerad av</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Forcerad av</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Relätillstånd</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Relätillstånd</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Återställ historik på själva monitorn</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Återställ historik på själva monitorn</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Tryck för att ta ut</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Tryck för att ta ut</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Vänligen vänta, tar ut</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Vänligen vänta, tar ut</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Ingen lagring funnen</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Ingen lagring funnen</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 temperatursensor</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 temperatursensor</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 temperatursensor (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 temperatursensor (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Temperatursensor (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Temperatursensor (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Inga åtgärder</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Inga åtgärder</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Varning: Aktiverings- och inaktiveringstemperaturer är inställda på samma värde. Detta leder till att villkoret kommer att ignoreras.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Varning: Aktiverings- och inaktiveringstemperaturer är inställda på samma värde. Detta leder till att villkoret kommer att ignoreras.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Villkor %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Villkor %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Funktion inaktiverad</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Funktion inaktiverad</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Ingen (inaktivera)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Ingen (inaktivera)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Relä 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Relä 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Relä 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Relä 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Varning: Det ovan valda reläet är inte inställt för temperatur och detta villkor kommer att ignoreras.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Varning: Det ovan valda reläet är inte inställt för temperatur och detta villkor kommer att ignoreras.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Aktiveringsvärde</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Aktiveringsvärde</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Volymenhet</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Volymenhet</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Kubikmeter</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Kubikmeter</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Liter (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Liter (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Gallons (US)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Gallons (US)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Gallons (Imperial)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Gallons (Imperial)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Lägsta spänning</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Lägsta spänning</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Högsta spänning</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Högsta spänning</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Högsta spänning</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Högsta ström</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Högsta ström</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Laddningstid</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Laddningstid</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Flytladdning</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">tim</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Flytladdning</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Flytladdning</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>tim</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>tim</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>%1 fel inträffade</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>%1 fel inträffade</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Belastning</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Belastning</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Näst sist</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Näst sist</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Tredje sist</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Tredje sist</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Fjärde sist</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Fjärde sist</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Högsta effekt</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Högsta effekt</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Kunde inte ansluta</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Kunde inte ansluta</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Frånkopplad, försöker återansluta</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Frånkopplad, försöker återansluta</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Ansluter...</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Ansluter...</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Ansluter...</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Ansluten, väntar på mäklarmeddelanden</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Ansluten, väntar på mäklarmeddelanden</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Ansluten, mottar mäklarmeddelanden</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Ansluten, mottar mäklarmeddelanden</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Ansluten, laddar användargränssnitt</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Ansluten, laddar användargränssnitt</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Ogiltig protokollversion</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Ogiltig protokollversion</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Kund-id nekat</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Kund-id nekat</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Mäklartjänst ej tillgänglig</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Mäklartjänst ej tillgänglig</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Felaktigt användarnamn eller lösenord</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Felaktigt användarnamn eller lösenord</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Kund ej auktoriserad</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Kund ej auktoriserad</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Transportanslutningsfel</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Transportanslutningsfel</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Protokollöverträdelse</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Protokollöverträdelse</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Fel MQTT-protokoll nivå 5</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Fel MQTT-protokoll nivå 5</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Tysta larm</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Tysta larm</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Total energi</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Total energi</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>Min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>Min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1h %2m</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1h %2m</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1h %2m</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1h %2m</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Misslyckande</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Misslyckande</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Hämtar IP-adress</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Hämtar IP-adress</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Ansluten</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Koppla ifrån</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Koppla ifrån</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Frånkopplad</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC-belastningar</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC-belastningar</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>DC-belastningar</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>DC-belastningar</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Vind</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Vind</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Land</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Land</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Nätströmsbegränsning</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Nätströmsbegränsning</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Generatorströmsbegränsning</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Generatorströmsbegränsning</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Landströmsbegränsning</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Landströmsbegränsning</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Stoppar</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Stoppar</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Stoppar</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 kvar</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 kvar</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 tank (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 tank (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>AC-laddare</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>AC-laddare</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Generator</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Generator</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>DC-laddare</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>DC-laddare</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>DC-generator</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>DC-generator</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC-system</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC-system</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Bränslecell</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Bränslecell</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Axelgenerator</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Axelgenerator</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Vattengenerator</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Vattengenerator</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Vindgenerator</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Vindgenerator</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Låg</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Låg</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Hög</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Hög</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Håll batterierna laddade</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Håll batterierna laddade</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimerad med battery life</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimerad med battery life</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimerad utan battery life</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimerad utan battery life</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Extern kontroll</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Laddad</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Laddad</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Väntar på sol</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Väntar på sol</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Väntar på RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Väntar på RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Väntar på start</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Väntar på start</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Jordtestfel</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Jordtestfel</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Testfel CP-ingång</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Testfel CP-ingång</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Restström upptäckt</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Restström upptäckt</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Underspänning upptäckt</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Underspänning upptäckt</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Överspänning upptäckt</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Överspänning upptäckt</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Överhettning upptäckt</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Överhettning upptäckt</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Laddningsgräns</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Laddningsgräns</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Starta laddning</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Starta laddning</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Schemalagd</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Schemalagd</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Schemalagd</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Uppvärmning</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Uppvärmning</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Nedkylning</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Nedkylning</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Provdrift</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Provdrift</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Manuell start</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Manuell start</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Starta laddning</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Starta laddning</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>I drift (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>I drift (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>I drift (reglerad)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>I drift (reglerad)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Relä %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Relä %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Fel</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Fel</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorption</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorption</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Lagring</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Lagring</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Utjämna</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Utjämna</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Extern kontroll</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>AES-läge</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>AES-läge</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Feltillstånd</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Feltillstånd</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Bulkladdning</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Bulkladdning</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Absorptionsladdning</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Absorptionsladdning</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Floatladdning.</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Floatladdning.</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Förvaringsläge</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Förvaringsläge</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Utjämningsladdning</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Utjämningsladdning</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Pass-thru</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Pass-thru</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Växelriktning</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Växelriktning</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Hjälpström</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Hjälpström</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Strömförsörjningsläge</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Strömförsörjningsläge</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Upprätthålla</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Vakna</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Vakna</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Upprepad absorption</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Upprepad absorption</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Autoutjämning</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Autoutjämning</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>Battery Safe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>Battery Safe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Belastningsavkänning</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Belastningsavkänning</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Blockerad</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Blockerad</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dynamiskt ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dynamiskt ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dynamiskt ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Gruppmaster</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Gruppmaster</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Instansmaster</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Instansmaster</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Grupp- &amp; instansmaster</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Grupp- &amp; instansmaster</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Fristående och gruppmaster</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Fristående och gruppmaster</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Endast laddare</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Endast laddare</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Endast växelriktare</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Endast växelriktare</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Larm låg batterispänning</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Larm hög batterispänning</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Kortslutningslarm</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Kortslutningslarm</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Inaktivera åtkomstpunkt</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Inaktivera åtkomstpunkt</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>DC-ingång</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>DC-ingång</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>För litiumbatterier rekommenderas inte en nivå under 10 % laddning. För andra batterityper, kolla databladet för att se tillverkarens rekommenderade lägsta nivå.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>För litiumbatterier rekommenderas inte en nivå under 10 % laddning. För andra batterityper, kolla databladet för att se tillverkarens rekommenderade lägsta nivå.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Inaktivera autostart?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Inaktivera autostart?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Växelriktare/ laddare (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Växelriktare/ laddare (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Visa processoranvändning</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Visa processoranvändning</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Lämna applikation</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Lämna applikation</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Avsluta</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Avsluta</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Applikationsversion</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Applikationsversion</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Oljetemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Oljetemperatur</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Observera att om du ändrar miniminivån för "tid kvar urladdning" ändrar du även inställningen för "låg laddningsstatus" i relämenyn</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Observera att om du ändrar miniminivån för &quot;tid kvar urladdning&quot; ändrar du även inställningen för &quot;låg laddningsstatus&quot; i relämenyn</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Drifttid</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Drifttid</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Laddad Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Laddad Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Påbörjade cykler</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Påbörjade cykler</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Slutförda cykler</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Slutförda cykler</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Antal uppstarter</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Antal uppstarter</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Antal djupa urladdningar</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Antal djupa urladdningar</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Laddningscykelhistorik</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Laddningscykelhistorik</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Sensorvärde vid full</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Sensorvärde vid full</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Tid till service</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Tid till service</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Autostart-funktion</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Autostart-funktion</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Säkerställ att generatorn inte är ansluten till AC-ingång %1 när du använder detta alternativ.</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Säkerställ att generatorn inte är ansluten till AC-ingång %1 när du använder detta alternativ.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Servicetimern har återställts.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Servicetimern har återställts.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Kontinuerlig skanning kan störa Wi-Fi-funktionen.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Kontinuerlig skanning kan störa Wi-Fi-funktionen.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Högsta och lägsta mätarintervaller</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Högsta och lägsta mätarintervaller</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Startar om applikation ...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Startar om applikation ...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Kunde inte byta språk!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Kunde inte byta språk!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 min</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 min</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 min</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Aldrig</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Vänta medan språket byts.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Vänta medan språket byts.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Kort översikt enhet</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Kort översikt enhet</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Inga etiketter</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Inga etiketter</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Visa tankvolymer</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Visa tankvolymer</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Visa procentantal</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Visa procentantal</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Obs: Om ström inte kan visas (exempelvis när totalvärdet för de kombinerade AC- och DC-källorna visas) visas effekt istället.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Obs: Om ström inte kan visas (exempelvis när totalvärdet för de kombinerade AC- och DC-källorna visas) visas effekt istället.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Laddningsströmbegränsningar</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Laddningsströmbegränsningar</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Officiell publicering</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Officiell publicering</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Betautgåva</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Betautgåva</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Testning (Internt Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Testning (Internt Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Utveckling (Internt Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Utveckling (Internt Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Startar om ...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Startar om ...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Aktivera status-LED</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Aktivera status-LED</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Uppvärmning och nedkylning</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Uppvärmning och nedkylning</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Stopptid generator</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Stopptid generator</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Larm när generatorn inte är i autostart-läge</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Larm när generatorn inte är i autostart-läge</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Ett larm utlöses när autostart-funktionen har varit inaktiv i över 10 minuter</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Ett larm utlöses när autostart-funktionen har varit inaktiv i över 10 minuter</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Egen förbrukning från batteri</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Egen förbrukning från batteri</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Alla systembelastningar</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Alla systembelastningar</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Endast kritiska laster</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Endast kritiska laster</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Lägsta SoC (om inte nätet felar)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Battery life-status</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Battery life-status</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Få tillgång till Signal K på http://venus.local:3000 och via VRM</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Få tillgång till Signal K på http://venus.local:3000 och via VRM</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Få tillgång till Node-RED på https://venus.local:1881 och via VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Få tillgång till Node-RED på https://venus.local:1881 och via VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Batterimätningar</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Batterimätningar</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Systemstatus</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Systemstatus</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Enhetsförteckning</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Enhetsförteckning</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>VRM enhetsinstanser</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>VRM enhetsinstanser</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Larm för hög temperatur</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Larm för hög temperatur</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>BMS kontrollerad</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>BMS kontrollerad</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Larm och fel</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Larm och fel</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Den här funktionen kräver fasta programvaruversion 400 eller högre. Kontakta din installatör för att uppdatera din Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Den här funktionen kräver fasta programvaruversion 400 eller högre. Kontakta din installatör för att uppdatera din Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Laddaren är inte redo, utjämning kan inte påbörjas</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Laddaren är inte redo, utjämning kan inte påbörjas</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Utjämning kan inte aktiveras under bulkladdningsläget.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Utjämning kan inte aktiveras under bulkladdningsläget.</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eco</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eco</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Högsta ström</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Högsta ström</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Högsta effekt</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Högsta effekt</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Lägsta ström</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Lägsta ström</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Ingen</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Inte tillgänglig</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Av</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">Ok</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Total historik</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Total historik</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Inställningar</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Okänd</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Produktion idag</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Produktion idag</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Fast programvara installerad, enheten startar om.</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Fast programvara installerad, enheten startar om.</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Ingångskontroll Touch</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Ingångskontroll Touch</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Testfel för svetsade kontakter (kortslutna)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Testfel för svetsade kontakter (kortslutna)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Växlar till trefas</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Växlar till trefas</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Växlar till enfas</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Växlar till enfas</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Stoppa laddning</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Stoppa laddning</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Reserverad</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Reserverad</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Växelriktarläge</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Växelriktarläge</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Out L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Out L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Ingång</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Ingång</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Passthrough</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Passthrough</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Sidan laddas automatiskt om igen om 10 sekunder för att ladda den senaste versionen.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Sidan laddas automatiskt om igen om 10 sekunder för att ladda den senaste versionen.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Växelriktare (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Växelriktare (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Växelriktare/laddare</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Växelriktare/laddare</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Inga energimätare hittades
+        <translation>Inga energimätare hittades
 
 Observera att denna meny endast visar Carlo Gavazzi-mätare anslutna över RS485. För alla andra mätare, inklusive Carlo Gavazzi-mätare anslutna över Ethernet, se menyn för Modbus TCP/UDP-enheter istället.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Autointervaller</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Autointervaller</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>När detta är aktiverat justeras de lägsta och högsta värdena för mätare och diagram automatiskt beroende på tidigare värden.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>När detta är aktiverat justeras de lägsta och högsta värdena för mätare och diagram automatiskt beroende på tidigare värden.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Återställ alla värden till noll</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Återställ alla värden till noll</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Återställ intervallvärden</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Återställ intervallvärden</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Är du säker på att du vill återställa alla värden till noll?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Är du säker på att du vill återställa alla värden till noll?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Maximal ström: AC-in 1 ansluten</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Maximal ström: AC-in 1 ansluten</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Maximal ström: AC-in 2 ansluten</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Maximal ström: AC-in 2 ansluten</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Högsta ström: inga AC-ingångar</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Högsta ström: inga AC-ingångar</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>DC-utgång</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>DC-utgång</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solceller</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solceller</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Motor RPM</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Motor RPM</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Motortemperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Motortemperatur</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Controllertemperatur</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Controllertemperatur</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Aktiv cykel</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Aktiv cykel</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Cykel %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Cykel %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>DC-frånkoppling</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>DC-frånkoppling</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Ström av</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Ström av</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Funktionsändring</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Funktionsändring</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Uppdatering av fast program</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Uppdatering av fast program</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Återställning programvara</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Återställning programvara</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Ofullständig</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Ofullständig</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Förfluten tid</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Förfluten tid</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Ladda/ Underhåll (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Ladda/ Underhåll (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Batteri (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Batteri (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Låg AC-UT-spänning</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Låg AC-UT-spänning</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Hög AC-UT-spänning</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Hög AC-UT-spänning</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Totalt utbyte</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Totalt utbyte</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Systemutbyte</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Systemutbyte</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Daglig historik</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Daglig historik</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Inga larm att konfigurera</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Inga larm att konfigurera</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Maximal solcellsspänning</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Maximal solcellsspänning</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Maximal batterispänning</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Maximal batterispänning</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Lägsta batterispänning</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Lägsta batterispänning</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Batteribanksfel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Batteribanksfel</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Batterispänning stöds ej</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Batterispänning stöds ej</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Felaktigt antal batterier</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Felaktigt antal batterier</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Ogiltig batterikonfiguration</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Ogiltig batterikonfiguration</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Balanserarstatus</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Balanserarstatus</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Balanserat</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Balanserat</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Obalans</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Obalans</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Använd det här alternativet i system som inte utför topplastutjämning.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Använd det här alternativet i system som inte utför topplastutjämning.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Använd detta alternativ för topplastutjämning.</translation>
+        <translation>Använd detta alternativ för topplastutjämning.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Gränsvärdet för topplastutjämning är inställt med inställningen för strömbegränsning av AC-ingång. Se dokumentationen för ytterligare information.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Gränsvärdet för topplastutjämning är inställt med inställningen för strömbegränsning av AC-ingång. Se dokumentationen för ytterligare information.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Topplastutjämningsgränsen för import och export kan ändras på den här skärmen. Se dokumentationen för ytterligare information.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>Topplastutjämningsgränsen för import och export kan ändras på den här skärmen. Se dokumentationen för ytterligare information.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Gräns för systemets AC-importström</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Gräns för systemets AC-importström</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>För att använda den här funktionen måste nätmätning vara inställd på Extern mätare och en uppdaterad ESS-assistent måste vara installerad.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>För att använda den här funktionen måste nätmätning vara inställd på Extern mätare och en uppdaterad ESS-assistent måste vara installerad.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Högsta systemimportström (per fas)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Högsta systemimportström (per fas)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Nätmätning måste vara inställd på Extern mätare för att använda den här funktionen.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Nätmätning måste vara inställd på Extern mätare för att använda den här funktionen.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Högsta systemexportström (per fas)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Högsta systemexportström (per fas)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Kopplat</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Kopplat</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Sammanfattning</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Systembelastning hög, stänger sidopanelen för att minska CPU-belastning</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Systembelastning hög, stänger sidopanelen för att minska CPU-belastning</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Gräns ingångsström</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Gräns ingångsström</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Kortslutning</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Kortslutning</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Köpande</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Köpande</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Försäljning</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Försäljning</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Mål SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Mål SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC-out %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC-out %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Spårare</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Spårare</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>RS-enheter</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>RS-enheter</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Pausa elektronanimeringar</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Pausa elektronanimeringar</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Total kapacitet</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Total kapacitet</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Antal BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Antal BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Gräns för systemets AC-exportström</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Gräns för systemets AC-exportström</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Modbus TCP/UDP-enheter</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Modbus TCP/UDP-enheter</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Lägg till enhet</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Lägg till enhet</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Scanna för enheter</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Scanna för enheter</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Sparade enheter</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Sparade enheter</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Upptäckta enheter</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Upptäckta enheter</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Lägg till Modbus TCP/UDP-enhet</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Lägg till Modbus TCP/UDP-enhet</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protokoll</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protokoll</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Port</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Port</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Enhet</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Enhet</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Ingen Modbus-enhet har sparats</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Ingen Modbus-enhet har sparats</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Enhet %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Enhet %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Ta bort Modbus-enhet?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Ta bort Modbus-enhet?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Ingen Modbus-enhet har upptäckts</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Ingen Modbus-enhet har upptäckts</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Batteri %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Batteri %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>AC-ström</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>AC-ström</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Generator start/stopp inaktiverad</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Generator start/stopp inaktiverad</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Funktionen för fjärrstart av generatorn är inaktiverad. GX kommer inte kunna starta eller stoppa generatorn nu. Aktivera den på generatorns kontrollpanel.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Funktionen för fjärrstart av generatorn är inaktiverad. GX kommer inte kunna starta eller stoppa generatorn nu. Aktivera den på generatorns kontrollpanel.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Autostart-funktion</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Autostart-funktion</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Nuvarande drifttid</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Kontrollstatus</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Kontrollstatus</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Generatorstatus</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Generatorstatus</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Fjärrstartsläge</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Fjärrstartsläge</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Oljetryck</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Oljetryck</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Schemalagda laddningsnivåer</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Schemalagda laddningsnivåer</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Aktiv (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Aktiv (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Manuellt stopp</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Manuellt stopp</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Öppen krets</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Öppen krets</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (ej tillgänglig)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (ej tillgänglig)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Touch-ingång på</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Touch-ingång på</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Touch-ingång av</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Touch-ingång av</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Touch-ingång inaktiv</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Touch-ingång inaktiv</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Bekräfta varningar</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Bekräfta varningar</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Kontrollfelkod</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Kontrollfelkod</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Använd den här menyn för att definiera vilken data som ska visas när man klickar på batterisymbolen på översiktssidan. Samma val är även synliga på VRM-portalen.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Använd den här menyn för att definiera vilken data som ska visas när man klickar på batterisymbolen på översiktssidan. Samma val är även synliga på VRM-portalen.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Systemspänning [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Systemspänning [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Anslutningsinformation</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Anslutningsinformation</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Var vänlig välj...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Var vänlig välj...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Säkrad</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Säkrad</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Lösenordet är skyddat och nätverkskommunikationen är krypterad</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Lösenordet är skyddat och nätverkskommunikationen är krypterad</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Svag</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Svag</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Lösenordet är skyddat men nätverkskommunikationen är inte krypterad</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Lösenordet är skyddat men nätverkskommunikationen är inte krypterad</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Osäkrad</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Osäkrad</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Inget lösenord och nätverkskommunikationen är inte krypterad</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Inget lösenord och nätverkskommunikationen är inte krypterad</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Lösenordet måste innehålla minst 8 tecken</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Ange lösenord</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Lösenordet måste innehålla minst 8 tecken</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Lösenordet måste innehålla minst 8 tecken</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Välja ”säkrad” profil?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Välja ”säkrad” profil?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Välja ”svag” profil?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Välja ”svag” profil?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Välja ”osäkrad” profil?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Välja ”osäkrad” profil?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>• Lokala nätverkstjänster är lösenordsskyddade
+        <translation>• Lokala nätverkstjänster är lösenordsskyddade
 • Nätverkskommunikationen är krypterad
 • En säker anslutning med VRM har upprättats
 • Osäkra inställningar kan inte aktiveras</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• Lokala nätverkstjänster är lösenordsskyddade
+        <translation>• Lokala nätverkstjänster är lösenordsskyddade
 • Även okrypterad åtkomst till lokala webbsidor är aktiverad (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• Lokala nätverkstjänster kräver inget lösenord
+        <translation>• Lokala nätverkstjänster kräver inget lösenord
 • Även okrypterad åtkomst till lokala webbsidor är aktiverad (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Root-lösenord</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Root-lösenord</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Utloggning</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Utloggning</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Logga ut nu</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Logga ut nu</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Logga ut?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Logga ut?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Detta kopplar från alla lokala nätverksanslutningar.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Detta kopplar från alla lokala nätverksanslutningar.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Logga ut</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Logga ut</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Skrivskyddad</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Skrivskyddad</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Full</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Full</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Är du säker`?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Är du säker`?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Genom att ändra inställningen till skrivskyddad eller Av blir du utestängd.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Genom att ändra inställningen till skrivskyddad eller Av blir du utestängd.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>MQTT-åtkomst</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>MQTT-åtkomst</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>”%1” är inte ett nummer.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>”%1” är inte ett nummer.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Bekräfta</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Bekräfta</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Använd ett nummer med %1 siffror eller färre.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Använd ett nummer med %1 siffror eller färre.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>”%1” är inte en giltig IP adress.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>”%1” är inte en giltig IP adress.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>”%1” är inte ett giltigt portnummer. Använd ett nummer mellan 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>”%1” är inte ett giltigt portnummer. Använd ett nummer mellan 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 ä inte ett giltigt nummer. Använd ett nummer mellan 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 ä inte ett giltigt nummer. Använd ett nummer mellan 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Nuvarande drifttid</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Nuvarande drifttid</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Felkoder för generator</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Felkoder för generator</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Kylflänstemperatur</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Kylflänstemperatur</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Laddningsspänning</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Laddningsspänningen styrs för närvarande av BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Laddningsspänningen styrs för närvarande av BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Landströmbegränsning</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Landströmbegränsning</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>BMS kontrollerad</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>BMS kontrollerad</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>BMS-kontrolenl är automatiskt påslagen när en BMS finns tillgänglig. Återställ den om systemkonfigurationen har ändrats eller om det inte finns någon BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>BMS-kontrolenl är automatiskt påslagen när en BMS finns tillgänglig. Återställ den om systemkonfigurationen har ändrats eller om det inte finns någon BMS.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Servicetimer inaktiverad.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Servicetimer inaktiverad.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>VRM Portal</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>VRM Portal</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (fjärråtkomst via VPN)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (fjärråtkomst via VPN)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SoC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SoC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>En Säkerhetsprofil måste konfigureras innan nätverkstjänsterna kan aktiveras. Se Inställningar - Allmänna</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>En Säkerhetsprofil måste konfigureras innan nätverkstjänsterna kan aktiveras. Se Inställningar - Allmänna</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>”%1” ersattes med ”%2” eftersom det innehöll ogiltiga tecken.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>”%1” ersattes med ”%2” eftersom det innehöll ogiltiga tecken.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Initierar...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Initierar...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Backend startar...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Backend startar...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Backend stoppad.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Backend stoppad.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Anslutning misslyckades.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Anslutning misslyckades.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Denna GX-enhet är urloggad från Tailscale.
+        <translation>Denna GX-enhet är urloggad från Tailscale.
 
 Vänta eller kontrollera din internetanslutning.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Väntar på svar från Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Väntar på svar från Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Anslut denna GX-enhet till ditt Tailscale-konto genom att öppna denna länk:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Anslut denna GX-enhet till ditt Tailscale-konto genom att öppna denna länk:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Vänta eller kontrollera din internetanslutning.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Vänta eller kontrollera din internetanslutning.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Okänd status: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Okänd status: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Fel: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Fel: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Inaktivera Tailscale för att ändra dessa inställningar.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Inaktivera Tailscale för att ändra dessa inställningar.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Aktivera Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Aktivera Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Maskinnamn</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Maskinnamn</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Utloggning från Tailscale-konto</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Utloggning från Tailscale-konto</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Lokal nätverksåtkomst</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Lokal nätverksåtkomst</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Åtkomst till lokalt Ethernet-nätverk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Åtkomst till lokalt Ethernet-nätverk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Åtkomst till lokalt WiFi-nätverk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Åtkomst till lokalt WiFi-nätverk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Anpassade nätverk</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Anpassade nätverk</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Exempel: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Exempel: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Förklaring:
+        <translation>Förklaring:
 
 Denna funktion, som kallas subnätsrouter av Tailscale, möjliggör åtkomst till andra enheter i det lokala nätverket(en).
 
@@ -7385,2989 +8027,3057 @@ Det anpassade nätverksfältet godtar en kommaavgränsad lista av CIDR-notations
 Efter att du har lagt till/aktiverat ett nytt nätverk måste du godkänna en gång i Tailscales adminkonsoll.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Anpassade "tailscale up"-argument</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Anpassade &quot;tailscale up&quot;-argument</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Anpassad server-URL (headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Anpassad server-URL (headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Denna generatorregulator kräver ett hjälprelä för att kunna styras men hjälpreläet är inte konfigurerat. Konfigurera Relä 1 i Inställningar → Relä till "Hjälprelä för ansluten generator".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Denna generatorregulator kräver ett hjälprelä för att kunna styras men hjälpreläet är inte konfigurerat. Konfigurera Relä 1 i Inställningar → Relä till &quot;Hjälprelä för ansluten generator&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Larm om hög startbatterispänning</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Larm om hög startbatterispänning</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Hoppa över generatoruruppvärmning</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Hoppa över generatoruruppvärmning</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Aktiv men inga tjänster (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Aktiv men inga tjänster (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Root-lösenord ändrat till %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Root-lösenord ändrat till %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Hjälprelä för ansluten generator</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Hjälprelä för ansluten generator</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>AC-belastningarnas position</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>AC-belastningarnas position</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>AC-ingång och utgång</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>AC-ingång och utgång</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Använd det här alternativet när AC-belastningarna finns på växelriktare/laddarens ingång. Använd detta alternativ om du är osäker.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Använd det här alternativet när AC-belastningarna finns på växelriktare/laddarens ingång. Använd detta alternativ om du är osäker.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Endast AC-utgång</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Endast AC-utgång</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Använd det här alternativet när systemet använder en nätmätare, men alla AC-belastningar är på växelriktare/laddarens utgång.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Använd det här alternativet när systemet använder en nätmätare, men alla AC-belastningar är på växelriktare/laddarens utgång.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Varje månad</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Varje månad</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>EV-laddare</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>EV-laddare</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Värmepump</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Värmepump</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Nödvändiga belastningar</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Nödvändiga belastningar</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Starta och stoppa generatorn baserat på de inställda villkoren för autostart.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Starta och stoppa generatorn baserat på de inställda villkoren för autostart.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Inställningar för DC-generator</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Inställningar för DC-generator</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Växelströmsgeneratortemperatur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Växelströmsgeneratortemperatur</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Motortemperatur</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Motortemperatur</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Total drifttid</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Total drifttid</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Nätverkssäkerhetsprofil</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Nätverkssäkerhetsprofil</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Senaste %1 dagar</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Senaste %1 dagar</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generatorn stoppar om %1 om inte villkor för autostart är aktiverade och håller den igång.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generatorn stoppar om %1 om inte villkor för autostart är aktiverade och håller den igång.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Generatorn fortsätter att vara i drift tills den stoppas manuellt om inte villkor för autostart är aktiverade och håller den igång.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Generatorn fortsätter att vara i drift tills den stoppas manuellt om inte villkor för autostart är aktiverade och håller den igång.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Klassiskt användargränssnitt</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Klassiskt användargränssnitt</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Nytt användargränssnitt</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Nytt användargränssnitt</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Språket har ändrats!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Effektbegränsning</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Språket har ändrats!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>För Multi-RS- och Hs19-enheter är ESS-inställningar tillgängliga på produktsidan för RS-system.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>För Multi-RS- och Hs19-enheter är ESS-inställningar tillgängliga på produktsidan för RS-system.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Generator start/stopp</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Generator start/stopp</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Det är inte möjligt att byta fast programvaruversion om inte "Nätverkssäkerhetsprofil" har valts i "Inställningar/ Allmänna".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Det är inte möjligt att byta fast programvaruversion om inte &quot;Nätverkssäkerhetsprofil&quot; har valts i &quot;Inställningar/ Allmänna&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Drifttid</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Drifttid</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Systemlarm</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Systemlarm</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Inga systemlarm</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Inga systemlarm</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Tillbaka</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Tillbaka</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Nyheter</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Nyheter</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>Hoppa över</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>Hoppa över</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Välkommen!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Välkommen!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Vi är jätteglada över att kunna introducera ett fullständigt omdesignat gränssnitt som förbättrar både användbarheten och utseendet på din GX.
+        <translation>Vi är jätteglada över att kunna introducera ett fullständigt omdesignat gränssnitt som förbättrar både användbarheten och utseendet på din GX.
 
 Med strömlinjeformad navigering och en fräsch look blir allting du älskar ännu enklare att nå och mer visuellt tilltalande.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Mörkt - ljust läge</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Mörkt - ljust läge</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Olika omgivningar kräver olika skärminställningar. Mörkt eller ljust läge säkerställer att du får den bästa visuella upplevelsen oavsett var du befinner dig.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Olika omgivningar kräver olika skärminställningar. Mörkt eller ljust läge säkerställer att du får den bästa visuella upplevelsen oavsett var du befinner dig.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>All viktig information du behöver presenteras i en ren och enkel layout. Huvudelementet är en anpassningsbar widget som innehåller ringar, vilket ger dig snabb tillgång till dina systeminsikter med ett ögonkast.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>All viktig information du behöver presenteras i en ren och enkel layout. Huvudelementet är en anpassningsbar widget som innehåller ringar, vilket ger dig snabb tillgång till dina systeminsikter med ett ögonkast.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Få bättre kontroll med vår uppdaterade översiktspanel som innehåller systemdata i realtid - allt på en plats för enkel övervakning.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Få bättre kontroll med vår uppdaterade översiktspanel som innehåller systemdata i realtid - allt på en plats för enkel övervakning.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Kontroller:</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Kontroller:</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Alla dag-för-dag-kontroller finns nu kombinerade tillsammans i den nya kontrollpanelen. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Alla dag-för-dag-kontroller finns nu kombinerade tillsammans i den nya kontrollpanelen. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watt och ampere</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watt och ampere</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Du kan nu växla mellan watt och ampere. Välj den enhet som passar dig bäst.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Du kan nu växla mellan watt och ampere. Välj den enhet som passar dig bäst.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Mer information</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Mer information</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Gå till länken nedan för att läsa mer om det förnyade gränssnittet.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Gå till länken nedan för att läsa mer om det förnyade gränssnittet.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Skanna QR-koden för att läsa mer om det förnyade gränssnittet.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Skanna QR-koden för att läsa mer om det förnyade gränssnittet.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Genomfört</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Genomfört</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Nästa</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Nästa</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Fel: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Fel: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Aktivt fel</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Aktivt fel</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Generatorns totala drifttid (timmar)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Generatorns totala drifttid (timmar)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation></translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation></translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation></translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation></translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation></translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation></translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation></translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Node-RED fabriksåterställning</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Node-RED fabriksåterställning</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Är du säker på att du vill återställa Node-RED till fabriksinställningarna? Detta kommer att radera alla dina flöden.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Är du säker på att du vill återställa Node-RED till fabriksinställningarna? Detta kommer att radera alla dina flöden.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation></translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation></translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation></translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation></translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Inaktiveringsvärde</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Inaktiveringsvärde</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation></translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation></translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation></translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation></translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation></translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation></translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation></translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation></translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation></translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Sammanfattning</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation></translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Översikt</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation></translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation></translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation></translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation></translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation></translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation></translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation></translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation></translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation></translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Generatorns start/stopp-funktion är inte på, gå till reläinställningarna och ändra funktionen till "Genset start/stopp"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Normaltid i Marocko</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Normaltid i V. Centralafrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Normaltid i Sydafrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Normaltid i Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Normaltid i Egypten</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Normaltid i Östafrika</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Normaltid i Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Normaltid i Ö. Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Normaltid på Grönland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Normaltid i Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Normaltid Newfoundland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Normaltid Ö. Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Normaltid Atlanten</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Normaltid i centrala Brasilien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Normaltid Stilla havet - Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Normaltid i Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Normaltid i V. Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Normaltid i Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Normaltid Stilla havet - Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Normaltid i Ö. USA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Normaltid i centrala Kanada</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Normaltid i Centralamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Central Standard Time (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Mountain Standard Time (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Mountain Standard Time USA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacific Standard Time (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Normaltid i Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutian</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Normaltid på Nya Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Normaltid i V. Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Normaltid SÖ. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Normaltid i centrala Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Normaltid V. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Normaltid i Östafrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Normaltid Stilla havet - Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Normaltid i V. Sydamerika</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Normaltid V. Europa</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Normaltid i Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Normaltid i Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Normaltid i Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Normaltid i Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Normaltid i Tokyo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Normaltid i Korea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Normaltid i Singapore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Normaltid i Ulaanbaatar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Normaltid i Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Normaltid i N.Ö. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Normaltid i Kina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Normaltid SÖ. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Normaltid i N. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Normaltid i Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Normaltid i N. Centralasien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Normaltid i centrala Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Normaltid i Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Normaltid i Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Normaltid på Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Normaltid i Indien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Normaltid V. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Normaltid i Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Normaltid i Ekaterinburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Normaltid i Georgien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Normaltid i Kaukasus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Normaltid i Azerbajdzan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Normaltid i Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Normaltid i Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arab Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Normaltid i Syrien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Normaltid i Mellanöstern</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Normaltid i Jordanien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Normaltid i Israel</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Normaltid på Azorerna</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Normaltid i Kap Verde</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Normaltid i Tasmanien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Normaltid i Ö. Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Normaltid i Ö. Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Normaltid i centrala Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Normaltid i centrala Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Normaltid i V. Australien</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Normaltid vid datumgränsen</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Normaltid Centraleuropa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Normaltid Centraleuropa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Normaltid V. Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Normaltid Östeuropa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Normaltid Belarus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Normaltid i Ryssland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Normaltid Turkiet</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Normaltid på Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Normaltid på Julön</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Normaltid på Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Normaltid på Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Normaltid på Nya Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Normaltid på Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Normaltid på Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Normaltid på Påskön</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Generatorns start/stopp-funktion är inte på, gå till reläinställningarna och ändra funktionen till &quot;Genset start/stopp&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Okänd</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Solcellsproduktion</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">DC-ingång</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC-belastningar</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">DC-belastningar</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Översikt</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Totalt utbyte</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Systemutbyte</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Enbart larm</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Larm &amp; varningar</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Varning</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Inget fel</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Inget fel</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Okänt fel: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Okänt fel: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Inget fel</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Inget fel</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Initialiseringsfel batteri</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Initialiseringsfel batteri</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Inga batterier anslutna</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Inga batterier anslutna</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Okänt batteri</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Okänt batteri</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Olika batterityper</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Olika batterityper</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Felaktigt antal batterier</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Felaktigt antal batterier</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt hittades inte</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt hittades inte</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Mätningsfel batteri</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Mätningsfel batteri</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Invändigt beräkningsfel</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Invändigt beräkningsfel</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Antal batterier i serie felaktigt</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Antal batterier i serie felaktigt</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Maskinvarufel</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Maskinvarufel</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Fel i vakthund</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Fel i vakthund</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Överspänning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Överspänning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Underspänning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Underspänning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Övertemperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Övertemperatur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Undertemperatur</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Undertemperatur</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Standby för underladdning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Standby för underladdning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>ADC fel</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>ADC fel</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Kommunikationsfel batteri</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Kommunikationsfel batteri</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Förladdningsfel</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Förladdningsfel</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Fel säkerhetskontaktor</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Fel säkerhetskontaktor</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Uppdateringsfel batteri</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Uppdateringsfel batteri</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>BMS-kabelfel</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>BMS-kabelfel</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Felaktig referensspänning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Felaktig referensspänning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Felaktig systemspänning</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Felaktig systemspänning</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Förladdningsavbrott</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Förladdningsavbrott</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Fel ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Fel ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibreringsdata förlorad</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibreringsdata förlorad</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Inställningar ogiltiga</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Inställningar ogiltiga</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Förregling</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Förregling</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Nödstopp</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Nödstopp</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Kommunikationsavbrott</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Kommunikationsavbrott</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Säkerhetslås</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Säkerhetslås</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Övertemperatur terminal</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Övertemperatur terminal</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Inget fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Batteri hög temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Batteri högspänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Batteri Tsense felkopplad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Batteri Tsense saknas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Batteri Vsense felkopplad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Batteri Vsense  saknas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Batteri höga ledningsförluster</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Batteri låg spänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Batteri hög brumspänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Batteri låg laddningsstatus</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Batteri problem med mittpunktsspänning (MPV)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Batteritemperatur för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Laddartemperatur för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>För hög laddarström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Negativ ström laddare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Bulktid laddare utgången</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problem sensor laddningsström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Invändig T-sensor felkopplad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Invändig T-sensor saknas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Laddarfläkt ej hittad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Laddarfläkt överström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Överhettning laddningsterminal</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Laddare, kortslutning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Laddare problem med effektsteg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Överladdningsskydd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Ingående högspänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Inkommande ström för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Inkommande effekt för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Problem ingångspolaritet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Ingående spänning saknas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Avstängning ingång (inga nya försök)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Avstänging av ingång (nytt försök)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Inmatning internt fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Solcellsisoleringsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Jordfel detekterat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Växelriktare överbelastning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>För hög växelriktartemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Växelriktare maximal ström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Växelriktare intern DC-nivå</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Växelriktare fel AC-utmatningsnivå</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Växelriktare effektstegsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Växelriktare ansluten till AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>ACIN1 testfel nätrelä</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>ACIN2 testfel nätrelä</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Enhet försvann</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Inkompatibel enhet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>BMS anslutning förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Nät felkonfigurerat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Fasrotation</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Flera AC-ingångar</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Fasöverbelastning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Fel vid skrivning till minne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>CPU-temperatur för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Kommunikation förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibreringsdata förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Inkompatibel programvara</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Inkompatibel maskinvara</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Inställningar ogiltiga</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Referensspänning misslyckades</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Testarfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Historik ogiltig</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Ogiltig kWh-räknare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>DC-spänningsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Fel på GFCI (jordfelsbrytare)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>3,3 V försörjningsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>5 V försörjningsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>12 V försörjningsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>15 V försörjningsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Avstängning vid låg solcellsingång</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Sätt brytaren i ett olåst läge för att ändra inställningarna.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Använd D-bussdatakälla: anslut till angiven D-bussadress.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>adress</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Använd D-bussdatakälla: anslut till standard D-bussadress</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Använd MQTT-datakälla: anslut till angiven MQQT-mäklaradress.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>adress</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>Enhetsportal-id MQTT datakälla.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>Portal-id</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Webbhotell-shard MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>shard</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Användarnamn MQTT-datakälla</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Användare</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Lösenord MQTT-datakälla</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>lösen</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Token MQTT-datakälla</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Token-kod</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Aktivera FPS-räknare</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Skippa startbild</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Använd simulerad datakälla för testning.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Enheten avstängd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Blandad gammal/ny MK2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Förväntat fel enheter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Ingen annan enhet upptäckt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Överspänning på AC ut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>DDC programfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE-Bus MBS utan assistent</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Markrelätestet misslyckades</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Synkr. fel systemtid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Testfel nätrelä</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Konfiguration felanpassning med 2:a mcu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Överföringsfel enhet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Väntar på konfigurering eller dongle saknas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Fasmaster saknas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Överspänning har inträffat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Slav har ingen AC-ingång!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Enheten kan inte vara slav</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Systemskydd initierat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Programvara inte kompatibel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Invändigt fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Underkänt relätest förhindrar anslutning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Fel VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Okänt fel:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Invändigt fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Inget fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Batteri hög temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Batteri högspänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Batteri låg spänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Batterispänning har överstigit det inställda maxvärdet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Hög temperatur växelströmsgenerator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Högt RPM växelströmsgenerator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Fältdrift FET hög temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Nödvändig sensor saknas</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Låg spänning växelströmsgenerator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Hög spänningsoffset växelströmsgenerator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Generatorspänning har överstigit det inställda maxvärdet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Hög spänning växelströmsgenerator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Batteri frånkopplat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Frånkoppling vid hög batterispänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Batteriinstans utom räckhåll</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>För många BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Batteri nära att kopplas från</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>För många enheter att spåra</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Frånkoppling vid låg batterispänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Frånkoppling vid hög batteriström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Frånkoppling vid hög batteritemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Frånkoppling vid låg batteritemperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>BMS anslutning förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC inaktiv</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>DC/DC-omvandlare inte redo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC hög primär spänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC låg primär spänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC hög sekundär spänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC låg sekundär spänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC hög temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>DC/DC felkonfigurering</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Batteritemperatursensor defekt</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Okänt fel:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Okänt fel:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Inget fel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Batteri hög temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Batteri högspänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Batteri Tsense felkopplad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Batteri Tsense saknas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Batteri Vsense felkopplad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Batteri Vsense  saknas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Batteri höga ledningsförluster</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Batteri låg spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Batteri hög brumspänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Batteri låg laddningsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Batteri problem med mittpunktsspänning (MPV)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Batteritemperatur för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Laddartemperatur för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>För hög laddarström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Negativ ström laddare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Bulktid laddare utgången</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Problem sensor laddningsström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Invändig T-sensor felkopplad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Invändig T-sensor saknas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Laddarfläkt ej hittad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Laddarfläkt överström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Överhettning laddningsterminal</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Laddare, kortslutning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Laddare problem med effektsteg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Överladdningsskydd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Ingående högspänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Inkommande ström för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Inkommande effekt för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Problem ingångspolaritet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Ingående spänning saknas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Avstängning ingång (inga nya försök)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Avstänging av ingång (nytt försök)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Inmatning internt fel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Solcellsisoleringsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Jordfel detekterat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Växelriktare överbelastning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>För hög växelriktartemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Växelriktare maximal ström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Växelriktare intern DC-nivå</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Växelriktare fel AC-utmatningsnivå</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Växelriktare effektstegsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Växelriktare ansluten till AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>ACIN1 testfel nätrelä</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>ACIN2 testfel nätrelä</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Enhet försvann</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Inkompatibel enhet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>BMS anslutning förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Nät felkonfigurerat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Fasrotation</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Flera AC-ingångar</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Fasöverbelastning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Fel vid skrivning till minne</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>CPU-temperatur för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Kommunikation förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibreringsdata förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Inkompatibel programvara</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Inkompatibel maskinvara</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Inställningar ogiltiga</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Referensspänning misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Testarfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Historik ogiltig</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>Ogiltig kWh-räknare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>DC-spänningsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Fel på GFCI (jordfelsbrytare)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>3,3 V försörjningsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>5 V försörjningsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>12 V försörjningsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>15 V försörjningsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Avstängning vid låg solcellsingång</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Okänt fel:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Okänt fel:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Okänt fel:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Okänt fel:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Inget fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>AC-spänning L1 för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>AC-spänning för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>AC-spänning L1 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>AC-spänning för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>AC-frekvens L1 för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>AC-frekvens för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>AC-frekvens L1 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>AC-frekvens för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC-ström L1 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>AC-ström för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>AC-effekt L1 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>AC-effekt för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Nödstopp</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Servoström för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Oljetryck för lågt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Oljetryck för högt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Motortemperatur för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Motortemperatur för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Spolningstemperatur för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Spolningstemperatur för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Avgastemperatur för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Avgastemperatur för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Låg elektronisk temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Hög elektronisk temperatur</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Startspänning är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Startström för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Glödspänning är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Glödström för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Kallstartshjälpsspänning är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Kallstartshjälpsström är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Spänning till magnetventil för bränsle är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Ström till bryggmagnet för bränsle för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Stoppmagnetens hållspänning är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Ström till solenoid hållspole för stopp för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Stoppmagnetens dragspole har för låg spänning </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Ström till solenoid dragspole för stopp för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Fläkt/vattenpumpspänning är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Fläkt/vattenpumpspänning är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Strömsensorspänning är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Strömsensorström är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Boost-utgångsspänning för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Förstärkningsutgångsström för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Bussförsörjningpänning är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Bussförsörjningsström är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Startbatterispänning för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Startbatterispänning för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Rotation för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Rotation för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Oväntat stopp/problem med bränsleförsörjning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Spänning till effektkontaktor är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Ström till effektkontaktor för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>AC-spänning L2 för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>AC-spänning L2 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>AC-frekvens L2 för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>AC-frekvens L2 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>AC-ström L2 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>AC-effekt L2 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>AC-spänning L3 för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>AC-spänning L3 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>AC-frekvens L3 för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>AC-frekvens L3 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC-ström L3 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>AC-effekt L3 för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Utgångsväxelriktarspänning är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Utgångsväxelriktarström är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Universell utgångsspänning (1 A) är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Universell utgångsspänning (1 A) är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Universell utgångsspänning (5 A) är för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Universell utgångsspänning (5 A) är för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Låg AGT DC-spänning 1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Hög AGT DC-spänning1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>Låg AGT DC-ström 1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>Hög AGT DC-ström 1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Låg AGT DC-spänning 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Hög AGT DC-spänning 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>Låg AGT DC-ström 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>Hög AGT DC-ström 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Låg AGT B6-kylare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>Hög AGT B6-kylare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>Låg AGT B6-skena (-)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>Hög AGT B6-skena (-)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>Låg AGT B6-skena (+)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>Hög AGT B6-skena (+)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Bränsletemperatur för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Bränsletemperatur för hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Bränslenivå för låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Kontrollpanel förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Panel förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Service behövs</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>3-fasmodul förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>AGT-modul förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Synkroniseringsfel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Förlorade extern ECU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Intagsluftfilter</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Diagnosmeddelande (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Synkroniseringsmodul förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Belastningsbalansering misslyckades</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Synkroniseringsläge inaktiverat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Röd stopplampa (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Gul varningslamap (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Indikatorlampa för funktionsfel (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Skyddslampa (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Rotationsfält felaktigt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Bränslenivåsensor förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Startar utan växelriktare</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Buss #1 död</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Startbegäran nekad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Fjärrstart nekad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Relä för forcerad avstängning av belastning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Synkroniseringsmodul är offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Förlorade BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Omvandlarens DC-länkspänning är låg/omvänd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Omvandlarens DC-länkström är låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Omvandlarens DC-förladdningsspänning är låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Omvandlarens DC-förladdningsspänning är hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Fel på omvandlarens IGBT/MOSFET-driver</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Omvandlarfel i effektregleringsslinga</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Omvandlarens AC-frekvensdetektering</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Fel på omvandlarens kontrollvärde</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Fabriksinställning ändrad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parameter ändrad i adminläge</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Manuellt ingripande (ext. system)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Initiering misslyckades</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Vakthund</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Växelriktartemperatur hög L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Växelriktartemperatur hög L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Växelriktartemperatur hög L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Växelriktartemperatur hög DC-länk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Växelriktare överbelastning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Växelriktarkommunikation förlorad</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>DC-överbelastning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>DC-överspänning</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Ingen anslutning</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Inget fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Okänt fel: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Okänt fel:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Oljetryck</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Övertemperatur cylinderhuvud</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Laddningskontroll</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Högre hastighet än förväntat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Överhastighet</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Högre oljetemperatur än förväntat</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Oljetemperatur öppen krets/kortslutning till ström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Oljetemperatur kortslutning till jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analogt börvärde högt/ kortslutning till ström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analogt börvärde lågt/ kortslutning till jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Väntetid för mottagande av TSC1-meddelande har löpt ut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Väntetid för mottagande av CM1-meddelande har löpt ut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Batterispänning hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Batterispänning låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Hastighetssignal förvrängd</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Försörjning av intern 5 V-sensor hög</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Försörjning av intern 5 V-sensor låg</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Barometriskt tryck högt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Barometriskt tryck lågt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Utgångsbränslepump korslutning till ström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Utgångsbränslepump korslutning till jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Utgångsglödstift korslutning till ström</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Utgångsglödstift korslutning till jord</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Injektor öppen krets/kortslutning till jord på låg sida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Intern kortslutning injektorspole</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Injektor kortslutning till ström på låg sida</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Servicetimmar har gått ut</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Processorfel</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Okänt fel:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Batteri</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Kyl</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Kyl</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Allmän</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Allmän</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Rum</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Rum</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Utomhus</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Utomhus</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Varmvattenberedare</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Varmvattenberedare</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Frys</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Frys</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Okänt fel:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Inget fel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>AC-spänning L1 för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>AC-spänning för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>AC-spänning L1 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>AC-spänning för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>AC-frekvens L1 för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>AC-frekvens för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>AC-frekvens L1 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>AC-frekvens för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC-ström L1 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>AC-ström för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>AC-effekt L1 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>AC-effekt för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Nödstopp</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Servoström för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Oljetryck för lågt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Oljetryck för högt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Motortemperatur för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Motortemperatur för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Spolningstemperatur för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Spolningstemperatur för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Avgastemperatur för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Avgastemperatur för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Låg elektronisk temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Hög elektronisk temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Startspänning är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Startström för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Glödspänning är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Glödström för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Kallstartshjälpsspänning är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Kallstartshjälpsström är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Spänning till magnetventil för bränsle är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Ström till bryggmagnet för bränsle för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Stoppmagnetens hållspänning är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Ström till solenoid hållspole för stopp för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Stoppmagnetens dragspole har för låg spänning </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Ström till solenoid dragspole för stopp för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Fläkt/vattenpumpspänning är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Fläkt/vattenpumpspänning är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Strömsensorspänning är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Strömsensorström är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Boost-utgångsspänning för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Förstärkningsutgångsström för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Bussförsörjningpänning är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Bussförsörjningsström är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Startbatterispänning för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Startbatterispänning för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Rotation för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Rotation för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Oväntat stopp/problem med bränsleförsörjning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Spänning till effektkontaktor är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Ström till effektkontaktor för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>AC-spänning L2 för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>AC-spänning L2 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>AC-frekvens L2 för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>AC-frekvens L2 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>AC-ström L2 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>AC-effekt L2 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>AC-spänning L3 för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>AC-spänning L3 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>AC-frekvens L3 för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>AC-frekvens L3 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC-ström L3 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>AC-effekt L3 för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Utgångsväxelriktarspänning är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Utgångsväxelriktarström är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Universell utgångsspänning (1 A) är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Universell utgångsspänning (1 A) är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Universell utgångsspänning (5 A) är för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Universell utgångsspänning (5 A) är för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>Låg AGT DC-spänning 1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>Hög AGT DC-spänning1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>Låg AGT DC-ström 1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>Hög AGT DC-ström 1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Låg AGT DC-spänning 2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Hög AGT DC-spänning 2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>Låg AGT DC-ström 2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>Hög AGT DC-ström 2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>Låg AGT B6-kylare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>Hög AGT B6-kylare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>Låg AGT B6-skena (-)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>Hög AGT B6-skena (-)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>Låg AGT B6-skena (+)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>Hög AGT B6-skena (+)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Bränsletemperatur för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Bränsletemperatur för hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Bränslenivå för låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Kontrollpanel förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Panel förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Service behövs</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>3-fasmodul förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>AGT-modul förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Synkroniseringsfel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Förlorade extern ECU</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Intagsluftfilter</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Diagnosmeddelande (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Synkroniseringsmodul förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Belastningsbalansering misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Synkroniseringsläge inaktiverat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Röd stopplampa (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Gul varningslamap (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Indikatorlampa för funktionsfel (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Skyddslampa (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Rotationsfält felaktigt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Bränslenivåsensor förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Startar utan växelriktare</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Buss #1 död</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Startbegäran nekad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Fjärrstart nekad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Relä för forcerad avstängning av belastning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Synkroniseringsmodul är offline</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>Förlorade BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Omvandlarens DC-länkspänning är låg/omvänd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Omvandlarens DC-länkström är låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Omvandlarens DC-förladdningsspänning är låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Omvandlarens DC-förladdningsspänning är hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Fel på omvandlarens IGBT/MOSFET-driver</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Omvandlarfel i effektregleringsslinga</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Omvandlarens AC-frekvensdetektering</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Fel på omvandlarens kontrollvärde</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Fabriksinställning ändrad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Parameter ändrad i adminläge</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Manuellt ingripande (ext. system)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Initiering misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Vakthund</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Växelriktartemperatur hög L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Växelriktartemperatur hög L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Växelriktartemperatur hög L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Växelriktartemperatur hög DC-länk</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Växelriktare överbelastning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Växelriktarkommunikation förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>DC-överbelastning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>DC-överspänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Ingen anslutning</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Inget fel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Okänt fel: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Okänt fel:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Oljetryck</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Övertemperatur cylinderhuvud</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Laddningskontroll</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Högre hastighet än förväntat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Överhastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Högre oljetemperatur än förväntat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Oljetemperatur öppen krets/kortslutning till ström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Oljetemperatur kortslutning till jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Analogt börvärde högt/ kortslutning till ström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Analogt börvärde lågt/ kortslutning till jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Väntetid för mottagande av TSC1-meddelande har löpt ut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Väntetid för mottagande av CM1-meddelande har löpt ut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Batterispänning hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Batterispänning låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Hastighetssignal förvrängd</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Försörjning av intern 5 V-sensor hög</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Försörjning av intern 5 V-sensor låg</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Barometriskt tryck högt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Barometriskt tryck lågt</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Utgångsbränslepump korslutning till ström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Utgångsbränslepump korslutning till jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Utgångsglödstift korslutning till ström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Utgångsglödstift korslutning till jord</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Injektor öppen krets/kortslutning till jord på låg sida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Intern kortslutning injektorspole</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Injektor kortslutning till ström på låg sida</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Servicetimmar har gått ut</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Processorfel</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Sätt brytaren i ett olåst läge för att ändra inställningarna.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Använd D-bussdatakälla: anslut till angiven D-bussadress.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>adress</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Använd D-bussdatakälla: anslut till standard D-bussadress</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Använd MQTT-datakälla: anslut till angiven MQQT-mäklaradress.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>adress</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>Enhetsportal-id MQTT datakälla.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>Portal-id</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Webbhotell-shard MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>shard</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Användarnamn MQTT-datakälla</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Användare</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Lösenord MQTT-datakälla</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>lösen</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Token MQTT-datakälla</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Token-kod</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Aktivera FPS-räknare</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Skippa startbild</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Använd simulerad datakälla för testning.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Normaltid i Marocko</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Normaltid i V. Centralafrika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Normaltid i Sydafrika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Normaltid i Namibia</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Normaltid i Egypten</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Normaltid i Östafrika</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Normaltid i Argentina</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Normaltid i Ö. Sydamerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Normaltid på Grönland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Normaltid i Montevideo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Normaltid Newfoundland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Normaltid Ö. Sydamerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Normaltid Atlanten</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Normaltid i centrala Brasilien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Normaltid Stilla havet - Sydamerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Normaltid i Paraguay</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Normaltid i V. Sydamerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Normaltid i Venezuela</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Eastern Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Normaltid Stilla havet - Sydamerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Normaltid i Ö. USA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Normaltid i centrala Kanada</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Normaltid i Centralamerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Central Standard Time (Mexiko)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Central Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Mountain Standard Time (Mexiko)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Mountain Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Mountain Standard Time USA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Pacific Standard Time (Mexiko)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Normaltid i Alaska</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hawaii-Aleutian</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Normaltid på Nya Zeeland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Normaltid i V. Australien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Normaltid SÖ. Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Normaltid i centrala Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Normaltid V. Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Normaltid i Östafrika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Normaltid Stilla havet - Sydamerika</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Normaltid i V. Sydamerika</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Normaltid V. Europa</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Normaltid i Kamchatka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Normaltid i Magadan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Normaltid i Vladivostok</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Normaltid i Yakutsk</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Normaltid i Tokyo</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Normaltid i Korea</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Normaltid i Singapore</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Normaltid i Ulaanbaatar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Normaltid i Taipei</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Normaltid i N.Ö. Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Normaltid i Kina</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Normaltid SÖ. Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Normaltid i N. Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Normaltid i Myanmar</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Normaltid i N. Centralasien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Normaltid i centrala Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Normaltid i Bangladesh</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Normaltid i Nepal</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Normaltid på Sri Lanka</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Normaltid i Indien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Normaltid V. Asien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Normaltid i Pakistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Normaltid i Ekaterinburg</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Normaltid i Georgien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Normaltid i Kaukasus</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Normaltid i Azerbajdzan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Arabian Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Normaltid i Afghanistan</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Normaltid i Iran</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Arabic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Arab Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Normaltid i Syrien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Normaltid i Mellanöstern</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Normaltid i Jordanien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Normaltid i Israel</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Greenwich Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Normaltid på Azorerna</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Normaltid i Kap Verde</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Normaltid i Tasmanien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Normaltid i Ö. Australien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Normaltid i Ö. Australien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Normaltid i centrala Australien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Normaltid i centrala Australien</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Normaltid i V. Australien</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Mid-Atlantic Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Normaltid vid datumgränsen</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>GMT Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Normaltid Centraleuropa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Normaltid Centraleuropa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Normaltid V. Europa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Normaltid Östeuropa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>FLE Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>GTB Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Normaltid Belarus</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Normaltid i Ryssland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Normaltid Turkiet</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Normaltid på Mauritius</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Normaltid på Julön</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Normaltid på Tonga</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Normaltid på Fiji</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Normaltid på Nya Zeeland</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Normaltid på Samoa</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Normaltid på Hawaii</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Normaltid på Påskön</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Invändigt fel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Okänt fel:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Invändigt fel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Inget fel</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Batteri hög temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Batteri högspänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Batteri låg spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Batterispänning har överstigit det inställda maxvärdet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Hög temperatur växelströmsgenerator</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Högt RPM växelströmsgenerator</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Fältdrift FET hög temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Nödvändig sensor saknas</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Låg spänning växelströmsgenerator</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Hög spänningsoffset växelströmsgenerator</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Generatorspänning har överstigit det inställda maxvärdet</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Hög spänning växelströmsgenerator</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Batteri frånkopplat</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Frånkoppling vid hög batterispänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Batteriinstans utom räckhåll</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>För många BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Batteri nära att kopplas från</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>För många enheter att spåra</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Frånkoppling vid låg batterispänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Frånkoppling vid hög batteriström</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Frånkoppling vid hög batteritemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Frånkoppling vid låg batteritemperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>BMS anslutning förlorad</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC inaktiv</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>DC/DC-omvandlare inte redo</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC hög primär spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC låg primär spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC hög sekundär spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC låg sekundär spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC hög temperatur</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>DC/DC felkonfigurering</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Batteritemperatursensor defekt</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_th.ts
+++ b/i18n/venus-gui-v2_th.ts
@@ -1,7381 +1,8023 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="th">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>พิการ</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>พิการ</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>โอเวอร์โหลดอินเวอร์เตอร์</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>โอเวอร์โหลดอินเวอร์เตอร์</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>พลังงาน</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>พลังงาน</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>ปิด</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>ปิด</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>อัตโนมัติ</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>อัตโนมัติ</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">แบตเตอรี่</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">เชื่อมต่อแล้ว</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">ตัดการเชื่อมต่อ</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">เครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>แรงดันแบตเตอรี่สูง</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>แรงดันแบตเตอรี่สูง</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>อินเวอร์เตอร์/เครื่องชาร์จ</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>อินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>แรงดันแบตเตอรี่ต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>แรงดันแบตเตอรี่ต่ำ</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>คู่มือ</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>คู่มือ</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>ไม่มี</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>ไม่มี</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>ตำแหน่ง</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>ตำแหน่ง</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>ความเร็ว</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>ความเร็ว</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>สถานะ</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>สถานะ</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>กำลังติดตั้ง %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>กำลังติดตั้ง %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>SOC ขั้นต่ำ</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>SOC ขั้นต่ำ</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">ไม่รู้จัก</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>ใส่รหัสผ่าน</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>ใส่รหัสผ่าน</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>กดเพื่อตรวจสอบ</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>กดเพื่อตรวจสอบ</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>กริด</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>กริด</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>ผลผลิตพลังงานแสงอาทิตย์</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>ผลผลิตพลังงานแสงอาทิตย์</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>การควบคุมภายนอก</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>การควบคุมภายนอก</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>ถัง</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>ถัง</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>สิ่งแวดล้อม</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>สิ่งแวดล้อม</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>ไม่มีการแจ้งเตือนในปัจจุบัน</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>ไม่มีการแจ้งเตือนในปัจจุบัน</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>บลูทูธ</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>บลูทูธ</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>ทั่วไป</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>ทั่วไป</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>เฟิร์มแวร์</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>เฟิร์มแวร์</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>วันเวลา</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>วันเวลา</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>ติดตั้งระบบ</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>ติดตั้งระบบ</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>การแสดงผลและภาษา</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>การแสดงผลและภาษา</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM ออนไลน์</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM ออนไลน์</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>เครื่องวัดพลังงาน</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>เครื่องวัดพลังงาน</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>อินเวอร์เตอร์ PV</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>อินเวอร์เตอร์ PV</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>อีเธอร์เน็ต</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>อีเธอร์เน็ต</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>โมเด็ม GSM</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>โมเด็ม GSM</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>จีพีเอส</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>จีพีเอส</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>เครื่องกำเนิดไฟฟ้าเริ่มต้น/หยุด</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>เครื่องกำเนิดไฟฟ้าเริ่มต้น/หยุด</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>ปั๊มถัง</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>ปั๊มถัง</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>บริการ</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>บริการ</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>อินพุต/เอาต์พุต</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>อินพุต/เอาต์พุต</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Venus OS คุณสมบัติขนาดใหญ่</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Venus OS คุณสมบัติขนาดใหญ่</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>ขีดจำกัดอายุการใช้งานแบตเตอรี่: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>ขีดจำกัดอายุการใช้งานแบตเตอรี่: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">เริ่มอัตโนมัติ</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>การเริ่มต้นอัตโนมัติจะถูกปิดใช้งาน และเครื่องกำเนิดไฟฟ้าจะไม่เริ่มทำงานโดยอัตโนมัติตามเงื่อนไขที่กำหนดค่าไว้</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>การเริ่มต้นอัตโนมัติจะถูกปิดใช้งาน และเครื่องกำเนิดไฟฟ้าจะไม่เริ่มทำงานโดยอัตโนมัติตามเงื่อนไขที่กำหนดค่าไว้</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>หยุดด้วยตนเอง</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>หยุดด้วยตนเอง</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>เริ่มด้วยตัวเอง</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>เริ่มด้วยตัวเอง</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">ตำแหน่ง</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>เริ่มอัตโนมัติ</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>เริ่มอัตโนมัติ</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>สวิตช์</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>สวิตช์</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>ระดับการเข้าถึง</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>ระดับการเข้าถึง</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>ผู้ใช้</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>ผู้ใช้</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>ผู้ใช้ &amp; ผู้ติดตั้ง</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>ผู้ใช้ &amp; ผู้ติดตั้ง</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>ผู้ใช้ขั้นสูง</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>ผู้ใช้ขั้นสูง</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>บริการ</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>บริการ</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>ตรวจสอบให้แน่ใจว่าได้รีเซ็ตระบบ VE.Bus ด้วยหลังจากปิดใช้งาน DVCC</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>ตรวจสอบให้แน่ใจว่าได้รีเซ็ตระบบ VE.Bus ด้วยหลังจากปิดใช้งาน DVCC</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>จำกัดกระแสไฟชาร์จ</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>จำกัดกระแสไฟชาร์จ</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>กระแสไฟสูงสุด</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>กระแสไฟสูงสุด</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>ใช้ค่า %1 เพื่อเริ่ม/หยุด</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>ใช้ค่า %1 เพื่อเริ่ม/หยุด</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>เริ่มต้นเมื่อ %1 สูงกว่า</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>เริ่มต้นเมื่อ %1 สูงกว่า</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>เริ่มต้นเมื่อ %1 ต่ำกว่า</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>เริ่มต้นเมื่อ %1 ต่ำกว่า</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>หยุดเมื่อ %1 สูงกว่า</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>หยุดเมื่อ %1 สูงกว่า</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>หยุดเมื่อ %1 ต่ำกว่า</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>หยุดเมื่อ %1 ต่ำกว่า</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>ลบที่อยู่ IP?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>ลบที่อยู่ IP?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>สูงสุด: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>สูงสุด: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>การเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>การเชื่อมต่อ</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>ผลิตภัณฑ์</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>ผลิตภัณฑ์</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>ชื่อ</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">ชื่อ</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>รหัสสินค้า</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>รหัสสินค้า</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>เวอร์ชั่นฮาร์ดแวร์</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>เวอร์ชั่นฮาร์ดแวร์</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>ชื่ออุปกรณ์</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>ชื่ออุปกรณ์</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>ปิดใช้งานการควบคุมสวิตช์ระยะไกล</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>ปิดใช้งานการควบคุมสวิตช์ระยะไกล</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>เครื่องกำเนิดไฟฟ้าในสภาพความผิดพลาด</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>เครื่องกำเนิดไฟฟ้าในสภาพความผิดพลาด</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>ตรวจไม่พบเครื่องกำเนิดไฟฟ้าที่ AC ขาเข้า</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>ตรวจไม่พบเครื่องกำเนิดไฟฟ้าที่ AC ขาเข้า</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>เวลาทำงานสะสมตั้งแต่การทดสอบครั้งล่าสุด</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>เวลาทำงานสะสมตั้งแต่การทดสอบครั้งล่าสุด</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>เวลาในการดำเนินการทดสอบครั้งต่อไป</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>เวลาในการดำเนินการทดสอบครั้งต่อไป</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>วิ่งแล้ว</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>วิ่งแล้ว</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>เริ่มด้วยตัวเอง</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>เริ่มด้วยตัวเอง</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>เครื่องกำเนิดไฟฟ้าเริ่มต้น</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>เครื่องกำเนิดไฟฟ้าเริ่มต้น</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>เวลาทำงานประจำวัน</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>เวลาทำงานประจำวัน</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>ค่าต้องมากกว่าค่าสต็อป</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>ค่าต้องมากกว่าค่าสต็อป</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>ค่าต้องต่ำกว่าค่าเริ่มต้น</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>ค่าต้องต่ำกว่าค่าเริ่มต้น</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>เอาต์พุต AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>เอาต์พุต AC</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">เอาต์พุต AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>ใช้ AC Load เพื่อเริ่ม/หยุด</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>ใช้ AC Load เพื่อเริ่ม/หยุด</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>การวัด</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>การวัด</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>การบริโภคทั้งหมด</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>การบริโภคทั้งหมด</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>รวมอินเวอร์เตอร์ AC ขาออก</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>รวมอินเวอร์เตอร์ AC ขาออก</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>อินเวอร์เตอร์ AC ขาออกเฟสสูงสุด</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>อินเวอร์เตอร์ AC ขาออกเฟสสูงสุด</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>เริ่มเมื่อกำลังสูงกว่า</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>เริ่มเมื่อกำลังสูงกว่า</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>หยุดเมื่อพลังงานต่ำกว่า</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>หยุดเมื่อพลังงานต่ำกว่า</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>การตรวจสอบแบตเตอรี่</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>การตรวจสอบแบตเตอรี่</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>การตรวจสอบไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>การตรวจสอบไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">การตรวจสอบแบตเตอรี่</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">การตรวจสอบไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>เมื่อสูญเสียการสื่อสาร</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>เมื่อสูญเสียการสื่อสาร</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>หยุดเครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>หยุดเครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>ให้เครื่องกำเนิดไฟฟ้าทำงานต่อไป</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>ให้เครื่องกำเนิดไฟฟ้าทำงานต่อไป</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>หยุดเครื่องกำเนิดไฟฟ้าเมื่อมีอินพุต AC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>หยุดเครื่องกำเนิดไฟฟ้าเมื่อมีอินพุต AC</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>แบตเตอรี่ SOC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>แบตเตอรี่ SOC</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">อินเวอร์เตอร์อุณหภูมิสูง</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>อินเวอร์เตอร์อุณหภูมิสูง</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>อินเวอร์เตอร์อุณหภูมิสูง</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>เริ่มด้วยการเตือนอุณหภูมิสูง</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>เริ่มด้วยการเตือนอุณหภูมิสูง</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>เริ่มด้วยคำเตือนการโอเวอร์โหลด</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>เริ่มด้วยคำเตือนการโอเวอร์โหลด</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>วิ่งเป็นระยะ</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>วิ่งเป็นระยะ</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>ช่วงเวลาทำงาน</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>ช่วงเวลาทำงาน</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1 วัน</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1 วัน</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>ข้ามการวิ่งหากเคยวิ่งเพื่อ</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>ข้ามการวิ่งหากเคยวิ่งเพื่อ</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>เริ่มเสมอ</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>เริ่มเสมอ</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>วันที่เริ่มต้นช่วงการวิ่ง</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>วันที่เริ่มต้นช่วงการวิ่ง</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>ระยะเวลาการทำงาน (ชม.:น.)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>ระยะเวลาการทำงาน (ชม.:น.)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>ใช้งานจนกว่าแบตเตอรี่จะชาร์จจนเต็ม</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>ใช้งานจนกว่าแบตเตอรี่จะชาร์จจนเต็ม</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS ตกลง (แก้ไข)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS ตกลง (แก้ไข)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>เชื่อมต่อ GPS แล้ว แต่ไม่มีการซ่อม GPS</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>เชื่อมต่อ GPS แล้ว แต่ไม่มีการซ่อม GPS</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>ไม่ได้เชื่อมต่อ GPS</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>ไม่ได้เชื่อมต่อ GPS</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>ละติจูด</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>ละติจูด</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>ลองจิจูด</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>ลองจิจูด</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 กม./ชม</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 กม./ชม</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 ไมล์ต่อชั่วโมง</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 ไมล์ต่อชั่วโมง</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 กิโลตัน</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 กิโลตัน</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 เมตร/วินาที</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 เมตร/วินาที</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>คอร์ส</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>คอร์ส</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>ระดับความสูง</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>ระดับความสูง</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>จำนวนดาวเทียม</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>จำนวนดาวเทียม</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>จุดตั้งค่ากริด</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>จุดตั้งค่ากริด</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>จุดตั้งค่า AC-In</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>จุดตั้งค่า AC-In</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>ปัจจุบัน: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>ปัจจุบัน: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>แรงดันไฟฟ้า: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>แรงดันไฟฟ้า: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>ขีดจำกัด (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>ขีดจำกัด (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>ค่าธรรมเนียม: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>ค่าธรรมเนียม: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>การคายประจุ: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>การคายประจุ: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>ขีดจำกัด (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>ขีดจำกัด (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>มองเห็นได้</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>มองเห็นได้</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>ที่ซ่อนอยู่</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>ที่ซ่อนอยู่</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (การวัดเสริม)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (การวัดเสริม)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (เอาต์พุต %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (เอาต์พุต %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>จอภาพแบตเตอรี่ที่ใช้งาน</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>จอภาพแบตเตอรี่ที่ใช้งาน</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">ชื่อ</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">ใส่ชื่อ</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>ใส่ชื่อ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>ใส่ชื่อ</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>การสแกนอย่างต่อเนื่อง</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>การสแกนอย่างต่อเนื่อง</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>อะแดปเตอร์บลูทูธ</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>อะแดปเตอร์บลูทูธ</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Pincode</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Pincode</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>อาจจำเป็นต้องลบข้อมูลการจับคู่ที่มีอยู่ก่อนทำการเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>อาจจำเป็นต้องลบข้อมูลการจับคู่ที่มีอยู่ก่อนทำการเชื่อมต่อ</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>ประเภทเฟส</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>ประเภทเฟส</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>เฟสเดียว</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>เฟสเดียว</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>หลายเฟส</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>หลายเฟส</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>PV อินเวอร์เตอร์ ในเฟส 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>PV อินเวอร์เตอร์ ในเฟส 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>อินเวอร์เตอร์ PV ในเฟส 2 ตำแหน่ง</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>อินเวอร์เตอร์ PV ในเฟส 2 ตำแหน่ง</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>โปรไฟล์ CAN บัส</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>โปรไฟล์ CAN บัส</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">พิการ</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>ขึ้น แต่ไม่มีบริการ (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>ขึ้น แต่ไม่มีบริการ (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>อุปกรณ์</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>อุปกรณ์</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000 ออก</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000 ออก</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>ตัวเลือกหมายเลขประจำตัวที่ไม่ซ้ำ</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>ตัวเลือกหมายเลขประจำตัวที่ไม่ซ้ำ</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>โปรดรอสักครู่ การเปลี่ยนและตรวจสอบหมายเลขเฉพาะจะใช้เวลาสักครู่</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>โปรดรอสักครู่ การเปลี่ยนและตรวจสอบหมายเลขเฉพาะจะใช้เวลาสักครู่</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>ตัวเลือกด้านบนจะกำหนดว่าบล็อกใดของหมายเลขประจำตัวที่ไม่ซ้ำกันที่จะใช้สำหรับหมายเลขประจำตัวที่ไม่ซ้ำของ NAME ในฟิลด์ PGN 60928 NAME เปลี่ยนเมื่อใช้อุปกรณ์ GX หลายเครื่องในเครือข่าย VE.Can เดียวเท่านั้น</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>ตัวเลือกด้านบนจะกำหนดว่าบล็อกใดของหมายเลขประจำตัวที่ไม่ซ้ำกันที่จะใช้สำหรับหมายเลขประจำตัวที่ไม่ซ้ำของ NAME ในฟิลด์ PGN 60928 NAME เปลี่ยนเมื่อใช้อุปกรณ์ GX หลายเครื่องในเครือข่าย VE.Can เดียวเท่านั้น</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>ตัวเลือกด้านบนจะกำหนดว่าบล็อกใดของหมายเลขประจำตัวที่ไม่ซ้ำกันที่จะใช้สำหรับหมายเลขซีเรียลในฟิลด์ DGN 60928 ADDRESS_CLAIM เปลี่ยนเมื่อใช้อุปกรณ์ GX หลายเครื่องในเครือข่าย RV-C เดียวเท่านั้น</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>ตัวเลือกด้านบนจะกำหนดว่าบล็อกใดของหมายเลขประจำตัวที่ไม่ซ้ำกันที่จะใช้สำหรับหมายเลขซีเรียลในฟิลด์ DGN 60928 ADDRESS_CLAIM เปลี่ยนเมื่อใช้อุปกรณ์ GX หลายเครื่องในเครือข่าย RV-C เดียวเท่านั้น</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>ตรวจสอบหมายเลขประจำตัวที่ไม่ซ้ำ</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>ตรวจสอบหมายเลขประจำตัวที่ไม่ซ้ำ</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">กดเพื่อตรวจสอบ</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>มีอุปกรณ์อื่นเชื่อมต่อกับหมายเลขเฉพาะนี้ โปรดเลือกหมายเลขใหม่</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>มีอุปกรณ์อื่นเชื่อมต่อกับหมายเลขเฉพาะนี้ โปรดเลือกหมายเลขใหม่</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>ตกลง: ไม่มีอุปกรณ์อื่นเชื่อมต่อกับหมายเลขเฉพาะนี้</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>ตกลง: ไม่มีอุปกรณ์อื่นเชื่อมต่อกับหมายเลขเฉพาะนี้</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>สถานะเครือข่าย</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>สถานะเครือข่าย</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>ความสว่างที่ปรับได้</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>ความสว่างที่ปรับได้</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>ความสว่าง</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>ความสว่าง</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>แสดงเวลาปิด</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>แสดงเวลาปิด</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 วินาที</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 วินาที</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 วินาที</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 วินาที</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 นาที</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 นาที</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 นาที</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 นาที</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 นาที</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 นาที</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>ไม่เคย</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>ไม่เคย</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>โหมดการแสดงผล</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>โหมดการแสดงผล</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>มืด</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>มืด</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>แสงสว่าง</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>แสงสว่าง</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>ระดับมุมมองสั้นๆ</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>ระดับมุมมองสั้นๆ</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>ภาษา</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>ภาษา</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>การเปลี่ยนภาษา</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>การเปลี่ยนภาษา</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>จอแสดงผลพลังงานไฟฟ้า</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>จอแสดงผลพลังงานไฟฟ้า</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>กำลังไฟ (วัตต์)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>กำลังไฟ (วัตต์)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>ปัจจุบัน (แอมป์)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>ปัจจุบัน (แอมป์)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>หน่วย</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>หน่วย</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>ระดับ 1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>ระดับ 1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>เซลเซียส</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>เซลเซียส</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>ฟาเรนไฮต์</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>ฟาเรนไฮต์</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;ข้อควรระวัง:&lt;/b&gt; อ่านคู่มือก่อนทำการปรับเปลี่ยน</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;ข้อควรระวัง:&lt;/b&gt; อ่านคู่มือก่อนทำการปรับเปลี่ยน</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>จำกัดแรงดันประจุแบตเตอรี่ที่มีการจัดการ</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>จำกัดแรงดันประจุแบตเตอรี่ที่มีการจัดการ</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>แรงดันประจุสูงสุด</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>แรงดันประจุสูงสุด</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - ความรู้สึกแรงดันไฟฟ้าที่ใช้ร่วมกัน</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - ความรู้สึกแรงดันไฟฟ้าที่ใช้ร่วมกัน</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - ความรู้สึกอุณหภูมิที่ใช้ร่วมกัน</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - ความรู้สึกอุณหภูมิที่ใช้ร่วมกัน</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>เซ็นเซอร์ไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>เซ็นเซอร์ไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">เซ็นเซอร์ไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>เซ็นเซอร์ที่ใช้แล้ว</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>เซ็นเซอร์ที่ใช้แล้ว</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - ความรู้สึกปัจจุบันที่ใช้ร่วมกัน</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - ความรู้สึกปัจจุบันที่ใช้ร่วมกัน</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>สถานะ SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>สถานะ SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>ปิดการใช้งาน (การควบคุมภายนอก)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>ปิดการใช้งาน (การควบคุมภายนอก)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>ปิดการใช้งาน (ไม่มีที่ชาร์จ)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>ปิดการใช้งาน (ไม่มีที่ชาร์จ)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>ปิดการใช้งาน (ไม่มีการตรวจสอบแบตเตอรี่)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>ปิดการใช้งาน (ไม่มีการตรวจสอบแบตเตอรี่)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>การเลือกอัตโนมัติ</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>การเลือกอัตโนมัติ</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>ไม่มีการควบคุม BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>ไม่มีการควบคุม BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>การควบคุม BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>การควบคุม BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>ไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>ไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>เลือกอัตโนมัติ</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>เลือกอัตโนมัติ</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">ไม่มี</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>สร้างวันที่/เวลา</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>สร้างวันที่/เวลา</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>อัพเดทออนไลน์</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>อัพเดทออนไลน์</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>ติดตั้งเฟิร์มแวร์จาก SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>ติดตั้งเฟิร์มแวร์จาก SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>เฟิร์มแวร์สำรองที่เก็บไว้</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>เฟิร์มแวร์สำรองที่เก็บไว้</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>ตรวจสอบการอัปเดตบน SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>ตรวจสอบการอัปเดตบน SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>พบเฟิร์มแวร์</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>พบเฟิร์มแวร์</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>กำลังติดตั้ง %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>กำลังติดตั้ง %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">กดเพื่ออัปเดตเป็น %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>กดเพื่ออัปเดตเป็น %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>กดเพื่ออัปเดตเป็น %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>วันที่/เวลาสร้างเฟิร์มแวร์</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>วันที่/เวลาสร้างเฟิร์มแวร์</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>อัปเดตอัตโนมัติ</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>อัปเดตอัตโนมัติ</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>ตรวจสอบเท่านั้น</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>ตรวจสอบเท่านั้น</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>ตรวจสอบและดาวน์โหลดเท่านั้น</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>ตรวจสอบและดาวน์โหลดเท่านั้น</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>ตรวจสอบและอัปเดต</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>ตรวจสอบและอัปเดต</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>อัปเดตฟีด</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>อัปเดตฟีด</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>ประเภทรูปภาพ</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>ประเภทรูปภาพ</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>ปกติ</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>ปกติ</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>ใหญ่</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>ใหญ่</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>ตรวจสอบสำหรับการอัพเดต</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>ตรวจสอบสำหรับการอัพเดต</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>อัพเดทพร้อมใช้งาน</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>อัพเดทพร้อมใช้งาน</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>กำลังติดตั้ง %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>กำลังติดตั้ง %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">กำลังติดตั้ง %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>อัปเดตวันที่/เวลาสร้าง</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>อัปเดตวันที่/เวลาสร้าง</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>อินเวอร์เตอร์</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>อินเวอร์เตอร์</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>ค้นหาอินเวอร์เตอร์ PV</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>ค้นหาอินเวอร์เตอร์ PV</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>ที่อยู่ IP ที่ตรวจพบ</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>ที่อยู่ IP ที่ตรวจพบ</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>เพิ่มที่อยู่ IP ด้วยตนเอง</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>เพิ่มที่อยู่ IP ด้วยตนเอง</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>พอร์ต TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>พอร์ต TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>มัลติเฟส</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>มัลติเฟส</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3 พาวเวอร์</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3 พาวเวอร์</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>แยกเฟส (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>แยกเฟส (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>แสดง</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>แสดง</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>เอซี-อิน1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>เอซี-อิน1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>เอซีอิน1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>เอซีอิน1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>เอซี-อิน1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>เอซี-อิน1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out ส.ส</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out ส.ส</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">เอซีอิน1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">เอซี-อิน1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC ออก L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC ออก L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-ออก --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-ออก --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>เอซีอิน2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>เอซีอิน2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>เอซี-อิน2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>เอซี-อิน2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>สแกนหาที่อยู่ IP อีกครั้งหรือไม่</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>สแกนหาที่อยู่ IP อีกครั้งหรือไม่</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>ค้นหาซ้ำ</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>ค้นหาซ้ำ</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH บน LAN</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH บน LAN</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>การสนับสนุนระยะไกล</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>การสนับสนุนระยะไกล</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>ช่องทางการสนับสนุนระยะไกล</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>ช่องทางการสนับสนุนระยะไกล</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>รองรับ IP และพอร์ตระยะไกล</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>รองรับ IP และพอร์ตระยะไกล</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">ออกจากระบบตอนนี้</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>รีบูทเดี๋ยวนี้</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>รีบูทเดี๋ยวนี้</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">อุปกรณ์ได้รับการรีบูตแล้ว</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>เสียงเตือน</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>เสียงเตือน</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>โหมดสาธิต</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>โหมดสาธิต</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>สาธิต ESS</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>สาธิต ESS</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>การสาธิตเรือ/รถบ้าน 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>การสาธิตเรือ/รถบ้าน 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>เรือ/รถบ้านสาธิต2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>เรือ/รถบ้านสาธิต2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>การเริ่มโหมดสาธิตจะเปลี่ยนการตั้งค่าบางอย่างและอินเทอร์เฟซผู้ใช้จะไม่ตอบสนองชั่วขณะหนึ่ง</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>การเริ่มโหมดสาธิตจะเปลี่ยนการตั้งค่าบางอย่างและอินเทอร์เฟซผู้ใช้จะไม่ตอบสนองชั่วขณะหนึ่ง</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>เงื่อนไข</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>เงื่อนไข</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>เวลาทำงานขั้นต่ำ</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>เวลาทำงานขั้นต่ำ</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>เวลาอุ่นเครื่อง</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>เวลาอุ่นเครื่อง</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>เวลาเย็นลง</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>เวลาเย็นลง</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>ตรวจจับเครื่องกำเนิดไฟฟ้าที่อินพุต AC</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>ตรวจจับเครื่องกำเนิดไฟฟ้าที่อินพุต AC</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>ไม่มีอินพุต AC ใดถูกตั้งค่าเป็นเครื่องกำเนิด ไปที่หน้าการตั้งค่าระบบและตั้งค่าอินพุต AC ที่ถูกต้องเป็นเครื่องกำเนิดเพื่อเปิดใช้งานฟังก์ชันนี้</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>ไม่มีอินพุต AC ใดถูกตั้งค่าเป็นเครื่องกำเนิด ไปที่หน้าการตั้งค่าระบบและตั้งค่าอินพุต AC ที่ถูกต้องเป็นเครื่องกำเนิดเพื่อเปิดใช้งานฟังก์ชันนี้</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>สัญญาณเตือนจะทำงานเมื่อตรวจไม่พบพลังงานจากเครื่องกำเนิดไฟฟ้าที่อินพุต AC ของอินเวอร์เตอร์ ตรวจสอบให้แน่ใจว่าได้ตั้งค่าอินพุต AC ที่ถูกต้องเป็นเครื่องกำเนิดในหน้าการตั้งค่าระบบ</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>สัญญาณเตือนจะทำงานเมื่อตรวจไม่พบพลังงานจากเครื่องกำเนิดไฟฟ้าที่อินพุต AC ของอินเวอร์เตอร์ ตรวจสอบให้แน่ใจว่าได้ตั้งค่าอินพุต AC ที่ถูกต้องเป็นเครื่องกำเนิดในหน้าการตั้งค่าระบบ</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>เวลาเริ่มต้นชั่วโมงเงียบ</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>เวลาเริ่มต้นชั่วโมงเงียบ</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>เวลาสิ้นสุดชั่วโมงเงียบ</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>เวลาสิ้นสุดชั่วโมงเงียบ</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>ระยะเวลาดำเนินการและบริการ</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>ระยะเวลาดำเนินการและบริการ</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>รีเซ็ตตัวนับเวลาทำงานประจำวัน</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>รีเซ็ตตัวนับเวลาทำงานประจำวัน</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>รีเซ็ตตัวนับรันไทม์รายวัน</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>รีเซ็ตตัวนับรันไทม์รายวัน</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>ไม่สามารถแก้ไขตัวนับในขณะที่เครื่องกำเนิดไฟฟ้ากำลังทำงานอยู่</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>ไม่สามารถแก้ไขตัวนับในขณะที่เครื่องกำเนิดไฟฟ้ากำลังทำงานอยู่</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>ช่วงเวลาให้บริการเครื่องกำเนิดไฟฟ้า (ชั่วโมง)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>ช่วงเวลาให้บริการเครื่องกำเนิดไฟฟ้า (ชั่วโมง)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>ตั้งค่าช่วงเวลาการบริการเป็น %1h ใช้ปุ่ม "รีเซ็ตตัวจับเวลาบริการ" เพื่อรีเซ็ตตัวจับเวลาบริการ</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>ตั้งค่าช่วงเวลาการบริการเป็น %1h ใช้ปุ่ม &quot;รีเซ็ตตัวจับเวลาบริการ&quot; เพื่อรีเซ็ตตัวจับเวลาบริการ</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>รีเซ็ตตัวจับเวลาบริการ</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>รีเซ็ตตัวจับเวลาบริการ</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>การตั้งค่า GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>การตั้งค่า GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>รูปแบบ</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>รูปแบบ</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20.693 N, 5° 13.205 E</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20.693 N, 5° 13.205 E</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>หน่วยความเร็ว</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>หน่วยความเร็ว</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>กิโลเมตรต่อชั่วโมง</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>กิโลเมตรต่อชั่วโมง</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>เมตรต่อวินาที</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>เมตรต่อวินาที</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>ไมล์ต่อชั่วโมง</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>ไมล์ต่อชั่วโมง</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>นอต</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>นอต</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>ไม่มีโมเด็ม GSM เชื่อมต่ออยู่</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>ไม่มีโมเด็ม GSM เชื่อมต่ออยู่</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>อินเทอร์เน็ต</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>อินเทอร์เน็ต</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>ผู้ให้บริการ</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>ผู้ให้บริการ</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>อาจจำเป็นต้องกำหนดการตั้งค่า APN ด้านล่างในหน้านี้ โปรดติดต่อผู้ให้บริการของคุณเพื่อขอรายละเอียด
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>อาจจำเป็นต้องกำหนดการตั้งค่า APN ด้านล่างในหน้านี้ โปรดติดต่อผู้ให้บริการของคุณเพื่อขอรายละเอียด
 หากไม่ได้ผล ให้ตรวจสอบซิมการ์ดในโทรศัพท์เพื่อให้แน่ใจว่ามีเครดิตและ/หรือลงทะเบียนเพื่อใช้สำหรับข้อมูล</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>อนุญาตให้โรมมิ่ง</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>อนุญาตให้โรมมิ่ง</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>สถานะซิม</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>สถานะซิม</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>ไม่ได้ใส่ซิม</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>ไม่ได้ใส่ซิม</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>ต้องใช้ PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>ต้องใช้ PIN</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK จำเป็น</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK จำเป็น</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>ซิมล้มเหลว</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>ซิมล้มเหลว</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>ซิมไม่ว่าง</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>ซิมไม่ว่าง</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>ซิมผิด</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>ซิมผิด</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>PIN ผิด</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>PIN ผิด</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>พร้อม</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>พร้อม</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">ข้อผิดพลาดที่ไม่รู้จัก</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>พิน</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>พิน</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>ค่าเริ่มต้น</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>ค่าเริ่มต้น</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>ใช้APN .เริ่มต้น</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>ใช้APN .เริ่มต้น</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>ชื่อ APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>ชื่อ APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>ใช้การตรวจสอบสิทธิ์</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>ใช้การตรวจสอบสิทธิ์</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>ชื่อผู้ใช้</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>ชื่อผู้ใช้</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>ใช้งานเอง</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>ใช้งานเอง</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>ไม่พบผู้ช่วย ESS</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>ไม่พบผู้ช่วย ESS</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>วัดแสงกริด</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>วัดแสงกริด</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>เครื่องวัดภายนอก</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>เครื่องวัดภายนอก</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>อินเวอร์เตอร์/เครื่องชาร์จ</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>อินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>อินเวอร์เตอร์ไฟฟ้ากระแสสลับที่ใช้งาน</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>อินเวอร์เตอร์ไฟฟ้ากระแสสลับที่ใช้งาน</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>การควบคุมหลายเฟส</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>การควบคุมหลายเฟส</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>รวมทุกขั้นตอน</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>รวมทุกขั้นตอน</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>เฟสส่วนตัว</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>เฟสส่วนตัว</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>แต่ละเฟสได้รับการควบคุมเพื่อให้บรรลุจุดกำหนดกริดแยกกัน (ประสิทธิภาพของระบบลดลง)
+        <translation>แต่ละเฟสได้รับการควบคุมเพื่อให้บรรลุจุดกำหนดกริดแยกกัน (ประสิทธิภาพของระบบลดลง)
 
 ข้อควรระวัง: ใช้เฉพาะในกรณีที่ผู้ให้บริการสาธารณูปโภคต้องการเท่านั้น</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>ผลรวมของทุกเฟสได้รับการควบคุมอย่างชาญฉลาดเพื่อให้บรรลุจุดกำหนดของกริด (เพิ่มประสิทธิภาพของระบบ)
+        <translation>ผลรวมของทุกเฟสได้รับการควบคุมอย่างชาญฉลาดเพื่อให้บรรลุจุดกำหนดของกริด (เพิ่มประสิทธิภาพของระบบ)
 
 ใช้เว้นแต่จะได้รับอนุญาตจากผู้ให้บริการสาธารณูปโภค</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">ไม่ใช้งาน</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">ไดนามิก ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>SOC ขั้นต่ำ (เว้นแต่กริดจะล้มเหลว)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>SOC ขั้นต่ำ (เว้นแต่กริดจะล้มเหลว)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>ขีด จำกัด SOC ที่ใช้งานอยู่</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>ขีด จำกัด SOC ที่ใช้งานอยู่</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">ยังชีพประคับประคอง</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">เติมเงิน</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>การใช้สูงสุด</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>การใช้สูงสุด</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>สูงกว่าขั้นต่ำ SOC เท่านั้น</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>สูงกว่าขั้นต่ำ SOC เท่านั้น</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>ตลอดเวลา</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>ตลอดเวลา</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>ปลดประจำการ</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>ปลดประจำการ</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>ชาร์จช้า</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>ชาร์จช้า</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>ยังชีพประคับประคอง</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>ยังชีพประคับประคอง</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>เติมเงิน</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>เติมเงิน</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>ขีด จำกัด กำลังการชาร์จ</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>ขีด จำกัด กำลังการชาร์จ</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>กำลังชาร์จสูงสุด</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>กำลังชาร์จสูงสุด</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>จำกัดกำลังของอินเวอร์เตอร์</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>จำกัดกำลังของอินเวอร์เตอร์</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>กำลังสูงสุดของอินเวอร์เตอร์</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>กำลังสูงสุดของอินเวอร์เตอร์</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>จุดตั้งค่ากริด</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>จุดตั้งค่ากริด</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>กริดป้อนเข้า</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>กริดป้อนเข้า</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>AC-coupled PV - ป้อนมากเกินไป</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>AC-coupled PV - ป้อนมากเกินไป</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>DC-coupled PV - ป้อนส่วนเกิน</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>DC-coupled PV - ป้อนส่วนเกิน</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>จำกัดการป้อนเข้าของระบบ</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>จำกัดการป้อนเข้าของระบบ</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>ป้อนเข้าสูงสุด</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>ป้อนเข้าสูงสุด</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>เปิดใช้งานการจำกัดการป้อนเข้า</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>เปิดใช้งานการจำกัดการป้อนเข้า</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>นำเข้าแบบอะนาล็อก</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>นำเข้าแบบอะนาล็อก</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>นำเข้าแบบดิจิตอล</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>นำเข้าแบบดิจิตอล</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>อินพุตดิจิตอล %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>อินพุตดิจิตอล %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>เครื่องวัดชีพจร</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>เครื่องวัดชีพจร</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>สัญญาณเตือนประตู</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>สัญญาณเตือนประตู</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>ปั๊มน้ำท้องเรือ</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>ปั๊มน้ำท้องเรือ</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>สัญญาณเตือนท้องเรือ</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>สัญญาณเตือนท้องเรือ</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>สัญญาณกันขโมย</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>สัญญาณกันขโมย</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>เครื่องตรวจจับควัน</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>เครื่องตรวจจับควัน</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>สัญญาณเตือนไฟไหม้</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>สัญญาณเตือนไฟไหม้</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>สัญญาณเตือน CO2</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>สัญญาณเตือน CO2</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>เซ็นเซอร์บลูทูธ</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>เซ็นเซอร์บลูทูธ</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>โปรดทราบว่าฟีเจอร์เหล่านี้ไม่ได้รับการสนับสนุนอย่างเป็นทางการจาก Victron โปรดสอบถามไปที่ community.victronenergy.com
+        <translation>โปรดทราบว่าฟีเจอร์เหล่านี้ไม่ได้รับการสนับสนุนอย่างเป็นทางการจาก Victron โปรดสอบถามไปที่ community.victronenergy.com
 
 เอกสารประกอบ https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>สัญญาณ K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>สัญญาณ K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>โหนด-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>โหนด-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>เปิดใช้งาน (เซฟโหมด)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>เปิดใช้งาน (เซฟโหมด)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>เลื่อนออกไป %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>เลื่อนออกไป %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>รหัสพอร์ทัล VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>รหัสพอร์ทัล VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>ช่วงเวลาการบันทึก</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>ช่วงเวลาการบันทึก</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 นาที</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 นาที</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 นาที</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 นาที</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 ชั่วโมง</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 ชั่วโมง</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 ชั่วโมง</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 ชั่วโมง</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 ชั่วโมง</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 ชั่วโมง</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 ชั่วโมง</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 ชั่วโมง</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 วัน</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 วัน</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>ใช้การเชื่อมต่อที่ปลอดภัย (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>ใช้การเชื่อมต่อที่ปลอดภัย (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>ผู้ติดต่อล่าสุด</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>ผู้ติดต่อล่าสุด</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 ข้อความตอบกลับที่ไม่คาดคิด</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 ข้อความตอบกลับที่ไม่คาดคิด</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 การตอบสนอง HTTP ที่ไม่คาดคิด</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 การตอบสนอง HTTP ที่ไม่คาดคิด</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 หมดเวลาการเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 หมดเวลาการเชื่อมต่อ</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 ข้อผิดพลาดในการเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 ข้อผิดพลาดในการเชื่อมต่อ</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 DNS ล้มเหลว</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 DNS ล้มเหลว</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 ข้อผิดพลาดในการกำหนดเส้นทาง</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 ข้อผิดพลาดในการกำหนดเส้นทาง</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM ไม่พร้อมใช้งาน</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM ไม่พร้อมใช้งาน</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 ข้อผิดพลาดที่ไม่รู้จัก</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 ข้อผิดพลาดที่ไม่รู้จัก</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>ข้อความผิดพลาด:
+        <translation>ข้อความผิดพลาด:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>รีบูตอุปกรณ์เมื่อไม่มีการติดต่อ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>รีบูตอุปกรณ์เมื่อไม่มีการติดต่อ</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>ไม่มีความล่าช้าในการรีเซ็ตการติดต่อ (hh:mm)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>ไม่มีความล่าช้าในการรีเซ็ตการติดต่อ (hh:mm)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>สถานที่จัดเก็บ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>สถานที่จัดเก็บ</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>ไม่มีบัฟเฟอร์ที่ใช้งานอยู่</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>ไม่มีบัฟเฟอร์ที่ใช้งานอยู่</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>ที่เก็บข้อมูลภายใน</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>ที่เก็บข้อมูลภายใน</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>กำลังโอน</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>กำลังโอน</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>จัดเก็บข้อมูลภายนอก</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>จัดเก็บข้อมูลภายนอก</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">ข้อผิดพลาดที่ไม่รู้จัก</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>ไม่มีพื้นที่เหลือในการจัดเก็บ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>ไม่มีพื้นที่เหลือในการจัดเก็บ</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>IO error</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>IO error</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>เมานต์ผิดพลาด</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>เมานต์ผิดพลาด</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>มีอิมเมจเฟิร์มแวร์ ไม่ใช้.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>มีอิมเมจเฟิร์มแวร์ ไม่ใช้.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>การ์ด SD / USB stick ไม่สามารถเขียนได้</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>การ์ด SD / USB stick ไม่สามารถเขียนได้</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>พื้นที่ว่างในดิสก์</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>พื้นที่ว่างในดิสก์</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>ไบต์</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>ไบต์</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>ไบต์</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>ไบต์</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>บันทึกที่เก็บไว้</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>บันทึกที่เก็บไว้</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 บันทึก</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 บันทึก</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>อายุบันทึกเก่าที่สุด</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>อายุบันทึกเก่าที่สุด</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>เปิดใช้งาน Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>เปิดใช้งาน Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>ไม่มีรายงานข้อผิดพลาด</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>ไม่มีรายงานข้อผิดพลาด</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>เวลาของข้อผิดพลาดล่าสุด</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>เวลาของข้อผิดพลาดล่าสุด</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>บริการที่มีจำหน่าย</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>บริการที่มีจำหน่าย</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>รหัสหน่วย: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>รหัสหน่วย: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>ฟังก์ชั่น (รีเลย์ 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>ฟังก์ชั่น (รีเลย์ 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>ฟังก์ชั่น</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>ฟังก์ชั่น</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>รีเลย์ปลุก</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>รีเลย์ปลุก</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">ปั๊มถัง</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">คู่มือ</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>ขั้วรีเลย์สัญญาณเตือน</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>ขั้วรีเลย์สัญญาณเตือน</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>ปกติเปิด</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>ปกติเปิด</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>ปกติปิด</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>ปกติปิด</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>รีเลย์ 1 เปิด</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>รีเลย์ 1 เปิด</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>เปิดรีเลย์</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>เปิดรีเลย์</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>ฟังก์ชั่น (รีเลย์ 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>ฟังก์ชั่น (รีเลย์ 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>รีเลย์ 2 เปิด</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>รีเลย์ 2 เปิด</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>กฎการควบคุมอุณหภูมิ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>กฎการควบคุมอุณหภูมิ</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>การเปิดใช้งานรีเลย์เมื่ออุณหภูมิ</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>การเปิดใช้งานรีเลย์เมื่ออุณหภูมิ</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>ไม่มีการกำหนดค่ารีเลย์ให้เปิดใช้งานตามอุณหภูมิ ไปที่หน้าการตั้งค่ารีเลย์ที่อยู่ในเมนูการตั้งค่าหลัก และตั้งค่าฟังก์ชันรีเลย์เป็น "อุณหภูมิ"</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>ไม่มีการกำหนดค่ารีเลย์ให้เปิดใช้งานตามอุณหภูมิ ไปที่หน้าการตั้งค่ารีเลย์ที่อยู่ในเมนูการตั้งค่าหลัก และตั้งค่าฟังก์ชันรีเลย์เป็น &quot;อุณหภูมิ&quot;</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>ตัวเลือกนี้ช่วยให้คุณสลับระหว่างเฟิร์มแวร์เวอร์ชันปัจจุบันและเวอร์ชันก่อนหน้าได้ ไม่จำเป็นต้องใช้อินเทอร์เน็ตหรือ sdcard</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>ตัวเลือกนี้ช่วยให้คุณสลับระหว่างเฟิร์มแวร์เวอร์ชันปัจจุบันและเวอร์ชันก่อนหน้าได้ ไม่จำเป็นต้องใช้อินเทอร์เน็ตหรือ sdcard</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>เฟิร์มแวร์ %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>เฟิร์มแวร์ %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>กดเพื่อบูต</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>กดเพื่อบูต</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">เฟิร์มแวร์ %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>รีบูตเป็น %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>รีบูตเป็น %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>ไม่สามารถเปลี่ยนเวอร์ชั่นของเฟิร์มแวร์ได้ เมื่อตั้งค่าการอัปเดตอัตโนมัติเป็น "ตรวจสอบและอัปเดต" ตั้งค่าการอัปเดตอัตโนมัติเป็น "ปิดใช้งาน" หรือ "ตรวจสอบเท่านั้น" เพื่อเปิดใช้งานตัวเลือกนี้</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>ไม่สามารถเปลี่ยนเวอร์ชั่นของเฟิร์มแวร์ได้ เมื่อตั้งค่าการอัปเดตอัตโนมัติเป็น &quot;ตรวจสอบและอัปเดต&quot; ตั้งค่าการอัปเดตอัตโนมัติเป็น &quot;ปิดใช้งาน&quot; หรือ &quot;ตรวจสอบเท่านั้น&quot; เพื่อเปิดใช้งานตัวเลือกนี้</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>เฟิร์มแวร์สำรองไม่พร้อมใช้งาน</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>เฟิร์มแวร์สำรองไม่พร้อมใช้งาน</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>คอนโซลบน VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN บัสผ่าน TCP/IP (ดีบัก)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN บัสผ่าน TCP/IP (ดีบัก)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Shore power</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Shore power</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>ยานพาหนะ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>ยานพาหนะ</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>เรือ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>เรือ</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>ชื่อระบบ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>ชื่อระบบ</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>อัตโนมัติ</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>อัตโนมัติ</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">กริด</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">อัตโนมัติ</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>ผู้ใช้กำหนด</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>ผู้ใช้กำหนด</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>ชื่อที่ผู้ใช้กำหนด</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>ชื่อที่ผู้ใช้กำหนด</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>อินพุต AC 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>อินพุต AC 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>อินพุต AC 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>อินพุต AC 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>ตรวจสอบความล้มเหลวของกริด</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>ตรวจสอบความล้มเหลวของกริด</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>ตรวจสอบการตัดการเชื่อมต่อฝั่ง</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>ตรวจสอบการตัดการเชื่อมต่อฝั่ง</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>เลือกอัตโนมัติ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>เลือกอัตโนมัติ</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>มีระบบ DC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>มีระบบ DC</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>ซิงโครไนซ์ VE.Bus SOC กับแบตเตอรี่</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>ซิงโครไนซ์ VE.Bus SOC กับแบตเตอรี่</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>ใช้กระแสไฟชาร์จพลังงานแสงอาทิตย์เพื่อปรับปรุง VE.Bus SOC</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>ใช้กระแสไฟชาร์จพลังงานแสงอาทิตย์เพื่อปรับปรุง VE.Bus SOC</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>ตัวควบคุมแรงดันไฟฟ้าเครื่องชาร์จพลังงานแสงอาทิตย์</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>ตัวควบคุมแรงดันไฟฟ้าเครื่องชาร์จพลังงานแสงอาทิตย์</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>ตัวควบคุมกระแสไฟชาร์จพลังงานแสงอาทิตย์</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>ตัวควบคุมกระแสไฟชาร์จพลังงานแสงอาทิตย์</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">ตัวควบคุม BMS</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>ตัวควบคุม BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>ตัวควบคุม BMS</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>ไม่ได้เปิดใช้งานฟังก์ชันเริ่ม/หยุดปั๊มถัง ไปที่การตั้งค่ารีเลย์และตั้งค่าฟังก์ชันเป็น "ปั๊มถัง"</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>ไม่ได้เปิดใช้งานฟังก์ชันเริ่ม/หยุดปั๊มถัง ไปที่การตั้งค่ารีเลย์และตั้งค่าฟังก์ชันเป็น &quot;ปั๊มถัง&quot;</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>สถานะปั๊ม</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>สถานะปั๊ม</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">อัตโนมัติ</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>เซ็นเซอร์ถัง</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>เซ็นเซอร์ถัง</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>ระดับเริ่มต้น</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>ระดับเริ่มต้น</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>ระดับหยุด</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>ระดับหยุด</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>ขาดการเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>ขาดการเชื่อมต่อ</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>ถอดปลั๊ก</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>ถอดปลั๊ก</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[ที่ซ่อนอยู่]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[ที่ซ่อนอยู่]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>เชื่อมต่อกับเครือข่าย?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>เชื่อมต่อกับเครือข่าย?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>เชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>เชื่อมต่อ</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>ลืมเครือข่าย?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>ลืมเครือข่าย?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>ลืม</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>ลืม</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>คุณแน่ใจหรือว่าต้องการลืมเครือข่ายนี้</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>คุณแน่ใจหรือว่าต้องการลืมเครือข่ายนี้</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>หมายเลขทางกายภาพ</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>หมายเลขทางกายภาพ</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>การกำหนดค่า IP</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>การกำหนดค่า IP</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">คู่มือ</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">ปิด</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>แก้ไขแล้ว</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>แก้ไขแล้ว</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>เน็ตมาสก์</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>เน็ตมาสก์</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>ประตู</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>ประตู</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>เซิร์ฟเวอร์ DNS</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>เซิร์ฟเวอร์ DNS</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>ที่อยู่ IP ของลิงก์ในเครื่อง</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>ที่อยู่ IP ของลิงก์ในเครื่อง</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>ระวัง สำหรับระบบ ESS เช่นเดียวกับระบบที่มีแบตเตอรี่ที่มีการจัดการ อินสแตนซ์อุปกรณ์ CAN-bus จะต้องยังคงกำหนดค่าเป็น 0 ดูข้อมูลเพิ่มเติมในคู่มือ GX</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>ระวัง สำหรับระบบ ESS เช่นเดียวกับระบบที่มีแบตเตอรี่ที่มีการจัดการ อินสแตนซ์อุปกรณ์ CAN-bus จะต้องยังคงกำหนดค่าเป็น 0 ดูข้อมูลเพิ่มเติมในคู่มือ GX</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>อินสแตนซ์ของอุปกรณ์</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>อินสแตนซ์ของอุปกรณ์</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>ที่อยู่เครือข่าย</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>ที่อยู่เครือข่าย</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>อุปกรณ์ VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>อุปกรณ์ VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>อุปกรณ์# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>อุปกรณ์# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>ไม่มีจุดเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>ไม่มีจุดเชื่อมต่อ</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>ไม่มีอแด็ปเตอร์ Wi-Fi เชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>ไม่มีอแด็ปเตอร์ Wi-Fi เชื่อมต่อ</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>สร้างจุดเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>สร้างจุดเชื่อมต่อ</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>เครือข่าย Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>เครือข่าย Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>คุณแน่ใจหรือไม่ว่าต้องการปิดใช้งานจุดเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>คุณแน่ใจหรือไม่ว่าต้องการปิดใช้งานจุดเชื่อมต่อ</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>วันที่/เวลาUTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>วันที่/เวลาUTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>วันที่/เวลาท้องถิ่น</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>วันที่/เวลาท้องถิ่น</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>เขตเวลา</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>เขตเวลา</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>แอฟริกา</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>แอฟริกา</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>อเมริกา</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>อเมริกา</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>แอนตาร์กติกา</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>แอนตาร์กติกา</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>อาร์ตติค</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>อาร์ตติค</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>เอเชีย</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>เอเชีย</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>แอตแลนติก</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>แอตแลนติก</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>ออสเตรเลีย</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>ออสเตรเลีย</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>ยุโรป</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>ยุโรป</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>ชาวอินเดีย</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>ชาวอินเดีย</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>แปซิฟิก</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>แปซิฟิก</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>ฯลฯ</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>ฯลฯ</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>ไม่ได้เชื่อมต่อ %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>ไม่ได้เชื่อมต่อ %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>รีบูทเดี๋ยวนี้?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>รีบูทเดี๋ยวนี้?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>การเปลี่ยนแปลงอินสแตนซ์ VRM จะไม่มีผลจนกว่าจะรีบูตอุปกรณ์</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>การเปลี่ยนแปลงอินสแตนซ์ VRM จะไม่มีผลจนกว่าจะรีบูตอุปกรณ์</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>อุปกรณ์กำลังรีบูต...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>อุปกรณ์กำลังรีบูต...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>อุปกรณ์ได้รับการรีบูตแล้ว</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>อุปกรณ์ได้รับการรีบูตแล้ว</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>สัญญาณเตือนแรงดันแบตเตอรี่ต่ำ</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>สัญญาณเตือนแรงดันแบตเตอรี่ต่ำ</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>สัญญาณเตือนแรงดันแบตเตอรี่สูง</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>สัญญาณเตือนแรงดันแบตเตอรี่สูง</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>ข้อผิดพลาดล่าสุด</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>ข้อผิดพลาดล่าสุด</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>ผิดพลาดครั้งที่ 2</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>ผิดพลาดครั้งที่ 2</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>ผิดพลาดครั้งที่ 3</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>ผิดพลาดครั้งที่ 3</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>ผิดพลาดครั้งที่ 4</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>ผิดพลาดครั้งที่ 4</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>เครือข่าย</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>เครือข่าย</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>การตั้งค่าโหมด</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>การตั้งค่าโหมด</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>สแตนด์อโลน</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>สแตนด์อโลน</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">สแตนด์อโลน</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>โหลด</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>โหลด</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">การควบคุมภายนอก</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>การชาร์จ &amp; HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>การชาร์จ &amp; HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>การชาร์จ &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>การชาร์จ &amp; BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>ต่อ การควบคุม &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>ต่อ การควบคุม &amp; BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>การชาร์จ, Hub-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>การชาร์จ, Hub-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>การตั้งค่าหลัก</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>การตั้งค่าหลัก</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">ตัวรอง</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>ตัวรอง</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>ตัวรอง</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>กลุ่มตัวหลัก</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>กลุ่มตัวหลัก</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>ชาร์จตัวหลัก</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>ชาร์จตัวหลัก</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>หัวหน้ากลุ่ม &amp; การชาร์จ</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>หัวหน้ากลุ่ม &amp; การชาร์จ</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>แรงดันไฟชาร์จ</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>แรงดันไฟชาร์จ</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>รีเซ็ต</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>รีเซ็ต</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>การควบคุม BMS จะถูกเปิดใช้งานโดยอัตโนมัติเมื่อมี BMS รีเซ็ตหากการกำหนดค่าระบบเปลี่ยนแปลงหรือหากไม่มี BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>การควบคุม BMS จะถูกเปิดใช้งานโดยอัตโนมัติเมื่อมี BMS รีเซ็ตหากการกำหนดค่าระบบเปลี่ยนแปลงหรือหากไม่มี BMS</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">พลัง PV ทั้งหมด</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>โหลด</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>โหลด</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>พบ %1</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>พบ %1</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 ประวัติศาสตร์</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 ประวัติศาสตร์</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 ประวัติศาสตร์</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>การทำงานแบบเครือข่าย</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>การทำงานแบบเครือข่าย</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>มุมมองตาราง</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>มุมมองตาราง</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>แผนภูมิ</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>แผนภูมิ</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>คำเตือน</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>คำเตือน</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">เตือน</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>เตือน</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>เตือน</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>ปริมาณ</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>ปริมาณ</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>ลัดวงจร</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>ลัดวงจร</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>ขั้วย้อนกลับ</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>ขั้วย้อนกลับ</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>สถานีชาร์จ EV</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>สถานีชาร์จ EV</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>การประชุม</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>การประชุม</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>เวลา</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>เวลา</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>โหมดการชาร์จ</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>โหมดการชาร์จ</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>เริ่มต้นและหยุดกระบวนการด้วยตนเอง ใช้สิ่งนี้เพื่อการชาร์จที่รวดเร็วและการตรวจสอบอย่างใกล้ชิด</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>เริ่มต้นและหยุดกระบวนการด้วยตนเอง ใช้สิ่งนี้เพื่อการชาร์จที่รวดเร็วและการตรวจสอบอย่างใกล้ชิด</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>เริ่มและหยุดตามระดับประจุแบตเตอรี่ เหมาะสมที่สุดสำหรับการชาร์จแบบข้ามคืนและแบบขยายเวลาเพื่อหลีกเลี่ยงการชาร์จไฟเกิน</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>เริ่มและหยุดตามระดับประจุแบตเตอรี่ เหมาะสมที่สุดสำหรับการชาร์จแบบข้ามคืนและแบบขยายเวลาเพื่อหลีกเลี่ยงการชาร์จไฟเกิน</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>ลดอัตราค่าไฟฟ้าในช่วงนอกเวลาเร่งด่วน หรือหากคุณต้องการให้แน่ใจว่า EV ของคุณชาร์จเต็มและพร้อมใช้งานในเวลาที่กำหนด</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>ลดอัตราค่าไฟฟ้าในช่วงนอกเวลาเร่งด่วน หรือหากคุณต้องการให้แน่ใจว่า EV ของคุณชาร์จเต็มและพร้อมใช้งานในเวลาที่กำหนด</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>เปิดใช้งานการชาร์จ</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>เปิดใช้งานการชาร์จ</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>ล็อคจอแสดงผลเครื่องชาร์จ</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>ล็อคจอแสดงผลเครื่องชาร์จ</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>ที่อยู่แหล่งที่มา</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>ที่อยู่แหล่งที่มา</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>ติดตั้ง</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>ติดตั้ง</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>อินสแตนซ์บรรทัด #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>อินสแตนซ์บรรทัด #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>ตัวอย่างบรรทัด</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>ตัวอย่างบรรทัด</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>ตัวอย่างเครื่องชาร์จ</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>ตัวอย่างเครื่องชาร์จ</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>อินสแตนซ์อินเวอร์เตอร์</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>อินสแตนซ์อินเวอร์เตอร์</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>อินสแตนซ์แหล่ง DC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>อินสแตนซ์แหล่ง DC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>อินสแตนซ์แหล่งที่มา DC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>อินสแตนซ์แหล่งที่มา DC</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>แหล่ง DC ลำดับความสำคัญ #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>แหล่ง DC ลำดับความสำคัญ #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>ลำดับความสำคัญของแหล่ง DC</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>ลำดับความสำคัญของแหล่ง DC</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>ตัวอย่างถัง</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>ตัวอย่างถัง</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>อุปกรณ์ RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>อุปกรณ์ RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>เปิดใช้งานเครื่องมือสร้างภาพอัตราเฟรม</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>เปิดใช้งานเครื่องมือสร้างภาพอัตราเฟรม</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>ไม่รองรับ</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>ไม่รองรับ</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>ถอดอุปกรณ์ที่ไม่ได้เชื่อมต่อ</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>ถอดอุปกรณ์ที่ไม่ได้เชื่อมต่อ</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>พบอุปกรณ์ที่ไม่รองรับ</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>พบอุปกรณ์ที่ไม่รองรับ</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>ฟังก์ชั่นรีเลย์</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>ฟังก์ชั่นรีเลย์</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">เตือน</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>ชาร์จเจอร์หรือเครื่องกำเนิดไฟฟ้า เริ่ม/หยุด</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>ชาร์จเจอร์หรือเครื่องกำเนิดไฟฟ้า เริ่ม/หยุด</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">ควบคุมด้วยมือ</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">ฟิวส์ขาด</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>ควบคุมด้วยมือ</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>ควบคุมด้วยมือ</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>เปิดเสมอ (อย่าใช้รีเลย์)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>เปิดเสมอ (อย่าใช้รีเลย์)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>โปรดทราบว่าการเปลี่ยนการตั้งค่าสถานะการชาร์จต่ำจะเปลี่ยนการตั้งค่าการปล่อยประจุ Time-to-go ในเมนูแบตเตอรี่ด้วย</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>โปรดทราบว่าการเปลี่ยนการตั้งค่าสถานะการชาร์จต่ำจะเปลี่ยนการตั้งค่าการปล่อยประจุ Time-to-go ในเมนูแบตเตอรี่ด้วย</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>ฟิวส์ขาด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>ฟิวส์ขาด</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>ไฟ LED แสดงสถานะ</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>ไฟ LED แสดงสถานะ</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">ไม่มี</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>สวิตช์หลัก</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>สวิตช์หลัก</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>เครื่องทำความร้อน</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>เครื่องทำความร้อน</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>พัดลมภายใน</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>พัดลมภายใน</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>สัญลักษณ์เตือน</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>สัญลักษณ์เตือน</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>สัญลักษณ์แจ้งเตือน</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>สัญลักษณ์แจ้งเตือน</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>สวิตช์</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>สวิตช์</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>กำลังเริ่มต้น</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>กำลังเริ่มต้น</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>ปิดตัวลง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>ปิดตัวลง</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>กำลังอัปเดต</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>กำลังอัปเดต</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>กำลังจะทำงาน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>กำลังจะทำงาน</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>การชาร์จล่วงหน้า</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>การชาร์จล่วงหน้า</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>ตรวจสอบคอนแทค</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>ตรวจสอบคอนแทค</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>สถานะของสุขภาพ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>สถานะของสุขภาพ</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>อุณหภูมิแบตเตอรี่</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>อุณหภูมิแบตเตอรี่</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>อุณหภูมิอากาศ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>อุณหภูมิอากาศ</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>แรงดันสตาร์ท</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>แรงดันสตาร์ท</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>แรงดันบัส</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>แรงดันบัส</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>แรงดันไฟฟ้าส่วนบน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>แรงดันไฟฟ้าส่วนบน</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">ข้อผิดพลาดในการสื่อสาร</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">สถานะของสุขภาพ</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">แรงดันบัส</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>แรงดันส่วนล่าง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>แรงดันส่วนล่าง</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>ค่าเบี่ยงเบนจุดกึ่งกลาง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>ค่าเบี่ยงเบนจุดกึ่งกลาง</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>AmpHours ที่ใช้ไป</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>AmpHours ที่ใช้ไป</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>เวลาที่จะทำงาน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>เวลาที่จะทำงาน</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>รายละเอียด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>รายละเอียด</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>สัญญาณเตือนระดับโมดูล</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>สัญญาณเตือนระดับโมดูล</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>การวินิจฉัย</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>การวินิจฉัย</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>ฟิวส์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>ฟิวส์</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>ระบบ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>ระบบ</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>พารามิเตอร์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>พารามิเตอร์</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>ตรวจหาแบตเตอรี่อีกครั้ง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>ตรวจหาแบตเตอรี่อีกครั้ง</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">กดเพื่อตรวจหาอีกครั้ง</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>กดเพื่อตรวจหาอีกครั้ง</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>กดเพื่อตรวจหาอีกครั้ง</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>การตรวจจับแบตเตอรี่อีกครั้งอาจใช้เวลา 60 วินาที ในขณะเดียวกันชื่อของแบตเตอรี่อาจไม่ถูกต้อง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>การตรวจจับแบตเตอรี่อีกครั้งอาจใช้เวลา 60 วินาที ในขณะเดียวกันชื่อของแบตเตอรี่อาจไม่ถูกต้อง</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>กระแสไฟสูง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>กระแสไฟสูง</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>กระแสไฟออกสูง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>กระแสไฟออกสูง</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>SOC ต่ำ</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>SOC ต่ำ</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">แรงดันแบตเตอรี่สูง</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">SOC ต่ำ</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>แรงดันสตาร์ทต่ำ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>แรงดันสตาร์ทต่ำ</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>แรงดันไฟสตาร์ทสูง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>แรงดันไฟสตาร์ทสูง</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>เซ็นเซอร์อุณหภูมิแบตเตอรี่</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>เซ็นเซอร์อุณหภูมิแบตเตอรี่</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>แรงดันไฟฟ้าจุดกึ่งกลาง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>แรงดันไฟฟ้าจุดกึ่งกลาง</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">ฟิวส์ขาด</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>อุณหภูมิภายในสูง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>อุณหภูมิภายในสูง</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>อุณหภูมิการชาร์จต่ำ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>อุณหภูมิการชาร์จต่ำ</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>อุณหภูมิการชาร์จสูง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>อุณหภูมิการชาร์จสูง</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>ความล้มเหลวภายใน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>ความล้มเหลวภายใน</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>เบรกเกอร์ทริป</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>เบรกเกอร์ทริป</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>ความไม่สมดุลของเซลล์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>ความไม่สมดุลของเซลล์</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>แรงดันเซลล์ต่ำ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>แรงดันเซลล์ต่ำ</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>แรงดันเซลล์ต่ำสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>แรงดันเซลล์ต่ำสุด</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>แรงดันเซลล์สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>แรงดันเซลล์สูงสุด</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>อุณหภูมิเซลล์ต่ำสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>อุณหภูมิเซลล์ต่ำสุด</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>อุณหภูมิเซลล์สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>อุณหภูมิเซลล์สูงสุด</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>โมดูลแบตเตอรี่</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>โมดูลแบตเตอรี่</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 ออนไลน์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 ออนไลน์</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 ออฟไลน์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 ออฟไลน์</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>จำนวนโมดูลที่ปิดกั้นการชาร์จ / การคายประจุ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>จำนวนโมดูลที่ปิดกั้นการชาร์จ / การคายประจุ</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>ความจุที่ติดตั้ง / ที่มีจำหน่าย</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>ความจุที่ติดตั้ง / ที่มีจำหน่าย</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>การปลดปล่อยที่ต่ำที่สุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>การปลดปล่อยที่ต่ำที่สุด</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>ออกครั้งสุดท้าย</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>ออกครั้งสุดท้าย</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>การคายประจุเฉลี่ย</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>การคายประจุเฉลี่ย</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>รอบการชาร์จทั้งหมด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>รอบการชาร์จทั้งหมด</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>จำนวนการการคายประจุเต็มที่</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>จำนวนการการคายประจุเต็มที่</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>การคายประจุสะสม Ah</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>การคายประจุสะสม Ah</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>แรงดันเซลล์ขั้นต่ำ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>แรงดันเซลล์ขั้นต่ำ</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>แรงดันเซลล์สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>แรงดันเซลล์สูงสุด</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>เวลาตั้งแต่การชาร์จเต็มครั้งล่าสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>เวลาตั้งแต่การชาร์จเต็มครั้งล่าสุด</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>จำนวนการซิงโครไนซ์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>จำนวนการซิงโครไนซ์</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>สัญญาณเตือนแรงดันไฟฟ้าแบตเตอรี่สตาร์ทต่ำ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>สัญญาณเตือนแรงดันไฟฟ้าแบตเตอรี่สตาร์ทต่ำ</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>แรงดันแบตเตอรี่สตาร์ทขั้นต่ำ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>แรงดันแบตเตอรี่สตาร์ทขั้นต่ำ</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>แรงดันไฟแบตเตอรี่สตาร์ทสูงสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>แรงดันไฟแบตเตอรี่สตาร์ทสูงสุด</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>พลังงานที่ปล่อยออกมา</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>พลังงานที่ปล่อยออกมา</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>ชาร์จพลังงาน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>ชาร์จพลังงาน</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>ขีดจำกัดแรงดันประจุ (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>ขีดจำกัดแรงดันประจุ (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>ขีดจำกัดกระแสไฟ (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>ขีดจำกัดกระแสไฟ (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>ขีด จำกัด การปล่อยกระแสไฟ (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>ขีด จำกัด การปล่อยกระแสไฟ (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>ตัดการเชื่อมต่อแรงดันต่ำ (ละเว้นเสมอ)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>ตัดการเชื่อมต่อแรงดันต่ำ (ละเว้นเสมอ)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>แบตเตอรี่</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>แบตเตอรี่</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>รีเลย์ (บนจอภาพแบตเตอรี่)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>รีเลย์ (บนจอภาพแบตเตอรี่)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>เรียกคืนค่าเริ่มต้นจากโรงงาน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>เรียกคืนค่าเริ่มต้นจากโรงงาน</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>กดเพื่อคืนค่า</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>กดเพื่อคืนค่า</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>คืนค่าเริ่มต้นจากโรงงาน?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>คืนค่าเริ่มต้นจากโรงงาน?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>เปิดใช้งานบลูทูธ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>เปิดใช้งานบลูทูธ</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>แรงดันไฟที่กำหนด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>แรงดันไฟที่กำหนด</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 โวลต์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 โวลต์</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 โวลต์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 โวลต์</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 โวลต์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 โวลต์</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>ความจุ</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>ความจุ</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">ความจุ</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>แรงดันไฟชาร์จ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>แรงดันไฟชาร์จ</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>ปลายกระแส</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>ปลายกระแส</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>ชาร์จเวลาการตรวจจับ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>ชาร์จเวลาการตรวจจับ</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>เลขชี้กำลังเพอเคิร์ต</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>เลขชี้กำลังเพอเคิร์ต</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>ปัจจัยประสิทธิภาพการชาร์จ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>ปัจจัยประสิทธิภาพการชาร์จ</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>เกณฑ์ปัจจุบัน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>เกณฑ์ปัจจุบัน</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>ช่วงเวลาเฉลี่ยที่ต้องเดินทาง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>ช่วงเวลาเฉลี่ยที่ต้องเดินทาง</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>ช่วงเวลาการคายประจุ Time-to-go</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>ช่วงเวลาการคายประจุ Time-to-go</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>ออฟเซ็ตปัจจุบัน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>ออฟเซ็ตปัจจุบัน</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>ซิงโครไนซ์สถานะการชาร์จเป็น 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>ซิงโครไนซ์สถานะการชาร์จเป็น 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>กดเพื่อซิงค์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>กดเพื่อซิงค์</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>ปรับเทียบศูนย์ปัจจุบัน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>ปรับเทียบศูนย์ปัจจุบัน</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>กดเพื่อตั้งค่าเป็น 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>กดเพื่อตั้งค่าเป็น 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>ตัวแทนจำหน่าย %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>ตัวแทนจำหน่าย %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>ไม่มีไฟบนบัสบาร์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>ไม่มีไฟบนบัสบาร์</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">ขาดการเชื่อมต่อ</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n ฟิวส์ขาด</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n ฟิวส์ขาด</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>ไม่มีข้อมูล ดูหน้าก่อนหน้าสำหรับสถานะผู้จัดจำหน่าย</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>ไม่มีข้อมูล ดูหน้าก่อนหน้าสำหรับสถานะผู้จัดจำหน่าย</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>ฟิวส์ %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>ฟิวส์ %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>ไม่ได้ใช้</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>ไม่ได้ใช้</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>เป่า</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>เป่า</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>ปิดระบบเนื่องจากข้อผิดพลาด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>ปิดระบบเนื่องจากข้อผิดพลาด</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">ข้อผิดพลาดล่าสุด</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">ผิดพลาดครั้งที่ 2</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">ผิดพลาดครั้งที่ 3</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">ผิดพลาดครั้งที่ 4</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>สวิตช์ระบบ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>สวิตช์ระบบ</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>รีเลย์ภายนอก</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>รีเลย์ภายนอก</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>โปรแกรมการติดต่อ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>โปรแกรมการติดต่อ</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>แบตเตอรี่</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>แบตเตอรี่</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">ความจุ</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">แบตเตอรี่</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>ขนาน</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>ขนาน</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>ชุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>ชุด</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>แรงดันเซลล์ต่ำสุด/สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>แรงดันเซลล์ต่ำสุด/สูงสุด</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>อุณหภูมิเซลล์ต่ำสุด/สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>อุณหภูมิเซลล์ต่ำสุด/สูงสุด</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">การทรงตัว</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>การทรงตัว</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>การทรงตัว</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">ไม่รู้จัก</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>เอาท์พุต</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>เอาท์พุต</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>การขับเคลื่อน</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>การขับเคลื่อน</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>ความเร็วเครื่องยนต์</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>ความเร็วเครื่องยนต์</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>แรงดัน Aux</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>แรงดัน Aux</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>ไม่มีการแจ้งเตือน</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>ไม่มีการแจ้งเตือน</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>แรงดันต่ำ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>แรงดันต่ำ</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>ไฟฟ้าแรงสูง</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>ไฟฟ้าแรงสูง</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>แรงดันไฟต่ำ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>แรงดันไฟต่ำ</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>แรงดันไฟฟ้า aux สูง</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>แรงดันไฟฟ้า aux สูง</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>สัญญาณเตือนแรงดัน aux ต่ำ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>สัญญาณเตือนแรงดัน aux ต่ำ</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>สัญญาณเตือนแรงดันไฟฟ้า aux สูง</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>สัญญาณเตือนแรงดันไฟฟ้า aux สูง</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>แรงดันไฟฟ้า aux ขั้นต่ำ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>แรงดันไฟฟ้า aux ขั้นต่ำ</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>แรงดันไฟฟ้า aux สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>แรงดันไฟฟ้า aux สูงสุด</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>พลังงานที่ผลิตได้</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>พลังงานที่ผลิตได้</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>ใช้พลังงาน</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>ใช้พลังงาน</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>เปิดใช้งานการเตือน</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>เปิดใช้งานการเตือน</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>ระดับแอคทีฟ</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>ระดับแอคทีฟ</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>คืนค่าระดับ</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>คืนค่าระดับ</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>ล่าช้า</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>ล่าช้า</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>ระดับ</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>ระดับ</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>ที่เหลืออยู่</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>ที่เหลืออยู่</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">แบตเตอรี่เซนเซอร์</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>แบตเตอรี่เซนเซอร์</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>แบตเตอรี่เซนเซอร์</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>ประเภทเซนเซอร์</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>ประเภทเซนเซอร์</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>ค่าเริ่มต้น</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>ค่าเริ่มต้น</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>ยุโรป (0 ถึง 180 โอห์ม)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>ยุโรป (0 ถึง 180 โอห์ม)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>สหรัฐอเมริกา (240 ถึง 30 โอห์ม)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>สหรัฐอเมริกา (240 ถึง 30 โอห์ม)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>กำหนดเอง</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>กำหนดเอง</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">กำหนดเอง</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>ค่าเซ็นเซอร์เมื่อว่างเปล่า</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>ค่าเซ็นเซอร์เมื่อว่างเปล่า</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>ประเภทของเหลว</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>ประเภทของเหลว</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>อัตราส่วนบิวเทน</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>อัตราส่วนบิวเทน</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>รูปร่างที่กำหนดเอง</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>รูปร่างที่กำหนดเอง</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>เวลาเฉลี่ย</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>เวลาเฉลี่ย</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>ค่าเซ็นเซอร์</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>ค่าเซ็นเซอร์</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>ไม่มีการกำหนดรูปร่างที่กำหนดเอง คุณอาจกำหนดหนึ่งรายการได้มากถึงสิบคะแนน โปรดทราบว่า 0% และ 100% เป็นนัย</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>ไม่มีการกำหนดรูปร่างที่กำหนดเอง คุณอาจกำหนดหนึ่งรายการได้มากถึงสิบคะแนน โปรดทราบว่า 0% และ 100% เป็นนัย</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>จุด %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>จุด %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>เพิ่มจุด</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>เพิ่มจุด</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>ระดับเซนเซอร์</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>ระดับเซนเซอร์</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">ปริมาณ</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>ไม่อนุญาตให้ใช้ค่าระดับเซ็นเซอร์ซ้ำกัน</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>ไม่อนุญาตให้ใช้ค่าระดับเซ็นเซอร์ซ้ำกัน</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>ค่าปริมาณจะต้องเพิ่มขึ้น</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>ค่าปริมาณจะต้องเพิ่มขึ้น</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>สุนัขเฝ้าบ้าน</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>สุนัขเฝ้าบ้าน</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>ปลดล็อค (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>ปลดล็อค (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>ปลดล็อค (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>ปลดล็อค (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>ปลดล็อค (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>ปลดล็อค (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>ถูกล็อค</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>ถูกล็อค</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>การกำหนดค่าเฟส</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>การกำหนดค่าเฟส</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>สลับตำแหน่ง</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>สลับตำแหน่ง</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">เฟสเดียว</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2 เฟส</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2 เฟส</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3 เฟส</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3 เฟส</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">อุปกรณ์</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>เครื่องยนต์</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>เครื่องยนต์</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">ความเร็ว</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">โหลด</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>อุณหภูมิน้ำหล่อเย็น</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>อุณหภูมิน้ำหล่อเย็น</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>อุณหภูมิไอเสีย</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>อุณหภูมิไอเสีย</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>อุณหภูมิคดเคี้ยว</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>อุณหภูมิคดเคี้ยว</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>แรงดันแบตเตอรี่สตาร์ท</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>แรงดันแบตเตอรี่สตาร์ท</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>จำนวนการเริ่มต้น</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>จำนวนการเริ่มต้น</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">ตัวควบคุม BMS</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>ล็อคตัวเลือกด้านหน้า (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>ล็อคตัวเลือกด้านหน้า (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>ไม่มีข้อผิดพลาด (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>ไม่มีข้อผิดพลาด (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC Totals</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC Totals</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>พลังงาน L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>พลังงาน L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>ลำดับเฟส</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>ลำดับเฟส</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>เวอร์ชันตัวจัดการข้อมูล</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>เวอร์ชันตัวจัดการข้อมูล</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>กะรัต %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>กะรัต %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">ไม่มี</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>ไฟ LED กะพริบแสดงว่า CT . นี้</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>ไฟ LED กะพริบแสดงว่า CT . นี้</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>อุปกรณ์ Smappee bus</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>อุปกรณ์ Smappee bus</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>PV ชาร์จเจอร์</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>PV ชาร์จเจอร์</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>การตั้งค่านี้จะถูกปิดใช้งานเมื่อเชื่อมต่อ Digital Multi Control</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>การตั้งค่านี้จะถูกปิดใช้งานเมื่อเชื่อมต่อ Digital Multi Control</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>การตั้งค่านี้ถูกปิดใช้งานเมื่อมีการเชื่อมต่อ VE.Bus BMS</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>การตั้งค่านี้ถูกปิดใช้งานเมื่อมีการเชื่อมต่อ VE.Bus BMS</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>ไฟฟ้ากระแสสลับใน %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>ไฟฟ้ากระแสสลับใน %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>กระแสตรง</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>กระแสตรง</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>คว่ำ</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>คว่ำ</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">เปิดใช้งานการเตือน</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">คว่ำ</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>สลับตรรกะการเตือน</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>สลับตรรกะการเตือน</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>รังสี</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>รังสี</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>อุณหภูมิเซลล์</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>อุณหภูมิเซลล์</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>อุณหภูมิภายนอก (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>อุณหภูมิภายนอก (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>อุณหภูมิภายนอก</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>อุณหภูมิภายนอก</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>อุณหภูมิภายนอก (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>อุณหภูมิภายนอก (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>ความเร็วลม</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>ความเร็วลม</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>ตรวจจับอัตโนมัติ</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>ตรวจจับอัตโนมัติ</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>เซ็นเซอร์ความเร็วลม</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>เซ็นเซอร์ความเร็วลม</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>เซ็นเซอร์อุณหภูมิภายนอก</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>เซ็นเซอร์อุณหภูมิภายนอก</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>รวม</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>รวม</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>ตัวคูณ</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>ตัวคูณ</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>รีเซ็ตตัวนับ</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>รีเซ็ตตัวนับ</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">ลัดวงจร</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">ขั้วย้อนกลับ</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>เซ็นเซอร์แบตเตอรี่ต่ำ</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>เซ็นเซอร์แบตเตอรี่ต่ำ</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>ความชื้น</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>ความชื้น</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>ความกดดัน</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>ความกดดัน</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">ต่ำ</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>ออฟเซ็ต</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>ออฟเซ็ต</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>มาตราส่วน</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>มาตราส่วน</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>แรงดันเซ็นเซอร์</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>แรงดันเซ็นเซอร์</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>พลัง PV ทั้งหมด</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>พลัง PV ทั้งหมด</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>หน้าสินค้า</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>หน้าสินค้า</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>เซ็นเซอร์ไฟฟ้ากระแสสลับ %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>เซ็นเซอร์ไฟฟ้ากระแสสลับ %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>มี MK3 เวอร์ชันใหม่ให้บริการแล้ว
+        <translation>มี MK3 เวอร์ชันใหม่ให้บริการแล้ว
 หมายเหตุ: การอัพเดตอาจทำให้ระบบหยุดชั่วคราว</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>อัพเดต MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>อัพเดต MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>กดเพื่ออัพเดต</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>กดเพื่ออัพเดต</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>การอัปเดต MK3 ค่าต่างๆ จะปรากฏขึ้นอีกครั้งหลังจากการอัปเดตเสร็จสิ้น</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>การอัปเดต MK3 ค่าต่างๆ จะปรากฏขึ้นอีกครั้งหลังจากการอัปเดตเสร็จสิ้น</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">ชาร์จแบตเตอรี่ให้เต็ม 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>ชาร์จแบตเตอรี่ให้เต็ม 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>ชาร์จแบตเตอรี่ให้เต็ม 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">ขั้นสูง</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>กำลังดำเนินการ</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>กำลังดำเนินการ</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>กดเพื่อหยุด</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>กดเพื่อหยุด</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>กดเพื่อเริ่ม</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>กดเพื่อเริ่ม</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>ชาร์จแบตเตอรี่ให้เต็ม 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>ชาร์จแบตเตอรี่ให้เต็ม 100%</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>ระบบจะกลับสู่การทำงานปกติโดยให้ความสำคัญกับพลังงานทดแทน
+        <translation>ระบบจะกลับสู่การทำงานปกติโดยให้ความสำคัญกับพลังงานทดแทน
 คุณต้องการดำเนินการต่อหรือไม่?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>ไฟฟ้าริมฝั่งจะถูกใช้เมื่อมี และตัวเลือก "ลำดับความสำคัญของแสงอาทิตย์และลม" จะถูกละเว้น
+        <translation>ไฟฟ้าริมฝั่งจะถูกใช้เมื่อมี และตัวเลือก &quot;ลำดับความสำคัญของแสงอาทิตย์และลม&quot; จะถูกละเว้น
 คุณต้องการดำเนินการต่อหรือไม่?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>พลังงานฝั่งจะถูกใช้เพื่อชาร์จแบตเตอรี่ให้เต็มหนึ่งครั้ง
+        <translation>พลังงานฝั่งจะถูกใช้เพื่อชาร์จแบตเตอรี่ให้เต็มหนึ่งครั้ง
 หลังจากกระบวนการชาร์จเสร็จสิ้น ระบบจะกลับสู่การทำงานปกติ โดยให้ความสำคัญกับพลังงานแสงอาทิตย์และพลังงานลมเป็นหลัก
 คุณต้องการดำเนินการต่อหรือไม่?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>แรงดันไฟตรง</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>แรงดันไฟตรง</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>กระแสตรง</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>กระแสตรง</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>ขั้นสูง</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>ขั้นสูง</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>ตั้งปลุก</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>ตั้งปลุก</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>VE.Bus BMS จะปิดระบบโดยอัตโนมัติเมื่อจำเป็นเพื่อปกป้องแบตเตอรี่ จึงไม่สามารถควบคุมระบบของตัวควบคุมได้</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>VE.Bus BMS จะปิดระบบโดยอัตโนมัติเมื่อจำเป็นเพื่อปกป้องแบตเตอรี่ จึงไม่สามารถควบคุมระบบของตัวควบคุมได้</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>มีการติดตั้งผู้ช่วย BMS ที่ได้รับการกำหนดค่าสำหรับ VE.Bus BMS แต่ไม่พบ VE.Bus BMS!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>มีการติดตั้งผู้ช่วย BMS ที่ได้รับการกำหนดค่าสำหรับ VE.Bus BMS แต่ไม่พบ VE.Bus BMS!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>คำเตือน: การเปิดใช้งานอีควอไลเซอร์ในระบบ ESS ด้วยเครื่องชาร์จพลังงานแสงอาทิตย์อาจทำให้การชาร์จแบตเตอรี่ด้วยไฟฟ้าแรงสูงร่วมกับกระแสไฟฟ้าที่สูงเกินไป</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>คำเตือน: การเปิดใช้งานอีควอไลเซอร์ในระบบ ESS ด้วยเครื่องชาร์จพลังงานแสงอาทิตย์อาจทำให้การชาร์จแบตเตอรี่ด้วยไฟฟ้าแรงสูงร่วมกับกระแสไฟฟ้าที่สูงเกินไป</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>ระบบจะสลับไปลอยตัวโดยอัตโนมัติเมื่อการชาร์จ Equalization เสร็จสิ้น</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>ระบบจะสลับไปลอยตัวโดยอัตโนมัติเมื่อการชาร์จ Equalization เสร็จสิ้น</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>ขัดจังหวะอีควอไลเซอร์</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>ขัดจังหวะอีควอไลเซอร์</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>อีควอไลเซอร์</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>อีควอไลเซอร์</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>รบกวน...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>รบกวน...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>เริ่ม...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>เริ่ม...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">เริ่ม...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>กดเพื่อขัดจังหวะ</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>กดเพื่อขัดจังหวะ</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>แทรกแซงและเริ่มการดูดซึมใหม่</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>แทรกแซงและเริ่มการดูดซึมใหม่</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>แทรกแซงแล้วลอย</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>แทรกแซงแล้วลอย</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>ขัดจังหวะ</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>ขัดจังหวะ</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>อย่าขัดจังหวะ</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>อย่าขัดจังหวะ</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>ตรวจสอบระบบ VE.Bus อีกครั้ง</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>ตรวจสอบระบบ VE.Bus อีกครั้ง</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>กำลังตรวจหาซ้ำ...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>กำลังตรวจหาซ้ำ...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>รีสตาร์ทระบบ VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>รีสตาร์ทระบบ VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>กำลังรีสตาร์ท...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>กำลังรีสตาร์ท...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>กดเพื่อเริ่มต้นใหม่</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>กดเพื่อเริ่มต้นใหม่</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>อินพุต AC 1 ถูกละเว้น</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>อินพุต AC 1 ถูกละเว้น</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>อินพุต AC 2 ถูกละเว้น</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>อินพุต AC 2 ถูกละเว้น</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>การทดสอบรีเลย์ ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>การทดสอบรีเลย์ ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">สมบูรณ์</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">รอดำเนินการ</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>สมบูรณ์</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>สมบูรณ์</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>รอดำเนินการ</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>รอดำเนินการ</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>การวินิจฉัย VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>การวินิจฉัย VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>ตัวนับคุณภาพเครือข่ายเฟส L%1 อุปกรณ์ %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>ตัวนับคุณภาพเครือข่ายเฟส L%1 อุปกรณ์ %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>รายงานข้อผิดพลาด VE.Bus 8/11</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>รายงานข้อผิดพลาด VE.Bus 8/11</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>การแจ้งเตือนเท่านั้น</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>การแจ้งเตือนเท่านั้น</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>การแจ้งเตือนและคำเตือน</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>การแจ้งเตือนและคำเตือน</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>ข้อผิดพลาด BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>ข้อผิดพลาด BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>หมายเลขซีเรียล</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>หมายเลขซีเรียล</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>รายงานข้อผิดพลาด VE.Bus 11 ล่าสุด #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>รายงานข้อผิดพลาด VE.Bus 11 ล่าสุด #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>อยู่ระหว่างการทดสอบความปลอดภัยของ BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>อยู่ระหว่างการทดสอบความปลอดภัยของ BF</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>การทดสอบความปลอดภัยของ BF ตกลง</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>การทดสอบความปลอดภัยของ BF ตกลง</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>AC0 /AC1 ไม่ตรงกัน</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>AC0 /AC1 ไม่ตรงกัน</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>ข้อผิดพลาดในการสื่อสาร</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>ข้อผิดพลาดในการสื่อสาร</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>ข้อผิดพลาดรีเลย์ GND</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>ข้อผิดพลาดรีเลย์ GND</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>UMains ไม่ตรงกัน</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>UMains ไม่ตรงกัน</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>ระยะเวลาไม่ตรงกัน</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>ระยะเวลาไม่ตรงกัน</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>ไดรฟ์ของรีเลย์ BF ไม่ตรงกัน</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>ไดรฟ์ของรีเลย์ BF ไม่ตรงกัน</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>ข้อผิดพลาด: PE2 เปิดอยู่</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>ข้อผิดพลาด: PE2 เปิดอยู่</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>ข้อผิดพลาด: PE2 ปิดแล้ว</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>ข้อผิดพลาด: PE2 ปิดแล้ว</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>ขั้นตอนที่ล้มเหลว: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>ขั้นตอนที่ล้มเหลว: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>เฟส L%1 อุปกรณ์ %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>เฟส L%1 อุปกรณ์ %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>การรายงานข้อผิดพลาด VE.Bus 11 ต้องใช้เฟิร์มแวร์ VE.Bus เวอร์ชัน 454 เป็นขั้นต่ำ</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>การรายงานข้อผิดพลาด VE.Bus 11 ต้องใช้เฟิร์มแวร์ VE.Bus เวอร์ชัน 454 เป็นขั้นต่ำ</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus อย่างฉับพลัน</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus อย่างฉับพลัน</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>พลังงาน</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>พลังงาน</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>พลังงาน</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>พลังงาน</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>แรงดันไฟฟ้า</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>แรงดันไฟฟ้า</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>หมุนเวียน</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>หมุนเวียน</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>ที่ตั้ง</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>ที่ตั้ง</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>เฟส</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>เฟส</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>อินพุต AC ที่ใช้งานอยู่</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>อินพุต AC ที่ใช้งานอยู่</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>ระลอกคลื่น DC สูง</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>ระลอกคลื่น DC สูง</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>ไฟฟ้ากระแสตรงสูง</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>ไฟฟ้ากระแสตรงสูง</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>กระแสตรงสูง</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>กระแสตรงสูง</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>ข้อผิดพลาดในการวัดอุณหภูมิ</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>ข้อผิดพลาดในการวัดอุณหภูมิ</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>ข้อผิดพลาดในการรับรู้แรงดันไฟฟ้า</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>ข้อผิดพลาดในการรับรู้แรงดันไฟฟ้า</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>โอเวอร์โหลด</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>โอเวอร์โหลด</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>ระลอกคลื่นกระแสตรง</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>ระลอกคลื่นกระแสตรง</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>เซ็นเซอร์แรงดันไฟฟ้า</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>เซ็นเซอร์แรงดันไฟฟ้า</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">การหมุนเฟส</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>การหมุนเฟส</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>การหมุนเฟส</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>เวอร์ชั่น VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>เวอร์ชั่น VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>อุปกรณ์ MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>อุปกรณ์ MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>เวอร์ชั่น MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>เวอร์ชั่น MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>เวอร์ชันควบคุมหลายตัว</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>เวอร์ชันควบคุมหลายตัว</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>เวอร์ชัน VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>เวอร์ชัน VE.Bus BMS</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>เว้นแต่กริดจะล้มเหลว</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>เว้นแต่กริดจะล้มเหลว</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>เอซี อิน</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>เอซี อิน</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>อินพุต AC</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>อินพุต AC</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>อินพุต AC 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>อินพุต AC 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>อินพุต AC 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>อินพุต AC 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>หน้าที่</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>หน้าที่</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>โหลดไฟฟ้ากระแสสลับ</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>โหลดไฟฟ้ากระแสสลับ</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>แอร์ออก</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>แอร์ออก</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>เอาต์พุต AC</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>เอาต์พุต AC</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>เฟส AC L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>เฟส AC L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>เซ็นเซอร์เอซี %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>เซ็นเซอร์เอซี %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>เซ็นเซอร์เอซี</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>เซ็นเซอร์เอซี</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>คล่องแคล่ว</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>คล่องแคล่ว</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">เตือน</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">โอเวอร์โหลด</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>สถานะนาฬิกาปลุก</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>สถานะนาฬิกาปลุก</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>นาฬิกาปลุก</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>นาฬิกาปลุก</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>อนุญาตให้ชาร์จ</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>อนุญาตให้ชาร์จ</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>ปล่อยวาง</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>ปล่อยวาง</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>การสแกนอัตโนมัติ</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>การสแกนอัตโนมัติ</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>แบตเตอรี่</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>แบตเตอรี่</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>กระแสไฟแบตเตอรี่</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>กระแสไฟแบตเตอรี่</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>แรงดันแบตเตอรี่</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>แรงดันแบตเตอรี่</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>กระแสไฟชาร์จ</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>กระแสไฟชาร์จ</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>กำลังชาร์จ</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>กำลังชาร์จ</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>ล้างข้อผิดพลาด</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>ล้างข้อผิดพลาด</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>ปิด</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>ปิด</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>เชื่อมต่อแล้ว</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>เชื่อมต่อแล้ว</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>หมุนเวียน</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>หมุนเวียน</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>หม้อแปลงกระแส</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>หม้อแปลงกระแส</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>ชื่อกำหนดเอง</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>ชื่อกำหนดเอง</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>แก้ไขข้อบกพร่อง</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>แก้ไขข้อบกพร่อง</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>อุปกรณ์</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>อุปกรณ์</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">พิการ</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>การคายประจุ</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>การคายประจุ</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>ตัดการเชื่อมต่อ</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>ตัดการเชื่อมต่อ</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>เปิดใช้งาน</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>เปิดใช้งาน</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>เปิดใช้งาน</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>เปิดใช้งาน</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>พลังงาน</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>พลังงาน</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>ข้อผิดพลาด</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>ข้อผิดพลาด</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>ข้อผิดพลาด:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>ข้อผิดพลาด:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>รหัสข้อผิดพลาด</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>รหัสข้อผิดพลาด</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>เวอร์ชั่นเฟิร์มแวร์</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>เวอร์ชั่นเฟิร์มแวร์</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>เครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>เครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>อุณหภูมิแบตเตอรี่สูง</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>อุณหภูมิแบตเตอรี่สูง</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>สัญญาณเตือนระดับสูง</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>สัญญาณเตือนระดับสูง</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>แรงดันแบตเตอรี่สตาร์ทสูง</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>แรงดันแบตเตอรี่สตาร์ทสูง</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>อุณหภูมิสูง</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>อุณหภูมิสูง</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>สัญญาณเตือนไฟฟ้าแรงสูง</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>สัญญาณเตือนไฟฟ้าแรงสูง</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>ประวัติศาสตร์</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>ประวัติศาสตร์</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 ชั่วโมง</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 ชั่วโมง</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>ว่าง</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>ว่าง</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>ไม่ใช้งาน</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>ไม่ใช้งาน</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">อินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>ที่อยู่ IP</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>ที่อยู่ IP</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>อุณหภูมิแบตเตอรี่ต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>อุณหภูมิแบตเตอรี่ต่ำ</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>สัญญาณเตือนระดับต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>สัญญาณเตือนระดับต่ำ</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>แรงดันแบตเตอรี่สตาร์ทต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>แรงดันแบตเตอรี่สตาร์ทต่ำ</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>สถานะการชาร์จต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>สถานะการชาร์จต่ำ</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>อุณหภูมิต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>อุณหภูมิต่ำ</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>สัญญาณเตือนแรงดันต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>สัญญาณเตือนแรงดันต่ำ</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>ผู้ผลิต</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>ผู้ผลิต</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>อุณหภูมิสูงสุด</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>อุณหภูมิสูงสุด</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>แรงดันไฟฟ้าสูงสุด</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>แรงดันไฟฟ้าสูงสุด</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>อุณหภูมิต่ำสุด</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>อุณหภูมิต่ำสุด</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>แรงดันไฟฟ้าขั้นต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>แรงดันไฟฟ้าขั้นต่ำ</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>โหมด</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>โหมด</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>ชื่อรุ่น</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>ชื่อรุ่น</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>ไม่</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>ไม่</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>ไม่ว่าง</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>ไม่ว่าง</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>ไม่ได้เชื่อมต่อ</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>ไม่ได้เชื่อมต่อ</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>ออฟไลน์</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>ออฟไลน์</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>ตกลง</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>ตกลง</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>เปิด</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>เปิด</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>ออนไลน์</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>ออนไลน์</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>เปิด</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>เปิด</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>รหัสผ่าน</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>รหัสผ่าน</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>เฟส</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>เฟส</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>กดเพื่อล้าง</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>กดเพื่อล้าง</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>กดเพื่อรีเซ็ต</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>กดเพื่อรีเซ็ต</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>กดเพื่อสแกน</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>กดเพื่อสแกน</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>PV อินเวอร์เตอร์</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>PV อินเวอร์เตอร์</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>พีวี พาวเวอร์</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>พีวี พาวเวอร์</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>ชั่วโมงที่เงียบสงบ</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>ชั่วโมงที่เงียบสงบ</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>รีเลย์</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>รีเลย์</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>รีบูต</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>รีบูต</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>ลบ</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>ลบ</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>ทำงาน</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>ทำงาน</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>กำลังสแกน %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>กำลังสแกน %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>หมายเลขซีเรียล</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>หมายเลขซีเรียล</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>การตั้งค่า</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>การตั้งค่า</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>ติดตั้ง</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>ติดตั้ง</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>ความแรงของสัญญาณ</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>ความแรงของสัญญาณ</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>สแตนด์บาย</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>สแตนด์บาย</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>เริ่มเมื่อถึงเงื่อนไขสำหรับ</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>เริ่มเมื่อถึงเงื่อนไขสำหรับ</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>เวลาเริ่มต้น</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>เวลาเริ่มต้น</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>มูลค่าเริ่มต้นในช่วงเวลาที่เงียบสงบ</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>มูลค่าเริ่มต้นในช่วงเวลาที่เงียบสงบ</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>เริ่มเมื่อมีการเตือนสำหรับ</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>เริ่มเมื่อมีการเตือนสำหรับ</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>สถานะของค่าใช้จ่าย</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>สถานะของค่าใช้จ่าย</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>สถานะ</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>สถานะ</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>การเริ่มต้น (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>การเริ่มต้น (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>ค่าหยุดในช่วงเวลาที่เงียบสงบ</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>ค่าหยุดในช่วงเวลาที่เงียบสงบ</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>หยุดเมื่อถึงเงื่อนไขสำหรับ</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>หยุดเมื่อถึงเงื่อนไขสำหรับ</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>หยุด</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>หยุด</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>อุณหภูมิ</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>อุณหภูมิ</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>เซ็นเซอร์อุณหภูมิ</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>เซ็นเซอร์อุณหภูมิ</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>วันนี้</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>วันนี้</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>ทั้งหมด</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>ทั้งหมด</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>ตัวติดตาม</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>ตัวติดตาม</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>พิมพ์</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>พิมพ์</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>หมายเลขประจำตัวที่ไม่ซ้ำกัน</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>หมายเลขประจำตัวที่ไม่ซ้ำกัน</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>ไม่รู้จัก</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>ไม่รู้จัก</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>ข้อผิดพลาดของ VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>ข้อผิดพลาดของ VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>แรงดันไฟฟ้า</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>แรงดันไฟฟ้า</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>อินสแตนซ์ VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>อินสแตนซ์ VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>ให้หยุดหลังจากคำเตือนถูกลบออก</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>ให้หยุดหลังจากคำเตือนถูกลบออก</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>ใช่</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>ใช่</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>เมื่อวาน</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>เมื่อวาน</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>ผลผลิต</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>ผลผลิต</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>จำกัดการป้อนพลังงานเข้าเป็นศูนย์</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>จำกัดการป้อนพลังงานเข้าเป็นศูนย์</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>ตั้งวันที่</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>ตั้งวันที่</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>เริ่มเลย</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>เริ่มเลย</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>วิ่งตามกำหนดเวลา</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>วิ่งตามกำหนดเวลา</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>หยุดเดี๋ยวนี้</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>หยุดเดี๋ยวนี้</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>เวลาทำงานทั้งหมด</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>เวลาทำงานทั้งหมด</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>ตั้งเวลา %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>ตั้งเวลา %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>เครื่องกำเนิดไฟฟ้าจะทำงานต่อไปหากตรงตามเงื่อนไขการสตาร์ทอัตโนมัติ</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>เครื่องกำเนิดไฟฟ้าจะทำงานต่อไปหากตรงตามเงื่อนไขการสตาร์ทอัตโนมัติ</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>โหมดอินเวอร์เตอร์/เครื่องชาร์จ</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>โหมดอินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>ชุด</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>ชุด</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>ยกเลิก</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>ยกเลิก</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>ปิด</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>ปิด</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>ตั้งเวลา</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>ตั้งเวลา</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>พร้อมใช้งาน</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>พร้อมใช้งาน</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>ข้อผิดพลาดในการแลกเปลี่ยน</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>ข้อผิดพลาดในการแลกเปลี่ยน</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>สลับเรียบร้อยแล้ว</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>สลับเรียบร้อยแล้ว</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>กำลังสลับอินสแตนซ์อุปกรณ์...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>กำลังสลับอินสแตนซ์อุปกรณ์...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>อินสแตนซ์อุปกรณ์ %1 ถูกใช้โดย '%3' แล้ว สลับอินสแตนซ์ของอุปกรณ์และกำหนดสิ่งนั้นให้กับ %2 หรือไม่</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>อินสแตนซ์อุปกรณ์ %1 ถูกใช้โดย &apos;%3&apos; แล้ว สลับอินสแตนซ์ของอุปกรณ์และกำหนดสิ่งนั้นให้กับ %2 หรือไม่</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>อินสแตนซ์อุปกรณ์ %1 ถูกใช้โดยอุปกรณ์อื่นที่เป็นประเภทเดียวกันแล้ว สลับอินสแตนซ์ของอุปกรณ์และกำหนดสิ่งนั้นให้กับ %2 หรือไม่</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>อินสแตนซ์อุปกรณ์ %1 ถูกใช้โดยอุปกรณ์อื่นที่เป็นประเภทเดียวกันแล้ว สลับอินสแตนซ์ของอุปกรณ์และกำหนดสิ่งนั้นให้กับ %2 หรือไม่</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>ไม่สามารถสลับอินสแตนซ์ของอุปกรณ์ได้: การดำเนินการหมดเวลา</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>ไม่สามารถสลับอินสแตนซ์ของอุปกรณ์ได้: การดำเนินการหมดเวลา</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>อินสแตนซ์อุปกรณ์ใหม่จะทำงานเมื่อรีบูต</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>อินสแตนซ์อุปกรณ์ใหม่จะทำงานเมื่อรีบูต</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>แลกเปลี่ยน</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>แลกเปลี่ยน</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>เกิดข้อผิดพลาดขณะตรวจสอบการอัปเดตเฟิร์มแวร์</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>เกิดข้อผิดพลาดขณะตรวจสอบการอัปเดตเฟิร์มแวร์</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>กำลังดาวน์โหลดและติดตั้งเฟิร์มแวร์ %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>กำลังดาวน์โหลดและติดตั้งเฟิร์มแวร์ %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>กำลังติดตั้งเฟิร์มแวร์...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>กำลังติดตั้งเฟิร์มแวร์...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>เกิดข้อผิดพลาดระหว่างการติดตั้งเฟิร์มแวร์</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>เกิดข้อผิดพลาดระหว่างการติดตั้งเฟิร์มแวร์</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>ไม่มีเวอร์ชันใหม่กว่าที่มีอยู่</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>ไม่มีเวอร์ชันใหม่กว่าที่มีอยู่</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>ไม่พบเฟิร์มแวร์</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>ไม่พบเฟิร์มแวร์</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>เชื้อเพลิง</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>เชื้อเพลิง</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>น้ำจืด</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>น้ำจืด</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>น้ำเสีย</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>น้ำเสีย</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>อยู่ดีมีสุข</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>อยู่ดีมีสุข</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>น้ำมัน</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>น้ำมัน</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>น้ำดำ</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>น้ำดำ</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>น้ำมันเบนซิน</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>น้ำมันเบนซิน</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>ดีเซล</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>ดีเซล</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>แอลพีจี</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>แอลพีจี</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>น้ำมันไฮดรอลิก</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>น้ำมันไฮดรอลิก</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>น้ำดิบ</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>น้ำดิบ</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>การตั้งค่าถูกล็อคสำหรับระดับการเข้าถึง</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>การตั้งค่าถูกล็อคสำหรับระดับการเข้าถึง</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>รหัสผ่านผิด</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>รหัสผ่านผิด</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>รวบรัด</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>รวบรัด</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>ภาพรวม</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>ภาพรวม</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>ระดับ</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>ระดับ</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>การแจ้งเตือน</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>การแจ้งเตือน</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>ตอนนี้</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>ตอนนี้</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1 นาทีที่แล้ว</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1 นาทีที่แล้ว</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1 ชม. %2 นาทีที่แล้ว</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1 ชม. %2 นาทีที่แล้ว</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>ทุกวัน</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>ทุกวัน</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>วันธรรมดา</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>วันธรรมดา</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>วันหยุดสุดสัปดาห์</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>วันหยุดสุดสัปดาห์</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>วันจันทร์</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>วันจันทร์</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>วันอังคาร</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>วันอังคาร</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>วันพุธ</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>วันพุธ</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>วันพฤหัสบดี</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>วันพฤหัสบดี</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>วันศุกร์</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>วันศุกร์</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>วันเสาร์</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>วันเสาร์</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>วันอาทิตย์</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>วันอาทิตย์</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 หรือ %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 หรือ %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>กำหนดการ %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>กำหนดการ %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>วัน</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>วัน</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>ไม่ได้ตั้งค่า</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>ไม่ได้ตั้งค่า</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>ขีดจำกัด SOC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>ขีดจำกัด SOC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>การใช้งานเกินขีดจำกัด</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>การใช้งานเกินขีดจำกัด</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>เซลล์แสงอาทิตย์และแบตเตอรี่</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>เซลล์แสงอาทิตย์และแบตเตอรี่</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>กำลังตรวจสอบ...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>กำลังตรวจสอบ...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>สถานะปลุก</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>สถานะปลุก</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">เตือน</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>ล้างประวัติ</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>ล้างประวัติ</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>สำนักหักบัญชี</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>สำนักหักบัญชี</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>เปิดการบังคับ</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>เปิดการบังคับ</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>โดนบังคับ</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>โดนบังคับ</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>สถานะรีเลย์</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>สถานะรีเลย์</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>รีเซ็ตประวัติบนจอภาพเอง</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>รีเซ็ตประวัติบนจอภาพเอง</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>กดเพื่อนำออก</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>กดเพื่อนำออก</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>กำลังนำออก โปรดรอสักครู่</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>กำลังนำออก โปรดรอสักครู่</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>ไม่พบที่เก็บข้อมูล</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>ไม่พบที่เก็บข้อมูล</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>เซ็นเซอร์อุณหภูมิ %1</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>เซ็นเซอร์อุณหภูมิ %1</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 เซ็นเซอร์อุณหภูมิ (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 เซ็นเซอร์อุณหภูมิ (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>เซ็นเซอร์อุณหภูมิ (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>เซ็นเซอร์อุณหภูมิ (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>ไม่มีการดำเนินการ</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>ไม่มีการดำเนินการ</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>คำเตือน: อุณหภูมิการเปิดใช้งานและปิดใช้งานถูกตั้งค่าเป็นค่าเดียวกัน สิ่งนี้จะทำให้เงื่อนไขถูกละเลย</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>คำเตือน: อุณหภูมิการเปิดใช้งานและปิดใช้งานถูกตั้งค่าเป็นค่าเดียวกัน สิ่งนี้จะทำให้เงื่อนไขถูกละเลย</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>เงื่อนไข %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>เงื่อนไข %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>ปิดใช้งานฟังก์ชัน</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>ปิดใช้งานฟังก์ชัน</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>ไม่มี (ปิดการใช้งาน)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>ไม่มี (ปิดการใช้งาน)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>รีเลย์ 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>รีเลย์ 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>รีเลย์ 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>รีเลย์ 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>คำเตือน: ไม่ได้กำหนดค่ารีเลย์ที่เลือกไว้ด้านบนสำหรับอุณหภูมิ เงื่อนไขนี้จะถูกละเว้น</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>คำเตือน: ไม่ได้กำหนดค่ารีเลย์ที่เลือกไว้ด้านบนสำหรับอุณหภูมิ เงื่อนไขนี้จะถูกละเว้น</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>ค่าการเปิดใช้งาน</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>ค่าการเปิดใช้งาน</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>หน่วยระดับเสียง</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>หน่วยระดับเสียง</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>ลูกบาศก์เมตร</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>ลูกบาศก์เมตร</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>ลิตร</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>ลิตร</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>แกลลอน (สหรัฐฯ)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>แกลลอน (สหรัฐฯ)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>แกลลอน (อิมพีเรียล)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>แกลลอน (อิมพีเรียล)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>แรงดันไฟฟ้าขั้นต่ำ</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>แรงดันไฟฟ้าขั้นต่ำ</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>แรงดันไฟฟ้าสูงสุด</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>แรงดันไฟฟ้าสูงสุด</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">แรงดันไฟฟ้าสูงสุด</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>กระแสสูงสุด</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>กระแสสูงสุด</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>เวลาชาร์จ</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>เวลาชาร์จ</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">จำนวนมาก</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">ลอย</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">ชม</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>จำนวนมาก</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>จำนวนมาก</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>หน้าท้อง</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>หน้าท้อง</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>ลอย</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>ลอย</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>ชม</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>ชม</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>เกิดข้อผิดพลาด %1 รายการ</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>เกิดข้อผิดพลาด %1 รายการ</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>โหลด</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>โหลด</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>ที่ 2 สุดท้าย</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>ที่ 2 สุดท้าย</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>ที่ 3 สุดท้าย</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>ที่ 3 สุดท้าย</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>ที่ 4 สุดท้าย</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>ที่ 4 สุดท้าย</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>พลังสูงสุด</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>พลังสูงสุด</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>ไม่สามารถเชื่อมต่อ</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>ไม่สามารถเชื่อมต่อ</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>ถูกตัดการเชื่อมต่อ กำลังพยายามเชื่อมต่อใหม่</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>ถูกตัดการเชื่อมต่อ กำลังพยายามเชื่อมต่อใหม่</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>กำลังเชื่อมต่อ</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>กำลังเชื่อมต่อ</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">กำลังเชื่อมต่อ</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>เชื่อมต่อแล้ว กำลังรอข้อความจากนายหน้า</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>เชื่อมต่อแล้ว กำลังรอข้อความจากนายหน้า</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>เชื่อมต่อแล้ว กำลังรับข้อความจากนายหน้า</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>เชื่อมต่อแล้ว กำลังรับข้อความจากนายหน้า</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>เชื่อมต่อแล้ว กำลังโหลดส่วนติดต่อผู้ใช้</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>เชื่อมต่อแล้ว กำลังโหลดส่วนติดต่อผู้ใช้</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>เวอร์ชันโปรโตคอลไม่ถูกต้อง</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>เวอร์ชันโปรโตคอลไม่ถูกต้อง</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>รหัสลูกค้าถูกปฏิเสธ</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>รหัสลูกค้าถูกปฏิเสธ</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>ไม่มีบริการนายหน้า</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>ไม่มีบริการนายหน้า</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>ลูกค้าไม่ได้รับอนุญาต</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>ลูกค้าไม่ได้รับอนุญาต</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>ข้อผิดพลาดในการเชื่อมต่อการขนส่ง</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>ข้อผิดพลาดในการเชื่อมต่อการขนส่ง</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>ข้อผิดพลาดการละเมิดโปรโตคอล</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>ข้อผิดพลาดการละเมิดโปรโตคอล</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>ข้อผิดพลาดของโปรโตคอล MQTT ระดับ 5</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>ข้อผิดพลาดของโปรโตคอล MQTT ระดับ 5</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>ปลุกเงียบ</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>ปลุกเงียบ</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>พลังทั้งหมด</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>พลังทั้งหมด</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>นาที</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>นาที</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1d %2h</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1d %2h</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1m %2s</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1m %2s</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1m</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1m</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1s</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1s</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>ความล้มเหลว</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>ความล้มเหลว</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>กำลังเรียกที่อยู่ IP</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>กำลังเรียกที่อยู่ IP</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">เชื่อมต่อแล้ว</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>ตัดการเชื่อมต่อ</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>ตัดการเชื่อมต่อ</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">ตัดการเชื่อมต่อ</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>โหลด AC</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>โหลด AC</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>โหลดไฟฟ้ากระแสตรง</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>โหลดไฟฟ้ากระแสตรง</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>อีวีซีเอส</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>อีวีซีเอส</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>ลม</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>ลม</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>ชายฝั่ง</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>ชายฝั่ง</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>ขีด จำกัด ปัจจุบันของกริด</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>ขีด จำกัด ปัจจุบันของกริด</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>ขีด จำกัด กระแสไฟของเครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>ขีด จำกัด กระแสไฟของเครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>ขีดจำกัดกระแสฝั่ง</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>ขีดจำกัดกระแสฝั่ง</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">หยุด</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>หยุด</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>หยุด</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 ไปแล้ว</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 ไปแล้ว</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 รถถัง (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 รถถัง (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>เครื่องชาร์จไฟฟ้ากระแสสลับ</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>เครื่องชาร์จไฟฟ้ากระแสสลับ</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>เครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>เครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>เครื่องชาร์จไฟฟ้ากระแสตรง</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>เครื่องชาร์จไฟฟ้ากระแสตรง</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>เครื่องกำเนิดไฟฟ้ากระแสตรง</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>เครื่องกำเนิดไฟฟ้ากระแสตรง</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>ระบบ DC</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>ระบบ DC</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>เซลล์เชื้อเพลิง</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>เซลล์เชื้อเพลิง</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>เครื่องกำเนิดเพลา</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>เครื่องกำเนิดเพลา</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>เครื่องกำเนิดน้ำ</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>เครื่องกำเนิดน้ำ</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>ที่ชาร์จลม</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>ที่ชาร์จลม</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>ต่ำ</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>ต่ำ</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>สูง</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>สูง</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>เก็บแบตเตอรี่ไว้</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>เก็บแบตเตอรี่ไว้</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>ปรับให้เหมาะสมด้วยอายุการใช้งานแบตเตอรี่</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>ปรับให้เหมาะสมด้วยอายุการใช้งานแบตเตอรี่</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>ปรับให้เหมาะสมโดยไม่ต้องใช้แบตเตอรี่</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>ปรับให้เหมาะสมโดยไม่ต้องใช้แบตเตอรี่</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">การควบคุมภายนอก</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>ถูกชาร์จ</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>ถูกชาร์จ</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>รอพระอาทิตย์</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>รอพระอาทิตย์</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>รอ RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>รอ RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>รอการเริ่มต้น</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>รอการเริ่มต้น</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>ข้อผิดพลาดในการทดสอบภาคพื้นดิน</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>ข้อผิดพลาดในการทดสอบภาคพื้นดิน</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>ข้อผิดพลาดในการทดสอบอินพุต CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>ข้อผิดพลาดในการทดสอบอินพุต CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>ตรวจพบกระแสไฟฟ้าตกค้าง</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>ตรวจพบกระแสไฟฟ้าตกค้าง</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>ตรวจพบแรงดันตก</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>ตรวจพบแรงดันตก</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>ตรวจพบแรงดันไฟฟ้าเกิน</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>ตรวจพบแรงดันไฟฟ้าเกิน</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>ตรวจพบความร้อนสูงเกินไป</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>ตรวจพบความร้อนสูงเกินไป</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>ขีดจำกัดการชาร์จ</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>ขีดจำกัดการชาร์จ</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>เริ่มการชาร์จ</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>เริ่มการชาร์จ</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">กำหนดการ</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>กำหนดการ</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>กำหนดการ</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>อุ่นเครื่อง</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>อุ่นเครื่อง</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>เย็นลง</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>เย็นลง</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>ทดสอบการทำงาน</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>ทดสอบการทำงาน</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>เริ่มต้นด้วยตนเอง</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>เริ่มต้นด้วยตนเอง</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>กำลังโหลดบูต</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>กำลังโหลดบูต</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>ทำงาน (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>ทำงาน (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>ทำงาน (จำกัด)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>ทำงาน (จำกัด)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>รีเลย์ %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>รีเลย์ %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>ความผิดพลาด</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>ความผิดพลาด</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>การดูดซึม</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>การดูดซึม</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>พื้นที่จัดเก็บ</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>พื้นที่จัดเก็บ</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Equalize</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Equalize</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">การควบคุมภายนอก</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>พลังงานต่ำ</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>พลังงานต่ำ</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>สภาพข้อบกพร่อง</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>สภาพข้อบกพร่อง</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>การชาร์จจำนวนมาก</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>การชาร์จจำนวนมาก</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>การชาร์จแบบดูดซับ</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>การชาร์จแบบดูดซับ</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>การชาร์จแบบลอยตัว</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>การชาร์จแบบลอยตัว</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>โหมดการจัดเก็บข้อมูล</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>โหมดการจัดเก็บข้อมูล</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>การชาร์จที่เท่าเทียมกัน</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>การชาร์จที่เท่าเทียมกัน</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>ผ่าน</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>ผ่าน</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>สลับด้าน</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>สลับด้าน</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>ช่วยเหลือ</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>ช่วยเหลือ</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>โหมดพาวเวอร์ซัพพลาย</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>โหมดพาวเวอร์ซัพพลาย</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">ยังชีพประคับประคอง</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>ตื่น</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>ตื่น</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>การดูดซึมซ้ำ</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>การดูดซึมซ้ำ</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>ปรับสมดุลอัตโนมัติ</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>ปรับสมดุลอัตโนมัติ</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>แบตเตอรี่ปลอดภัย</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>แบตเตอรี่ปลอดภัย</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>โหลดตรวจจับ</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>โหลดตรวจจับ</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>ถูกบล็อค</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>ถูกบล็อค</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>ทดสอบ</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>ทดสอบ</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">ไดนามิก ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>ไดนามิก ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>ไดนามิก ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>กลุ่มตัวหลัก</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>กลุ่มตัวหลัก</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>อินสแตนซ์มาสเตอร์</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>อินสแตนซ์มาสเตอร์</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>ต้นแบบกลุ่มและอินสแตนซ์</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>ต้นแบบกลุ่มและอินสแตนซ์</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>สแตนด์อโลน &amp; หัวหน้ากลุ่ม</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>สแตนด์อโลน &amp; หัวหน้ากลุ่ม</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>ชาร์จเท่านั้น</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>ชาร์จเท่านั้น</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>อินเวอร์เตอร์เท่านั้น</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>อินเวอร์เตอร์เท่านั้น</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">สัญญาณเตือนแรงดันแบตเตอรี่ต่ำ</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">สัญญาณเตือนแรงดันแบตเตอรี่สูง</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>สัญญาณเตือนไฟฟ้าลัดวงจร</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>สัญญาณเตือนไฟฟ้าลัดวงจร</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>ปิดการใช้งานจุดเข้าใช้งาน</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>ปิดการใช้งานจุดเข้าใช้งาน</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>อินพุตกระแสตรง</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>อินพุตกระแสตรง</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>สำหรับแบตเตอรี่ลิเธียม ไม่แนะนำให้ชาร์จต่ำกว่า 10% สำหรับแบตเตอรี่ประเภทอื่นๆ ให้ตรวจสอบเอกสารข้อมูลเพื่อดูระดับขั้นต่ำที่แนะนำโดยผู้ผลิต</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>สำหรับแบตเตอรี่ลิเธียม ไม่แนะนำให้ชาร์จต่ำกว่า 10% สำหรับแบตเตอรี่ประเภทอื่นๆ ให้ตรวจสอบเอกสารข้อมูลเพื่อดูระดับขั้นต่ำที่แนะนำโดยผู้ผลิต</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>ปิดการใช้งานการเริ่มอัตโนมัติ?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>ปิดการใช้งานการเริ่มอัตโนมัติ?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>อินเวอร์เตอร์ / เครื่องชาร์จ (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>อินเวอร์เตอร์ / เครื่องชาร์จ (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>แสดงการใช้งาน CPU</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>แสดงการใช้งาน CPU</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>ออกจากการสมัคร</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>ออกจากการสมัคร</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>ล้มเลิก</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>ล้มเลิก</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>เวอร์ชันแอปพลิเคชัน</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>เวอร์ชันแอปพลิเคชัน</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>อุณหภูมิน้ำมัน</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>อุณหภูมิน้ำมัน</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>โปรดทราบว่าการเปลี่ยนการตั้งค่าชั้นจำหน่าย Time-to-go จะเปลี่ยนการตั้งค่าสถานะการชาร์จต่ำในเมนูรีเลย์ด้วย</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>โปรดทราบว่าการเปลี่ยนการตั้งค่าชั้นจำหน่าย Time-to-go จะเปลี่ยนการตั้งค่าสถานะการชาร์จต่ำในเมนูรีเลย์ด้วย</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>เวลาทำการ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>เวลาทำการ</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>โดนฟ้อง เอ่อ.</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>โดนฟ้อง เอ่อ.</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>วงจรเริ่มต้นขึ้น</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>วงจรเริ่มต้นขึ้น</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>รอบเสร็จสมบูรณ์</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>รอบเสร็จสมบูรณ์</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>จำนวนการเพิ่มพลัง</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>จำนวนการเพิ่มพลัง</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>จำนวนการปล่อยน้ำลึก</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>จำนวนการปล่อยน้ำลึก</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>ประวัติรอบการชาร์จ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>ประวัติรอบการชาร์จ</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>ค่าเซ็นเซอร์เมื่อเต็ม</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>ค่าเซ็นเซอร์เมื่อเต็ม</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>เวลาให้บริการ</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>เวลาให้บริการ</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>ฟังก์ชั่นเริ่มต้นอัตโนมัติ</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>ฟังก์ชั่นเริ่มต้นอัตโนมัติ</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>ตรวจสอบให้แน่ใจว่าเครื่องกำเนิดไฟฟ้าไม่ได้เชื่อมต่อกับอินพุต AC %1 เมื่อใช้ตัวเลือกนี้</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>ตรวจสอบให้แน่ใจว่าเครื่องกำเนิดไฟฟ้าไม่ได้เชื่อมต่อกับอินพุต AC %1 เมื่อใช้ตัวเลือกนี้</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>ตัวจับเวลาการบริการถูกรีเซ็ตแล้ว</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>ตัวจับเวลาการบริการถูกรีเซ็ตแล้ว</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>การสแกนอย่างต่อเนื่องอาจรบกวนการทำงานของ Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>การสแกนอย่างต่อเนื่องอาจรบกวนการทำงานของ Wi-Fi</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>ช่วงเกจขั้นต่ำและสูงสุด</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>ช่วงเกจขั้นต่ำและสูงสุด</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">หน้าแรก</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>กำลังรีสตาร์ทแอปพลิเคชัน...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>กำลังรีสตาร์ทแอปพลิเคชัน...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>ไม่สามารถเปลี่ยนภาษาได้!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>ไม่สามารถเปลี่ยนภาษาได้!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 นาที</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 นาที</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 นาที</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">ไม่เคย</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>กรุณารอสักครู่ในขณะที่ภาษามีการเปลี่ยนแปลง</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>กรุณารอสักครู่ในขณะที่ภาษามีการเปลี่ยนแปลง</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>หน่วยมุมมองสั้น ๆ</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>หน่วยมุมมองสั้น ๆ</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>ไม่มีป้ายกำกับ</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>ไม่มีป้ายกำกับ</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>แสดงปริมาตรถัง</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>แสดงปริมาตรถัง</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>แสดงเปอร์เซ็นต์</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>แสดงเปอร์เซ็นต์</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>หมายเหตุ: หากไม่สามารถแสดงกระแสได้ (เช่น เมื่อแสดงผลรวมสำหรับแหล่งจ่ายไฟ AC และ DC รวม) ก็จะแสดงกำลังไฟแทน</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>หมายเหตุ: หากไม่สามารถแสดงกระแสได้ (เช่น เมื่อแสดงผลรวมสำหรับแหล่งจ่ายไฟ AC และ DC รวม) ก็จะแสดงกำลังไฟแทน</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>ชาร์จขีดจำกัดปัจจุบัน</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>ชาร์จขีดจำกัดปัจจุบัน</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>การเปิดตัวอย่างเป็นทางการ</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>การเปิดตัวอย่างเป็นทางการ</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>การเปิดตัวเบต้า</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>การเปิดตัวเบต้า</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>การทดสอบ (Victron ภายใน)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>การทดสอบ (Victron ภายใน)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>พัฒนา (Victron ภายใน)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>พัฒนา (Victron ภายใน)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>กำลังรีบูต...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>กำลังรีบูต...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>เปิดใช้งานไฟ LED แสดงสถานะ</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>เปิดใช้งานไฟ LED แสดงสถานะ</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>วอร์มอัพและคูลดาวน์</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>วอร์มอัพและคูลดาวน์</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>เวลาหยุดเครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>เวลาหยุดเครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>แจ้งเตือนเมื่อเครื่องกำเนิดไฟฟ้าไม่อยู่ในโหมดสตาร์ทอัตโนมัติ</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>แจ้งเตือนเมื่อเครื่องกำเนิดไฟฟ้าไม่อยู่ในโหมดสตาร์ทอัตโนมัติ</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>สัญญาณเตือนจะถูกกระตุ้นเมื่อฟังก์ชันสตาร์ทอัตโนมัติถูกปิดใช้งานเป็นเวลานานกว่า 10 นาที</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>สัญญาณเตือนจะถูกกระตุ้นเมื่อฟังก์ชันสตาร์ทอัตโนมัติถูกปิดใช้งานเป็นเวลานานกว่า 10 นาที</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>การบริโภคเองจากแบตเตอรี่</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>การบริโภคเองจากแบตเตอรี่</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>โหลดระบบทั้งหมด</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>โหลดระบบทั้งหมด</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>โหลดวิกฤติเท่านั้น</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>โหลดวิกฤติเท่านั้น</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">SOC ขั้นต่ำ (เว้นแต่กริดจะล้มเหลว)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>สถานะอายุการใช้งานแบตเตอรี่</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>สถานะอายุการใช้งานแบตเตอรี่</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>เข้าถึงสัญญาณ K ได้ที่ http://venus.local:3000 และผ่าน VRM</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>เข้าถึงสัญญาณ K ได้ที่ http://venus.local:3000 และผ่าน VRM</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>เข้าถึง Node-RED ได้ที่ https://venus.local:1881 และผ่าน VRM</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>เข้าถึง Node-RED ได้ที่ https://venus.local:1881 และผ่าน VRM</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>การวัดแบตเตอรี่</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>การวัดแบตเตอรี่</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>สถานะของระบบ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>สถานะของระบบ</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>รายการอุปกรณ์</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>รายการอุปกรณ์</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">อีเธอร์เน็ต</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>อินสแตนซ์อุปกรณ์ VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>อินสแตนซ์อุปกรณ์ VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>สัญญาณเตือนอุณหภูมิสูง</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>สัญญาณเตือนอุณหภูมิสูง</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>ควบคุม BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>ควบคุม BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>สัญญาณเตือนและข้อผิดพลาด</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>สัญญาณเตือนและข้อผิดพลาด</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>คุณสมบัตินี้ต้องใช้เฟิร์มแวร์เวอร์ชัน 400 ขึ้นไป ติดต่อผู้ติดตั้งเพื่ออัปเดต Multi/Quattro ของคุณ</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>คุณสมบัตินี้ต้องใช้เฟิร์มแวร์เวอร์ชัน 400 ขึ้นไป ติดต่อผู้ติดตั้งเพื่ออัปเดต Multi/Quattro ของคุณ</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>ที่ชาร์จไม่พร้อม ไม่สามารถเริ่มการปรับสมดุลได้</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>ที่ชาร์จไม่พร้อม ไม่สามารถเริ่มการปรับสมดุลได้</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>ไม่สามารถทริกเกอร์การปรับสมดุลระหว่างสถานะการชาร์จจำนวนมาก</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>ไม่สามารถทริกเกอร์การปรับสมดุลระหว่างสถานะการชาร์จจำนวนมาก</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>อีโค</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>อีโค</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>กระแสสูงสุด</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>กระแสสูงสุด</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>กำลังสูงสุด</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>กำลังสูงสุด</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>กระแสไฟฟ้าขั้นต่ำ</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>กระแสไฟฟ้าขั้นต่ำ</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">ไม่มี</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">ไม่ว่าง</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">ปิด</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">ตกลง</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>ประวัติโดยรวม</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>ประวัติโดยรวม</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">การตั้งค่า</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">ไม่รู้จัก</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>ผลผลิตวันนี้</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>ผลผลิตวันนี้</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>ติดตั้งเฟิร์มแวร์แล้ว กำลังรีบูตอุปกรณ์</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>ติดตั้งเฟิร์มแวร์แล้ว กำลังรีบูตอุปกรณ์</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>การควบคุมแบบสัมผัส</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>การควบคุมแบบสัมผัส</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>ข้อผิดพลาดในการทดสอบหน้าสัมผัสรอยเชื่อม (ลัดวงจร)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>ข้อผิดพลาดในการทดสอบหน้าสัมผัสรอยเชื่อม (ลัดวงจร)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>กำลังเปลี่ยนเป็น 3 เฟส</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>กำลังเปลี่ยนเป็น 3 เฟส</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>กำลังเปลี่ยนเป็น 1 เฟส</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>กำลังเปลี่ยนเป็น 1 เฟส</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>หยุดชาร์จ</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>หยุดชาร์จ</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>ที่สงวนไว้</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>ที่สงวนไว้</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>โหมดอินเวอร์เตอร์</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>โหมดอินเวอร์เตอร์</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>ไฟฟ้ากระแสสลับออก L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>ไฟฟ้ากระแสสลับออก L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>ป้อนข้อมูล</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>ป้อนข้อมูล</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>ทะลุผ่าน</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>ทะลุผ่าน</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>หน้าจะโหลดซ้ำโดยอัตโนมัติในสิบวินาทีเพื่อโหลดเวอร์ชันล่าสุด</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>หน้าจะโหลดซ้ำโดยอัตโนมัติในสิบวินาทีเพื่อโหลดเวอร์ชันล่าสุด</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>อินเวอร์เตอร์ (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>อินเวอร์เตอร์ (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>อินเวอร์เตอร์/เครื่องชาร์จ</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>อินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>ไม่พบเครื่องวัดพลังงาน
+        <translation>ไม่พบเครื่องวัดพลังงาน
 
 โปรดทราบว่าเมนูนี้แสดงเฉพาะมิเตอร์ Carlo Gavazzi ที่เชื่อมต่อผ่าน RS485 สำหรับมิเตอร์อื่นๆ รวมถึงมิเตอร์ Carlo Gavazzi ที่เชื่อมต่อผ่านอีเธอร์เน็ต โปรดดูเมนูอุปกรณ์ Modbus TCP/UDP แทน</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>อัตโนมัติ</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>อัตโนมัติ</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>เมื่อเปิดใช้งาน ค่าต่ำสุดและสูงสุดของเกจและกราฟจะถูกปรับโดยอัตโนมัติตามค่าที่ผ่านมา</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>เมื่อเปิดใช้งาน ค่าต่ำสุดและสูงสุดของเกจและกราฟจะถูกปรับโดยอัตโนมัติตามค่าที่ผ่านมา</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>รีเซ็ตค่าช่วงทั้งหมดให้เป็นศูนย์</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>รีเซ็ตค่าช่วงทั้งหมดให้เป็นศูนย์</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>รีเซ็ตค่าช่วง</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>รีเซ็ตค่าช่วง</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ตค่าทั้งหมดให้เป็นศูนย์</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ตค่าทั้งหมดให้เป็นศูนย์</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>กระแสไฟสูงสุด: เชื่อมต่อ AC in 1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>กระแสไฟสูงสุด: เชื่อมต่อ AC in 1</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>กระแสสูงสุด: เชื่อมต่อ AC ใน 2</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>กระแสสูงสุด: เชื่อมต่อ AC ใน 2</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>กระแสไฟฟ้าสูงสุด: ไม่มีอินพุต AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>กระแสไฟฟ้าสูงสุด: ไม่มีอินพุต AC</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>เอาท์พุทกระแสตรง</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>เอาท์พุทกระแสตรง</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>แสงอาทิตย์</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>แสงอาทิตย์</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>มอเตอร์ RPM</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>มอเตอร์ RPM</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>อุณหภูมิมอเตอร์</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>อุณหภูมิมอเตอร์</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>อุณหภูมิตัวควบคุม</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>อุณหภูมิตัวควบคุม</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>วงจรที่ใช้งานอยู่</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>วงจรที่ใช้งานอยู่</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>วงจร %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>วงจร %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>ดีซีตัดการเชื่อมต่อ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>ดีซีตัดการเชื่อมต่อ</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>ปิดเครื่องแล้ว</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>ปิดเครื่องแล้ว</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>การเปลี่ยนแปลงฟังก์ชั่น</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>การเปลี่ยนแปลงฟังก์ชั่น</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>อัพเดตเฟิร์มแวร์</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>อัพเดตเฟิร์มแวร์</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>รีเซ็ตซอฟต์แวร์</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>รีเซ็ตซอฟต์แวร์</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>ไม่สมบูรณ์</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>ไม่สมบูรณ์</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>เวลาที่ผ่านไป</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>เวลาที่ผ่านไป</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>ชาร์จ/บำรุงรักษา (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>ชาร์จ/บำรุงรักษา (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>แบตเตอรี่ (V&lt;sub&gt;สตาร์ท&lt;/sub&gt;/V&lt;sub&gt;สิ้นสุด&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>แบตเตอรี่ (V&lt;sub&gt;สตาร์ท&lt;/sub&gt;/V&lt;sub&gt;สิ้นสุด&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>แรงดันไฟออก AC ต่ำ</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>แรงดันไฟออก AC ต่ำ</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>ไฟฟ้ากระแสสลับออกสูง</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>ไฟฟ้ากระแสสลับออกสูง</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>ผลตอบแทนรวม</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>ผลตอบแทนรวม</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>ผลตอบแทนของระบบ</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>ผลตอบแทนของระบบ</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>ประวัติประจำวัน</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>ประวัติประจำวัน</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>ไม่มีการตั้งค่าการเตือน</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>ไม่มีการตั้งค่าการเตือน</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>แรงดัน PV สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>แรงดัน PV สูงสุด</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>แรงดันแบตเตอรี่สูงสุด</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>แรงดันแบตเตอรี่สูงสุด</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>แรงดันแบตเตอรี่ขั้นต่ำ</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>แรงดันแบตเตอรี่ขั้นต่ำ</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>ข้อผิดพลาดของแบตเตอรีแบงก์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>ข้อผิดพลาดของแบตเตอรีแบงก์</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>ไม่รองรับแรงดันไฟฟ้าของแบตเตอรี่</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>ไม่รองรับแรงดันไฟฟ้าของแบตเตอรี่</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>จำนวนแบตเตอรี่ไม่ถูกต้อง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>จำนวนแบตเตอรี่ไม่ถูกต้อง</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>การกำหนดค่าแบตเตอรี่ไม่ถูกต้อง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>การกำหนดค่าแบตเตอรี่ไม่ถูกต้อง</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>สถานะบาลานเซอร์</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>สถานะบาลานเซอร์</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>สมดุล</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>สมดุล</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>ความไม่สมดุล</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>ความไม่สมดุล</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>ใช้ตัวเลือกในระบบที่ไม่ใช้การใช้งานสูงสุด</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>ใช้ตัวเลือกในระบบที่ไม่ใช้การใช้งานสูงสุด</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>ใช้ตัวเลือกนี้เพื่อการโกนสูงสุด</translation>
+        <translation>ใช้ตัวเลือกนี้เพื่อการโกนสูงสุด</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>เกณฑ์การโกนสูงสุดถูกกำหนดโดยใช้การตั้งค่าขีดจำกัดกระแสอินพุต AC ดูเอกสารประกอบสำหรับข้อมูลเพิ่มเติม</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>เกณฑ์การโกนสูงสุดถูกกำหนดโดยใช้การตั้งค่าขีดจำกัดกระแสอินพุต AC ดูเอกสารประกอบสำหรับข้อมูลเพิ่มเติม</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>เกณฑ์การโกนสูงสุดสำหรับการนำเข้าและส่งออกสามารถเปลี่ยนแปลงได้บนหน้าจอนี้ ดูเอกสารประกอบสำหรับข้อมูลเพิ่มเติม</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>เกณฑ์การโกนสูงสุดสำหรับการนำเข้าและส่งออกสามารถเปลี่ยนแปลงได้บนหน้าจอนี้ ดูเอกสารประกอบสำหรับข้อมูลเพิ่มเติม</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>จำกัดกระแสการนำเข้า AC ของระบบ</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>จำกัดกระแสการนำเข้า AC ของระบบ</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>หากต้องการใช้คุณลักษณะนี้ ต้องตั้งค่าการวัดกริดเป็นมิเตอร์ภายนอก และต้องติดตั้งตัวช่วย ESS ที่ทันสมัย</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>หากต้องการใช้คุณลักษณะนี้ ต้องตั้งค่าการวัดกริดเป็นมิเตอร์ภายนอก และต้องติดตั้งตัวช่วย ESS ที่ทันสมัย</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>กระแสนำเข้าระบบสูงสุด (ต่อเฟส)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>กระแสนำเข้าระบบสูงสุด (ต่อเฟส)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>ต้องตั้งค่าการวัดแสงตารางเป็นมิเตอร์ภายนอกเพื่อใช้คุณสมบัตินี้</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>ต้องตั้งค่าการวัดแสงตารางเป็นมิเตอร์ภายนอกเพื่อใช้คุณสมบัตินี้</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>กระแสส่งออกระบบสูงสุด (ต่อเฟส)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>กระแสส่งออกระบบสูงสุด (ต่อเฟส)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>แบบมีสาย</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>แบบมีสาย</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">รวบรัด</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>โหลดของระบบสูง ปิดแผงด้านข้างเพื่อลดภาระของ CPU</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>โหลดของระบบสูง ปิดแผงด้านข้างเพื่อลดภาระของ CPU</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>อินพุตขีดจำกัดปัจจุบัน</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>อินพุตขีดจำกัดปัจจุบัน</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>ไฟฟ้าลัดวงจร</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>ไฟฟ้าลัดวงจร</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>กำลังซื้อ</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>กำลังซื้อ</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>ขาย</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>ขาย</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>เป้าหมาย SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>เป้าหมาย SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>ไฟฟ้ากระแสสลับออก %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>ไฟฟ้ากระแสสลับออก %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>ตัวติดตาม</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>ตัวติดตาม</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>อุปกรณ์อาร์เอส</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>อุปกรณ์อาร์เอส</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>หยุดภาพเคลื่อนไหวของอิเล็กตรอนชั่วคราว</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>หยุดภาพเคลื่อนไหวของอิเล็กตรอนชั่วคราว</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>ความจุรวม</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>ความจุรวม</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>จำนวน BMS</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>จำนวน BMS</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 กิโลบิต/วินาที)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 กิโลบิต/วินาที)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 กิโลบิต/วินาที)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 กิโลบิต/วินาที)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>จำกัด ระบบกระแสไฟส่งออก AC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>จำกัด ระบบกระแสไฟส่งออก AC</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>อุปกรณ์ Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>อุปกรณ์ Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>เพิ่มอุปกรณ์</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>เพิ่มอุปกรณ์</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>สแกนหาอุปกรณ์</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>สแกนหาอุปกรณ์</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>อุปกรณ์ที่บันทึกไว้</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>อุปกรณ์ที่บันทึกไว้</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>อุปกรณ์ที่ค้นพบ</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>อุปกรณ์ที่ค้นพบ</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>เพิ่มอุปกรณ์ Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>เพิ่มอุปกรณ์ Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>ยูดีพี</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>ยูดีพี</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>มาตรการ</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>มาตรการ</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>พอร์ต</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>พอร์ต</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>หน่วย</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>หน่วย</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>ไม่มีการบันทึกอุปกรณ์ Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>ไม่มีการบันทึกอุปกรณ์ Modbus</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>อุปกรณ์ %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>อุปกรณ์ %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>ลบอุปกรณ์ Modbus หรือไม่</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>ลบอุปกรณ์ Modbus หรือไม่</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>ไม่พบอุปกรณ์ Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>ไม่พบอุปกรณ์ Modbus</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>แบตเตอรี่ %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>แบตเตอรี่ %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>กระแสสลับ</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>กระแสสลับ</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>เครื่องกำเนิดไฟฟ้าเริ่ม/หยุดปิดการใช้งาน</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>เครื่องกำเนิดไฟฟ้าเริ่ม/หยุดปิดการใช้งาน</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>ฟังก์ชันการเริ่มต้นระยะไกลถูกปิดใช้งานบนเครื่องกำเนิดไฟฟ้า GX จะไม่สามารถเริ่มหรือหยุดเครื่องกำเนิดไฟฟ้าได้ในขณะนี้ เปิดใช้งานบนแผงควบคุมเครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>ฟังก์ชันการเริ่มต้นระยะไกลถูกปิดใช้งานบนเครื่องกำเนิดไฟฟ้า GX จะไม่สามารถเริ่มหรือหยุดเครื่องกำเนิดไฟฟ้าได้ในขณะนี้ เปิดใช้งานบนแผงควบคุมเครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>ฟังก์ชั่นสตาร์ทอัตโนมัติ</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>ฟังก์ชั่นสตาร์ทอัตโนมัติ</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">เวลาการทำงานปัจจุบัน</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>สถานะการควบคุม</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>สถานะการควบคุม</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>สถานะเครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>สถานะเครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>โหมดเริ่มต้นระยะไกล</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>โหมดเริ่มต้นระยะไกล</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>แรงดันน้ำมัน</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>แรงดันน้ำมัน</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>ระดับการชาร์จตามกำหนดเวลา</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>ระดับการชาร์จตามกำหนดเวลา</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>ใช้งานอยู่ (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>ใช้งานอยู่ (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>หยุดด้วยตนเอง</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>หยุดด้วยตนเอง</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>วงจรเปิด</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>วงจรเปิด</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (ไม่พร้อมใช้งาน)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (ไม่พร้อมใช้งาน)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>สัมผัสอินพุตเปิด</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>สัมผัสอินพุตเปิด</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>ปิดอินพุตแบบสัมผัส</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>ปิดอินพุตแบบสัมผัส</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>ปิดใช้งานการป้อนข้อมูลแบบสัมผัส</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>ปิดใช้งานการป้อนข้อมูลแบบสัมผัส</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>รับทราบการแจ้งเตือน</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>รับทราบการแจ้งเตือน</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>รหัสข้อผิดพลาดการควบคุม</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>รหัสข้อผิดพลาดการควบคุม</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>ใช้เมนูนี้เพื่อกำหนดข้อมูลแบตเตอรี่ที่แสดงเมื่อคลิกไอคอนแบตเตอรี่ในหน้าภาพรวม ตัวเลือกเดียวกันนี้จะปรากฏบน VRM Portal เช่นกัน</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>ใช้เมนูนี้เพื่อกำหนดข้อมูลแบตเตอรี่ที่แสดงเมื่อคลิกไอคอนแบตเตอรี่ในหน้าภาพรวม ตัวเลือกเดียวกันนี้จะปรากฏบน VRM Portal เช่นกัน</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>แรงดันไฟฟ้าของระบบ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>แรงดันไฟฟ้าของระบบ</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>ข้อมูลการเชื่อมต่อ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>ข้อมูลการเชื่อมต่อ</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>กรุณาเลือก...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>กรุณาเลือก...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>ปลอดภัย</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>ปลอดภัย</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>มีการป้องกันด้วยรหัสผ่านและการสื่อสารเครือข่ายได้รับการเข้ารหัส</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>มีการป้องกันด้วยรหัสผ่านและการสื่อสารเครือข่ายได้รับการเข้ารหัส</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>อ่อนแอ</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>อ่อนแอ</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>มีการป้องกันด้วยรหัสผ่าน แต่การสื่อสารเครือข่ายไม่ได้เข้ารหัส</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>มีการป้องกันด้วยรหัสผ่าน แต่การสื่อสารเครือข่ายไม่ได้เข้ารหัส</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>ไม่ปลอดภัย</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>ไม่ปลอดภัย</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>ไม่มีรหัสผ่านและการสื่อสารเครือข่ายไม่ได้เข้ารหัส</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>ไม่มีรหัสผ่านและการสื่อสารเครือข่ายไม่ได้เข้ารหัส</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">รหัสผ่านต้องมีความยาวอย่างน้อย 8 ตัวอักษร</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">ใส่รหัสผ่าน</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>รหัสผ่านต้องมีความยาวอย่างน้อย 8 ตัวอักษร</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>รหัสผ่านต้องมีความยาวอย่างน้อย 8 ตัวอักษร</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>เลือกโปรไฟล์ 'ปลอดภัย' หรือไม่?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>เลือกโปรไฟล์ &apos;ปลอดภัย&apos; หรือไม่?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>เลือกโปรไฟล์ 'อ่อนแอ' หรือไม่?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>เลือกโปรไฟล์ &apos;อ่อนแอ&apos; หรือไม่?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>เลือกโปรไฟล์ 'ไม่ปลอดภัย' หรือไม่?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>เลือกโปรไฟล์ &apos;ไม่ปลอดภัย&apos; หรือไม่?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>• บริการเครือข่ายท้องถิ่นได้รับการป้องกันด้วยรหัสผ่าน
+        <translation>• บริการเครือข่ายท้องถิ่นได้รับการป้องกันด้วยรหัสผ่าน
 • การสื่อสารเครือข่ายได้รับการเข้ารหัส
 • เปิดใช้งานการเชื่อมต่อที่ปลอดภัยด้วย VRM
 • ไม่สามารถเปิดใช้งานการตั้งค่าที่ไม่ปลอดภัยได้</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• บริการเครือข่ายท้องถิ่นได้รับการป้องกันด้วยรหัสผ่าน
+        <translation>• บริการเครือข่ายท้องถิ่นได้รับการป้องกันด้วยรหัสผ่าน
 • เปิดใช้งานการเข้าถึงเว็บไซต์ท้องถิ่นโดยไม่เข้ารหัส (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>• บริการเครือข่ายท้องถิ่นไม่จำเป็นต้องมีรหัสผ่าน
+        <translation>• บริการเครือข่ายท้องถิ่นไม่จำเป็นต้องมีรหัสผ่าน
 • เปิดใช้งานการเข้าถึงเว็บไซต์ท้องถิ่นแบบไม่เข้ารหัสด้วยเช่นกัน (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>รหัสผ่านรูท</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>รหัสผ่านรูท</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>ออกจากระบบ</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>ออกจากระบบ</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>ออกจากระบบตอนนี้</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>ออกจากระบบตอนนี้</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>ออกจากระบบใช่ไหม?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>ออกจากระบบใช่ไหม?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>การกระทำนี้จะตัดการเชื่อมต่อเครือข่ายท้องถิ่นทั้งหมด</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>การกระทำนี้จะตัดการเชื่อมต่อเครือข่ายท้องถิ่นทั้งหมด</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>ออกจากระบบ</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>ออกจากระบบ</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>อ่านอย่างเดียว</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>อ่านอย่างเดียว</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>เต็ม</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>เต็ม</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>คุณแน่ใจมั้ย?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>คุณแน่ใจมั้ย?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>การเปลี่ยนการตั้งค่านี้เป็นอ่านอย่างเดียวหรือปิดจะทำให้คุณล็อคออก</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>การเปลี่ยนการตั้งค่านี้เป็นอ่านอย่างเดียวหรือปิดจะทำให้คุณล็อคออก</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>การเข้าถึง MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>การเข้าถึง MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' ไม่ใช่ตัวเลข</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; ไม่ใช่ตัวเลข</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>ยืนยัน</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>ยืนยัน</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>ใช้ตัวเลขที่มี %1 หลักหรือน้อยกว่า</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>ใช้ตัวเลขที่มี %1 หลักหรือน้อยกว่า</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' ไม่ใช่ที่อยู่ IP ที่ถูกต้อง</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; ไม่ใช่ที่อยู่ IP ที่ถูกต้อง</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' ไม่ใช่หมายเลขพอร์ตที่ถูกต้อง ใช้หมายเลขระหว่าง 0-65535</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; ไม่ใช่หมายเลขพอร์ตที่ถูกต้อง ใช้หมายเลขระหว่าง 0-65535</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 ไม่ใช่หมายเลขหน่วยที่ถูกต้อง ให้ใช้ตัวเลขระหว่าง 1-247</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 ไม่ใช่หมายเลขหน่วยที่ถูกต้อง ให้ใช้ตัวเลขระหว่าง 1-247</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>เวลาการทำงานปัจจุบัน</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>เวลาการทำงานปัจจุบัน</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>รหัสข้อผิดพลาดของเครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>รหัสข้อผิดพลาดของเครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>อุณหภูมิของฮีทซิงค์</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>อุณหภูมิของฮีทซิงค์</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">แรงดันไฟชาร์จ</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>ขณะนี้แรงดันไฟชาร์จได้รับการควบคุมโดย BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>ขณะนี้แรงดันไฟชาร์จได้รับการควบคุมโดย BMS</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>ขีดจำกัดกระแสไฟชาร์จ</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>ขีดจำกัดกระแสไฟชาร์จ</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>ควบคุม BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>ควบคุม BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>การควบคุม BMS จะเปิดใช้งานโดยอัตโนมัติเมื่อมี BMS รีเซ็ตหากการกำหนดค่าระบบเปลี่ยนไปหรือหากไม่มี BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>การควบคุม BMS จะเปิดใช้งานโดยอัตโนมัติเมื่อมี BMS รีเซ็ตหากการกำหนดค่าระบบเปลี่ยนไปหรือหากไม่มี BMS</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>ปิดการใช้งานตัวจับเวลาบริการแล้ว</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>ปิดการใช้งานตัวจับเวลาบริการแล้ว</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>พอร์ทัล VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>พอร์ทัล VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (การเข้าถึง VPN ระยะไกล)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (การเข้าถึง VPN ระยะไกล)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>เอสโอซี %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>เอสโอซี %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>ต้องกำหนดค่าโปรไฟล์ความปลอดภัยก่อนจึงจะเปิดใช้งานบริการเครือข่ายได้ โปรดดูการตั้งค่า - ทั่วไป</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>ต้องกำหนดค่าโปรไฟล์ความปลอดภัยก่อนจึงจะเปิดใช้งานบริการเครือข่ายได้ โปรดดูการตั้งค่า - ทั่วไป</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' ถูกแทนที่ด้วย '%2' เนื่องจากมีอักขระที่ไม่ถูกต้อง</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; ถูกแทนที่ด้วย &apos;%2&apos; เนื่องจากมีอักขระที่ไม่ถูกต้อง</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>กำลังเริ่มต้น...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>กำลังเริ่มต้น...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>กำลังเริ่มต้นแบ็คเอนด์...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>กำลังเริ่มต้นแบ็คเอนด์...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>แบ็คเอนด์หยุดแล้ว</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>แบ็คเอนด์หยุดแล้ว</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>การเชื่อมต่อล้มเหลว</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>การเชื่อมต่อล้มเหลว</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>อุปกรณ์ GX นี้ออกจากระบบ Tailscale แล้ว
+        <translation>อุปกรณ์ GX นี้ออกจากระบบ Tailscale แล้ว
 
 กรุณารอสักครู่หรือตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณ</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>กำลังรอการตอบกลับจาก Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>กำลังรอการตอบกลับจาก Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>เชื่อมต่ออุปกรณ์ GX นี้กับบัญชี Tailscale ของคุณโดยเปิดลิงก์นี้:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>เชื่อมต่ออุปกรณ์ GX นี้กับบัญชี Tailscale ของคุณโดยเปิดลิงก์นี้:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>กรุณารอสักครู่หรือตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณ</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>กรุณารอสักครู่หรือตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณ</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>สถานะที่ไม่รู้จัก: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>สถานะที่ไม่รู้จัก: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>ข้อผิดพลาด: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>ข้อผิดพลาด: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>ปิดใช้งาน Tailscale เพื่อแก้ไขการตั้งค่าเหล่านี้</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>ปิดใช้งาน Tailscale เพื่อแก้ไขการตั้งค่าเหล่านี้</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>เปิดใช้งาน Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>เปิดใช้งาน Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>ชื่อเครื่องจักร</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>ชื่อเครื่องจักร</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>ออกจากระบบบัญชี Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>ออกจากระบบบัญชี Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>การเข้าถึงเครือข่ายท้องถิ่น</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>การเข้าถึงเครือข่ายท้องถิ่น</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>เข้าถึงเครือข่ายอีเธอร์เน็ตในพื้นที่</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>เข้าถึงเครือข่ายอีเธอร์เน็ตในพื้นที่</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>เข้าถึงเครือข่าย WiFi ในพื้นที่</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>เข้าถึงเครือข่าย WiFi ในพื้นที่</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>เครือข่ายที่กำหนดเอง</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>เครือข่ายที่กำหนดเอง</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>ตัวอย่าง: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>ตัวอย่าง: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>คำอธิบาย:
+        <translation>คำอธิบาย:
 
 ฟีเจอร์นี้เรียกว่าเส้นทางซับเน็ตโดย Tailscale ซึ่งอนุญาตให้เข้าถึงอุปกรณ์อื่นในเครือข่ายท้องถิ่นจากระยะไกล
 
@@ -7384,2988 +8026,3056 @@ After adding/enabling a new network, you need to approve it in the Tailscale adm
 หลังจากเพิ่ม/เปิดใช้งานเครือข่ายใหม่แล้ว คุณต้องอนุมัติในคอนโซลผู้ดูแลระบบ Tailscale หนึ่งครั้ง</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>อาร์กิวเมนต์ "tailscale up" ที่กำหนดเอง</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>อาร์กิวเมนต์ &quot;tailscale up&quot; ที่กำหนดเอง</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>URL เซิร์ฟเวอร์ที่กำหนดเอง (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>URL เซิร์ฟเวอร์ที่กำหนดเอง (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>ตัวควบคุมเครื่องกำเนิดไฟฟ้าชุดนี้ต้องใช้รีเลย์ช่วยเหลือในการควบคุม แต่รีเลย์ช่วยเหลือไม่ได้รับการกำหนดค่า โปรดกำหนดค่ารีเลย์ 1 ภายใต้ การตั้งค่า → รีเลย์ เป็น "รีเลย์ช่วยเหลือเครื่องกำเนิดไฟฟ้าที่เชื่อมต่ออยู่"</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>ตัวควบคุมเครื่องกำเนิดไฟฟ้าชุดนี้ต้องใช้รีเลย์ช่วยเหลือในการควบคุม แต่รีเลย์ช่วยเหลือไม่ได้รับการกำหนดค่า โปรดกำหนดค่ารีเลย์ 1 ภายใต้ การตั้งค่า → รีเลย์ เป็น &quot;รีเลย์ช่วยเหลือเครื่องกำเนิดไฟฟ้าที่เชื่อมต่ออยู่&quot;</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>สัญญาณเตือนแรงดันแบตเตอรี่สตาร์ทสูง</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>สัญญาณเตือนแรงดันแบตเตอรี่สตาร์ทสูง</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>ข้ามการอุ่นเครื่องเครื่องปั่นไฟ</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>ข้ามการอุ่นเครื่องเครื่องปั่นไฟ</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>ขึ้นแต่ไม่มีบริการ (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>ขึ้นแต่ไม่มีบริการ (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>รหัสผ่านรูทเปลี่ยนเป็น %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>รหัสผ่านรูทเปลี่ยนเป็น %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>รีเลย์ตัวช่วยเครื่องกำเนิดไฟฟ้าที่เชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>รีเลย์ตัวช่วยเครื่องกำเนิดไฟฟ้าที่เชื่อมต่อ</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>ตำแหน่งของโหลด AC</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>ตำแหน่งของโหลด AC</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>อินพุตและเอาต์พุตไฟฟ้ากระแสสลับ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>อินพุตและเอาต์พุตไฟฟ้ากระแสสลับ</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>ใช้ตัวเลือกนี้เมื่อมีโหลด AC อยู่ที่อินพุตของอินเวอร์เตอร์/เครื่องชาร์จ ใช้ตัวเลือกนี้หากไม่แน่ใจ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>ใช้ตัวเลือกนี้เมื่อมีโหลด AC อยู่ที่อินพุตของอินเวอร์เตอร์/เครื่องชาร์จ ใช้ตัวเลือกนี้หากไม่แน่ใจ</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>เอาต์พุต AC เท่านั้น</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>เอาต์พุต AC เท่านั้น</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>ใช้ตัวเลือกนี้เมื่อระบบใช้มิเตอร์กริด แต่โหลด AC ทั้งหมดจะอยู่ที่เอาต์พุตของอินเวอร์เตอร์/เครื่องชาร์จ</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>ใช้ตัวเลือกนี้เมื่อระบบใช้มิเตอร์กริด แต่โหลด AC ทั้งหมดจะอยู่ที่เอาต์พุตของอินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>รายเดือน</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>รายเดือน</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>เครื่องชาร์จ EV</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>เครื่องชาร์จ EV</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>ปั๊มความร้อน</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>ปั๊มความร้อน</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>โหลดที่จำเป็น</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>โหลดที่จำเป็น</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>เริ่มต้นและหยุดเครื่องกำเนิดไฟฟ้าตามเงื่อนไขการเริ่มอัตโนมัติที่กำหนดค่าไว้</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>เริ่มต้นและหยุดเครื่องกำเนิดไฟฟ้าตามเงื่อนไขการเริ่มอัตโนมัติที่กำหนดค่าไว้</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>การตั้งค่าเครื่องกำเนิดไฟฟ้า DC</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>การตั้งค่าเครื่องกำเนิดไฟฟ้า DC</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>อุณหภูมิของไดชาร์จ</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>อุณหภูมิของไดชาร์จ</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>อุณหภูมิเครื่องยนต์</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>อุณหภูมิเครื่องยนต์</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>เวลาทำงานทั้งหมด</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>เวลาทำงานทั้งหมด</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>โปรไฟล์ความปลอดภัยเครือข่าย</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>โปรไฟล์ความปลอดภัยเครือข่าย</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>%1 วันที่ผ่านมา</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>%1 วันที่ผ่านมา</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>เครื่องกำเนิดไฟฟ้าจะหยุดทำงานที่ %1 เว้นแต่จะเปิดใช้งานเงื่อนไขการสตาร์ทอัตโนมัติเพื่อให้เครื่องทำงานได้ต่อไป</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>เครื่องกำเนิดไฟฟ้าจะหยุดทำงานที่ %1 เว้นแต่จะเปิดใช้งานเงื่อนไขการสตาร์ทอัตโนมัติเพื่อให้เครื่องทำงานได้ต่อไป</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>เครื่องกำเนิดไฟฟ้าจะทำงานจนกว่าจะหยุดด้วยตนเอง เว้นแต่จะมีการเปิดใช้งานเงื่อนไขการสตาร์ทอัตโนมัติเพื่อให้เครื่องทำงานได้ต่อไป</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>เครื่องกำเนิดไฟฟ้าจะทำงานจนกว่าจะหยุดด้วยตนเอง เว้นแต่จะมีการเปิดใช้งานเงื่อนไขการสตาร์ทอัตโนมัติเพื่อให้เครื่องทำงานได้ต่อไป</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>UI แบบคลาสสิก</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>UI แบบคลาสสิก</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>UI ใหม่</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>UI ใหม่</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>เปลี่ยนภาษาสำเร็จแล้ว!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>การจำกัดอำนาจ</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>เปลี่ยนภาษาสำเร็จแล้ว!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>สำหรับอุปกรณ์ Multi-RS และ HS19 การตั้งค่า ESS มีอยู่ในหน้าผลิตภัณฑ์ระบบ RS</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>สำหรับอุปกรณ์ Multi-RS และ HS19 การตั้งค่า ESS มีอยู่ในหน้าผลิตภัณฑ์ระบบ RS</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>การสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้า</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>การสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้า</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>การสลับเวอร์ชันเฟิร์มแวร์ไม่สามารถทำได้หากไม่ได้เลือก "โปรไฟล์ความปลอดภัยของเครือข่าย" ใน "การตั้งค่า/ทั่วไป"</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>การสลับเวอร์ชันเฟิร์มแวร์ไม่สามารถทำได้หากไม่ได้เลือก &quot;โปรไฟล์ความปลอดภัยของเครือข่าย&quot; ใน &quot;การตั้งค่า/ทั่วไป&quot;</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>ระยะเวลา</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>ระยะเวลา</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>ระบบแจ้งเตือน</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>ระบบแจ้งเตือน</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>ไม่มีสัญญาณเตือนจากระบบ</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>ไม่มีสัญญาณเตือนจากระบบ</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>กลับ</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>กลับ</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>มีอะไรใหม่</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>มีอะไรใหม่</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>ข้าม</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>ข้าม</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>ยินดีต้อนรับ!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>ยินดีต้อนรับ!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>เรารู้สึกตื่นเต้นที่จะแนะนำอินเทอร์เฟซที่ออกแบบใหม่หมดซึ่งช่วยเพิ่มประสิทธิภาพในการใช้งานและความสวยงามของ GX ของคุณ
+        <translation>เรารู้สึกตื่นเต้นที่จะแนะนำอินเทอร์เฟซที่ออกแบบใหม่หมดซึ่งช่วยเพิ่มประสิทธิภาพในการใช้งานและความสวยงามของ GX ของคุณ
 
 ด้วยการนำทางที่คล่องตัวและรูปลักษณ์ใหม่ ทุกสิ่งที่คุณชื่นชอบจึงเข้าถึงได้ง่ายยิ่งขึ้นและดึงดูดสายตามากขึ้น</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>โหมดมืด-สว่าง</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>โหมดมืด-สว่าง</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>สภาพแวดล้อมที่แตกต่างกันต้องการการตั้งค่าการแสดงผลที่แตกต่างกัน โหมดมืดและโหมดสว่างรับประกันประสบการณ์การรับชมที่ดีที่สุดไม่ว่าคุณจะอยู่ที่ใดก็ตาม</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>สภาพแวดล้อมที่แตกต่างกันต้องการการตั้งค่าการแสดงผลที่แตกต่างกัน โหมดมืดและโหมดสว่างรับประกันประสบการณ์การรับชมที่ดีที่สุดไม่ว่าคุณจะอยู่ที่ใดก็ตาม</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>ข้อมูลสำคัญทั้งหมดที่คุณต้องการ นำเสนอในรูปแบบที่สะอาดตาและเรียบง่าย จุดเด่นคือวิดเจ็ตที่ปรับแต่งได้พร้อมวงแหวน ช่วยให้คุณเข้าถึงข้อมูลเชิงลึกของระบบได้อย่างรวดเร็ว</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>ข้อมูลสำคัญทั้งหมดที่คุณต้องการ นำเสนอในรูปแบบที่สะอาดตาและเรียบง่าย จุดเด่นคือวิดเจ็ตที่ปรับแต่งได้พร้อมวงแหวน ช่วยให้คุณเข้าถึงข้อมูลเชิงลึกของระบบได้อย่างรวดเร็ว</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>รับการควบคุมที่มากขึ้นด้วยแผงภาพรวมที่อัปเดตของเราซึ่งมีข้อมูลระบบแบบเรียลไทม์รวมอยู่ในที่เดียวเพื่อการตรวจสอบที่ง่ายดาย</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>รับการควบคุมที่มากขึ้นด้วยแผงภาพรวมที่อัปเดตของเราซึ่งมีข้อมูลระบบแบบเรียลไทม์รวมอยู่ในที่เดียวเพื่อการตรวจสอบที่ง่ายดาย</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>การควบคุม</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>การควบคุม</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>ตอนนี้การควบคุมรายวันทั้งหมดจะถูกรวมไว้ด้วยกันในบานหน้าต่างการควบคุมใหม่ </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">ตอนนี้การควบคุมรายวันทั้งหมดจะถูกรวมไว้ด้วยกันในบานหน้าต่างการควบคุมใหม่ </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>วัตต์และแอมป์</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>วัตต์และแอมป์</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>คุณสามารถสลับระหว่างวัตต์และแอมแปร์ได้แล้ว เลือกหน่วยที่ตรงกับความต้องการของคุณมากที่สุด</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>คุณสามารถสลับระหว่างวัตต์และแอมแปร์ได้แล้ว เลือกหน่วยที่ตรงกับความต้องการของคุณมากที่สุด</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>เรียนรู้เพิ่มเติม</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>เรียนรู้เพิ่มเติม</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>เข้าถึงลิงก์ด้านล่างเพื่อดูข้อมูลเพิ่มเติมเกี่ยวกับ UI ที่ได้รับการปรับปรุงใหม่&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>เข้าถึงลิงก์ด้านล่างเพื่อดูข้อมูลเพิ่มเติมเกี่ยวกับ UI ที่ได้รับการปรับปรุงใหม่&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>สแกนรหัส QR เพื่อดูข้อมูลเพิ่มเติมเกี่ยวกับ UI ที่ได้รับการปรับปรุงใหม่</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>สแกนรหัส QR เพื่อดูข้อมูลเพิ่มเติมเกี่ยวกับ UI ที่ได้รับการปรับปรุงใหม่</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>เสร็จแล้ว</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>เสร็จแล้ว</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>ต่อไป</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>ต่อไป</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>ข้อผิดพลาด: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>ข้อผิดพลาด: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>ข้อผิดพลาดที่ใช้งานอยู่</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>ข้อผิดพลาดที่ใช้งานอยู่</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>เวลาทำงานของเครื่องกำเนิดไฟฟ้าทั้งหมด (ชั่วโมง)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>เวลาทำงานของเครื่องกำเนิดไฟฟ้าทั้งหมด (ชั่วโมง)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>หน้าแรก</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>หน้าแรก</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>อินเทอร์เฟซผู้ใช้</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>อินเทอร์เฟซผู้ใช้</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>อินเทอร์เฟซผู้ใช้ (คอนโซลระยะไกล)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>อินเทอร์เฟซผู้ใช้ (คอนโซลระยะไกล)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 อัปเดตแล้ว</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 อัปเดตแล้ว</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>อินเทอร์เฟซผู้ใช้จะสลับไปที่ %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>อินเทอร์เฟซผู้ใช้จะสลับไปที่ %1</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 ถูกตั้งค่าเป็น %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>อินเวอร์เตอร์ PV นี้รองรับการจำกัดพลังงาน ปิดใช้งานการตั้งค่านี้หากรบกวนการทำงานปกติ</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 ถูกตั้งค่าเป็น %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>กด 'ตกลง' เพื่อรีบูต</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>กด &apos;ตกลง&apos; เพื่อรีบูต</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>รีเซ็ตโรงงาน Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>รีเซ็ตโรงงาน Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ต Node-RED เป็นค่าเริ่มต้นจากโรงงาน การดำเนินการนี้จะลบโฟลว์ทั้งหมดของคุณ</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ต Node-RED เป็นค่าเริ่มต้นจากโรงงาน การดำเนินการนี้จะลบโฟลว์ทั้งหมดของคุณ</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>สถานะการเชื่อมต่อ</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>สถานะการเชื่อมต่อ</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>สถานะการเชื่อมต่อ (ช่อง HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>สถานะการเชื่อมต่อ (ช่อง HTTPS)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>สถานะการเชื่อมต่อ (ช่อง HTTP)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>สถานะการเชื่อมต่อ (ช่อง HTTP)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>สถานะการเชื่อมต่อ (ช่อง MQTT เรียลไทม์)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>สถานะการเชื่อมต่อ (ช่อง MQTT เรียลไทม์)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>สถานะการเชื่อมต่อ (ช่อง MQTT RPC)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>สถานะการเชื่อมต่อ (ช่อง MQTT RPC)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>เริ่มอัตโนมัติ • %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>เริ่มอัตโนมัติ • %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>ค่าปิดการใช้งาน</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>ค่าปิดการใช้งาน</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>ไม่ได้ทำงาน</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>ไม่ได้ทำงาน</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>การสูญเสียการสื่อสาร</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>การสูญเสียการสื่อสาร</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>เงื่อนไข SOC</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>เงื่อนไข SOC</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>สภาวะโหลดไฟฟ้ากระแสสลับ</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>สภาวะโหลดไฟฟ้ากระแสสลับ</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>สภาพกระแสไฟแบตเตอรี่</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>สภาพกระแสไฟแบตเตอรี่</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>สภาพแรงดันไฟแบตเตอรี่</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>สภาพแรงดันไฟแบตเตอรี่</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>สภาวะโอเวอร์โหลดอินเวอร์เตอร์</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>สภาวะโอเวอร์โหลดอินเวอร์เตอร์</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>เอสเอส %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>เอสเอส %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 ปิดใช้งานการชาร์จ/ปล่อยประจุ</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 ปิดใช้งานการชาร์จ/ปล่อยประจุ</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 ชาร์จถูกปิดใช้งาน</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 ชาร์จถูกปิดใช้งาน</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 ปิดการใช้งานการระบายออก</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 ปิดการใช้งานการระบายออก</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">รวบรัด</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>กางเกงชั้นใน (แผงด้านข้างเปิด)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>กางเกงชั้นใน (แผงด้านข้างเปิด)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">ภาพรวม</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>ระดับ (รถถัง)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>ระดับ (รถถัง)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>ระดับ (สิ่งแวดล้อม)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>ระดับ (สิ่งแวดล้อม)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>รายการแบตเตอรี่</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>รายการแบตเตอรี่</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>อุปกรณ์ GX ได้รับการอัปเดตแล้ว</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>อุปกรณ์ GX ได้รับการอัปเดตแล้ว</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>หลังจาก %n นาที</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>หลังจาก %n นาที</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>ไปที่หน้านี้เมื่อแอปพลิเคชันเริ่มต้น</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>ไปที่หน้านี้เมื่อแอปพลิเคชันเริ่มต้น</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>หมดเวลา</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>หมดเวลา</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>กลับไปยังหน้าเริ่มต้นเมื่อแอปพลิเคชันไม่ได้ใช้งาน</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>กลับไปยังหน้าเริ่มต้นเมื่อแอปพลิเคชันไม่ได้ใช้งาน</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>หลังจากที่ไม่ได้ใช้งานเป็นเวลา 1 นาที ให้เลือกหน้าปัจจุบันเป็นหน้าเริ่มต้น หากอยู่ในรายการนี้</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>หลังจากที่ไม่ได้ใช้งานเป็นเวลา 1 นาที ให้เลือกหน้าปัจจุบันเป็นหน้าเริ่มต้น หากอยู่ในรายการนี้</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>ขีดจำกัดปัจจุบันนี้ได้รับการแก้ไขในการกำหนดค่าระบบ ไม่สามารถปรับเปลี่ยนได้</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>ขีดจำกัดปัจจุบันนี้ได้รับการแก้ไขในการกำหนดค่าระบบ ไม่สามารถปรับเปลี่ยนได้</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>โหมดนี้ถูกกำหนดไว้ในการกำหนดค่าระบบแล้ว ไม่สามารถปรับเปลี่ยนได้</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>โหมดนี้ถูกกำหนดไว้ในการกำหนดค่าระบบแล้ว ไม่สามารถปรับเปลี่ยนได้</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>ไม่สามารถเปิดใช้งานฟังก์ชันการสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้าได้ ให้ไปที่การตั้งค่ารีเลย์และตั้งค่าฟังก์ชันเป็น "การสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้า"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>เวลามาตรฐานโมร็อกโก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>W. เวลามาตรฐานแอฟริกากลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>เวลามาตรฐานของแอฟริกาใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>เวลามาตรฐานนามิเบีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>เวลามาตรฐานอียิปต์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. เวลามาตรฐานแอฟริกา</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>เวลามาตรฐานอาร์เจนตินา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>E. เวลามาตรฐานของอเมริกาใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>เวลามาตรฐานกรีนแลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>เวลามาตรฐานมอนเตวิเดโอ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>เวลามาตรฐานนิวฟันด์แลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>SA เวลามาตรฐานตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>เวลามาตรฐานแอตแลนติก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>เวลามาตรฐานของบราซิลตอนกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิก SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>เวลามาตรฐานปารากวัย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA เวลามาตรฐานตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>เวลามาตรฐานของเวเนซุเอลา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกของ SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออกของสหรัฐอเมริกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>เวลามาตรฐานกลางของแคนาดา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>เวลามาตรฐานของอเมริกากลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>เวลามาตรฐานตอนกลาง (เม็กซิโก)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>เวลามาตรฐานตอนกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>เวลามาตรฐานแถบภูเขาสูง (เม็กซิโก)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>เวลามาตรฐานบนภูเขา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>เวลามาตรฐานภูเขาของสหรัฐอเมริกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>เวลามาตรฐานแปซิฟิก (เม็กซิโก)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>เวลามาตรฐานอลาสก้า</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>ฮาวาย-Aleutian</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. เวลามาตรฐานแอฟริกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิก SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA เวลามาตรฐานตะวันตก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>เวลามาตรฐานคัมชัตกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>เวลามาตรฐานมากาดาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>เวลามาตรฐานวลาดีวอสตอค</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>เวลามาตรฐานยาคุตสค์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>เวลามาตรฐานโตเกียว</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>เวลามาตรฐานเกาหลี</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>เวลามาตรฐานสิงคโปร์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>เวลามาตรฐานอูลานบาตอร์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>เวลามาตรฐานไทเป</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียเหนือตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>เวลามาตรฐานของจีน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียเหนือ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>เวลามาตรฐานของเมียนมาร์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียกลางเหนือ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>เวลามาตรฐานบังกลาเทศ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>เวลามาตรฐานเนปาล</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>เวลามาตรฐานศรีลังกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>เวลามาตรฐานอินเดีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>เวลามาตรฐานของปากีสถาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>เวลามาตรฐานเอคาเตรินเบิร์ก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>เวลามาตรฐานจอร์เจีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>เวลามาตรฐานคอเคซัส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>เวลามาตรฐานอาเซอร์ไบจาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>เวลามาตรฐานอาหรับ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>เวลามาตรฐานอัฟกานิสถาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>เวลามาตรฐานอิหร่าน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>เวลามาตรฐานภาษาอาหรับ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>เวลามาตรฐานอาหรับ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>เวลามาตรฐานซีเรีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออกกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>เวลามาตรฐานจอร์แดน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>เวลามาตรฐานของอิสราเอล</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>เวลามาตรฐานกรีนิช</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>เวลามาตรฐานอะซอเรส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>เวลามาตรฐานเคปเวิร์ด</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>เวลามาตรฐานแทสเมเนีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>E. เวลามาตรฐานของออสเตรเลีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออกของ AUS</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>เซน เวลามาตรฐานของออสเตรเลีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>เวลามาตรฐานกลาง AUS</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>เวลามาตรฐานกลางมหาสมุทรแอตแลนติก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Dateline เวลามาตรฐาน</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>เวลามาตรฐาน GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>เวลามาตรฐานโรแมนติก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>เวลามาตรฐาน FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>เวลามาตรฐาน GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>เวลามาตรฐานเบลารุส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>เวลามาตรฐานรัสเซีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>เวลามาตรฐานของตุรกี</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>เวลามาตรฐานมอริเชียส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>เวลามาตรฐานของเกาะคริสต์มาส</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>เวลามาตรฐานตองกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>เวลามาตรฐานฟิจิ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>เวลามาตรฐานซามัว</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>เวลามาตรฐานฮาวาย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>เวลามาตรฐานของเกาะอีสเตอร์</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>ไม่สามารถเปิดใช้งานฟังก์ชันการสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้าได้ ให้ไปที่การตั้งค่ารีเลย์และตั้งค่าฟังก์ชันเป็น &quot;การสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้า&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">ไม่รู้จัก</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">ผลผลิตพลังงานแสงอาทิตย์</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">อินพุตกระแสตรง</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">โหลด AC</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">โหลดไฟฟ้ากระแสตรง</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">ภาพรวม</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">สถานะ</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">ผลตอบแทนรวม</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">ผลตอบแทนของระบบ</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">การแจ้งเตือนเท่านั้น</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">การแจ้งเตือนและคำเตือน</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">คำเตือน</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>ข้อผิดพลาดในการเริ่มต้นแบตเตอรี่</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>ข้อผิดพลาดในการเริ่มต้นแบตเตอรี่</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>ไม่มีแบตเตอรี่เชื่อมต่อ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>ไม่มีแบตเตอรี่เชื่อมต่อ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>ไม่ทราบแบตเตอรี่</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>ไม่ทราบแบตเตอรี่</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>แบตเตอรี่ประเภทต่างๆ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>แบตเตอรี่ประเภทต่างๆ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>จำนวนแบตเตอรี่ไม่ถูกต้อง</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>จำนวนแบตเตอรี่ไม่ถูกต้อง</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>ไม่พบ Lynx Shunt</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>ไม่พบ Lynx Shunt</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>เกิดข้อผิดพลาดในการตรวจวัดแบตเตอรี่</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>เกิดข้อผิดพลาดในการตรวจวัดแบตเตอรี่</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>เกิดข้อผิดพลาดในการคำนวณภายใน</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>เกิดข้อผิดพลาดในการคำนวณภายใน</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>จำนวนแบตเตอรี่ในชุดไม่ถูกต้อง</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>จำนวนแบตเตอรี่ในชุดไม่ถูกต้อง</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>อุปกรณ์เกิดความผิดปกติ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>อุปกรณ์เกิดความผิดปกติ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>การตรวจจับการทำงานผิดปกติ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>การตรวจจับการทำงานผิดปกติ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>แรงดันไฟเกิน</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>แรงดันไฟเกิน</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>ภายใต้แรงดันไฟฟ้า</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>ภายใต้แรงดันไฟฟ้า</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>อุณหภูมิสูง</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>อุณหภูมิสูง</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>ภายใต้อุณหภูมิ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>ภายใต้อุณหภูมิ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>สแตนด์บายภายใต้การชาร์จ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>สแตนด์บายภายใต้การชาร์จ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>ADC เกิดข้อผิดพลาด</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>ADC เกิดข้อผิดพลาด</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>คอมแบตเตอรี ข้อผิดพลาด</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>คอมแบตเตอรี ข้อผิดพลาด</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>ข้อผิดพลาดในการชาร์จล่วงหน้า</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>ข้อผิดพลาดในการชาร์จล่วงหน้า</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>ข้อผิดพลาดคอนแทคความปลอดภัย</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>ข้อผิดพลาดคอนแทคความปลอดภัย</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>ข้อผิดพลาดในการอัปเดตแบตเตอรี่</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>ข้อผิดพลาดในการอัปเดตแบตเตอรี่</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>สาย BMS ผิดพลาด</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>สาย BMS ผิดพลาด</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>แรงดันไฟอ้างอิงล้มเหลว</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>แรงดันไฟอ้างอิงล้มเหลว</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>แรงดันไฟผิดระบบ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>แรงดันไฟผิดระบบ</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>หมดเวลาชาร์จล่วงหน้า</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>หมดเวลาชาร์จล่วงหน้า</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>ATC/ATD ล้มเหลว</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>ATC/ATD ล้มเหลว</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>ข้อมูลการสอบเทียบสูญหาย</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>ข้อมูลการสอบเทียบสูญหาย</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>การตั้งค่าไม่ถูกต้อง</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>การตั้งค่าไม่ถูกต้อง</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>ลูกโซ่</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>ลูกโซ่</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>หยุดฉุกเฉิน</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>หยุดฉุกเฉิน</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>หมดเวลาการสื่อสาร</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>หมดเวลาการสื่อสาร</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>ล็อคเพื่อความปลอดภัย</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>ล็อคเพื่อความปลอดภัย</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>เทอร์มินัลเกินอุณหภูมิ</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>เทอร์มินัลเกินอุณหภูมิ</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>อุณหภูมิสูงแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>แบตเตอรี่ไฟฟ้าแรงสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>แบตเตอรี่ Tsense ต่อสายผิด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>ไม่พบการเชื่อมต่อสาย Tsense ของแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>เชื่อมต่อสาย Vsense ของแบตเตอรี่ผิด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>แบตเตอรี Vsense หายไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>การสูญเสียสายไฟสูงของแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>แรงดันไฟต่ำของแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>แรงดันไฟฟ้าระลอกสูงของแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>สถานะการชาร์จของแบตเตอรี่ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>ปัญหาแรงดันไฟจุดกึ่งกลางของแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>อุณหภูมิแบตเตอรี่ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>เครื่องชาร์จอุณหภูมิสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>ตรวจพบกระแสไฟที่ชาร์จมากเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>กระแสไฟลบของเครื่องชาร์จ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>หมดเวลาชาร์จแบตหมด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>ปัญหาเซ็นเซอร์ปัจจุบันของเครื่องชาร์จ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>เซ็นเซอร์ภายในเดินสายผิด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>เซ็นเซอร์ภายในหายไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>ตรวจไม่พบพัดลมเครื่องชาร์จ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>พัดลมชาร์จกระแสเกิน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>ขั้วชาร์จร้อนเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>เครื่องชาร์จลัดวงจร</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>ปัญหาสเตจกำลังไฟของเครื่องชาร์จ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>การป้องกันการชาร์จเกิน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>อินพุตไฟฟ้าแรงสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>การป้อนกระแสเกิน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>ป้อนพลังงานมากเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>ตรวจพบปัญหาที่ขั้วต่อขาเข้า</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>แรงดันไฟฟ้าขาเข้าขาด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>อินพุตปิด (ไม่มีการลองใหม่)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>อินพุตปิด (ลองอีกครั้ง)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>การป้อนเข้าภายในล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>การแยก PV ล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>ตรวจพบความผิดพลาดของกราวด์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>โอเวอร์โหลดอินเวอร์เตอร์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>อุณหภูมิอินเวอร์เตอร์สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>กระแสไฟสูงสุดของอินเวอร์เตอร์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>อินเวอร์เตอร์ระดับ DC ภายใน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>อินเวอร์เตอร์ผิดระดับ ACout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>เกิดข้อผิดพลาดของ powerstage อินเวอร์เตอร์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>อินเวอร์เตอร์ที่เชื่อมต่อกับ AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>ความผิดพลาดในการทดสอบรีเลย์ ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>ข้อผิดพลาดในการทดสอบรีเลย์ ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>อุปกรณ์หายไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>อุปกรณ์ที่เข้ากันไม่ได้</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>ขาดการเชื่อมต่อ BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>กำหนดค่าเครือข่ายไม่ถูกต้อง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>การหมุนเฟส</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>อินพุต AC หลายช่อง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>โอเวอร์โหลดเฟส</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>ข้อผิดพลาดในการเขียนหน่วยความจำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>อุณหภูมิ CPU สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>การสื่อสารขาดการเชื่อมต่อ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>ข้อมูลการสอบเทียบสูญหาย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>เฟิร์มแวร์ที่เข้ากันไม่ได้</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>ฮาร์ดแวร์ที่เข้ากันไม่ได้</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>การตั้งค่าไม่ถูกต้อง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>แรงดันอ้างอิงล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>ผู้ทดสอบล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>ประวัติไม่ถูกต้อง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>ตัวนับ kWh ไม่ถูกต้อง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>ข้อผิดพลาดของแรงดันไฟฟ้ากระแสตรง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>ข้อผิดพลาดของเซ็นเซอร์ GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>ข้อผิดพลาดในการจัดหา 3V3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>ข้อผิดพลาดในการจัดหา 5V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>ข้อผิดพลาดในการจ่ายไฟ 12V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>ข้อผิดพลาดในการจ่ายไฟ 15V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>การปิดอินพุต PV</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>ตั้งสวิตช์ในตำแหน่งปลดล็อคเพื่อแก้ไขการตั้งค่า</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>ใช้แหล่งข้อมูล D-Bus: เชื่อมต่อกับที่อยู่ D-Bus ที่ระบุ</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>ที่อยู่</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>ใช้แหล่งข้อมูล D-Bus: เชื่อมต่อกับที่อยู่ D-Bus เริ่มต้น</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>ใช้แหล่งข้อมูล MQTT: เชื่อมต่อกับที่อยู่โบรกเกอร์ MQTT ที่ระบุ</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>ที่อยู่</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>รหัสพอร์ทัลอุปกรณ์แหล่งข้อมูล MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>รหัสพอร์ทัล</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>ชาร์ดเว็บโฮสต์ MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>เศษ</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>ชื่อผู้ใช้แหล่งข้อมูล MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>ผู้ใช้</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>รหัสผ่านแหล่งข้อมูล MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>ผ่าน</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>โทเค็นแหล่งข้อมูล MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>โทเค็น</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>เปิดใช้งานตัวนับ FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>ข้ามหน้าจอเริ่มต้น</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>ใช้แหล่งข้อมูลจำลองสำหรับการทดสอบ</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>อุปกรณ์ถูกปิด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>แบบผสมเก่า/ใหม่ MK2 .</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>ข้อผิดพลาดของอุปกรณ์ที่คาดไว้</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>ไม่พบอุปกรณ์อื่น</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>แรงดันไฟเกินใน AC-ขาออก</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>ข้อผิดพลาดของโปรแกรม DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS ไม่มีผู้ช่วย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>การทดสอบการถ่ายทอดกราวด์ล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>ข้อผิดพลาดในการซิงค์เวลาของระบบ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>ข้อผิดพลาดการทดสอบรีเลย์กริด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>การตั้งค่าไม่ตรงกันกับ mcu . ตัวที่ 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>ข้อผิดพลาดในการส่งอุปกรณ์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>กำลังรอการกำหนดค่าหรือดองเกิลหายไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>เฟสมาสเตอร์หายไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>เกิดแรงดันไฟเกิน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>สเลฟไม่มีอินพุต AC!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>อุปกรณ์ไม่สามารถเป็นทาสได้</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>การป้องกันระบบเริ่มต้นขึ้น</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>เฟิร์มแวร์ไม่เข้ากัน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>ข้อผิดพลาดภายใน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>การทดสอบรีเลย์ล้มเหลวป้องกันการเชื่อมต่อ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>ข้อผิดพลาดของ VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>ข้อผิดพลาดภายใน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>อุณหภูมิสูงแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>แบตเตอรี่ไฟฟ้าแรงสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>แรงดันไฟต่ำของแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>แรงดันแบตเตอรี่เกินการกำหนดค่าสูงสุด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับอุณหภูมิสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับ RPM สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>ไดรฟ์ภาคสนาม FET อุณหภูมิสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>ขาดเซ็นเซอร์ที่จำเป็น</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับแรงดันต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>ออฟเซ็ตไฟฟ้าแรงสูงกระแสสลับ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับเกินกำหนดmax</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับแรงสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>ถอดแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>ตัดการเชื่อมต่อไฟฟ้าแรงสูงของแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>อินสแตนซ์แบตเตอรี่อยู่นอกช่วง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>BMS มากเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>เกี่ยวกับการตัดการเชื่อมต่อแบตเตอรี่</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>มีอุปกรณ์ให้ติดตามมากเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>ตัดการเชื่อมต่อ แบตเตอรี่แรงดันต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>ตัดการเชื่อมต่อ กระแสไฟของแบตเตอรี่สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>ตัดการเชื่อมต่อ แบตเตอรี่อุณหภูมิสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>ตัดการเชื่อมต่อ แบตเตอรี่อุณหภูมิต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>ขาดการเชื่อมต่อ BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC พิการ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>ตัวแปลง DC/DC ไม่พร้อมทำงาน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC แรงดันไฟฟ้าหลักสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC แรงดันไฟหลักต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC แรงดันไฟฟ้าทุติยภูมิสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC แรงดันไฟฟ้าทุติยภูมิต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC อุณหภูมิสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>การกำหนดค่า DC/DC ผิดพลาด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>เซ็นเซอร์อุณหภูมิแบตเตอรี่ชำรุด</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>อุณหภูมิสูงแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>แบตเตอรี่ไฟฟ้าแรงสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>แบตเตอรี่ Tsense ต่อสายผิด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>ไม่พบการเชื่อมต่อสาย Tsense ของแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>เชื่อมต่อสาย Vsense ของแบตเตอรี่ผิด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>แบตเตอรี Vsense หายไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>การสูญเสียสายไฟสูงของแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>แรงดันไฟต่ำของแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>แรงดันไฟฟ้าระลอกสูงของแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>สถานะการชาร์จของแบตเตอรี่ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>ปัญหาแรงดันไฟจุดกึ่งกลางของแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>อุณหภูมิแบตเตอรี่ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>เครื่องชาร์จอุณหภูมิสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>ตรวจพบกระแสไฟที่ชาร์จมากเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>กระแสไฟลบของเครื่องชาร์จ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>หมดเวลาชาร์จแบตหมด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>ปัญหาเซ็นเซอร์ปัจจุบันของเครื่องชาร์จ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>เซ็นเซอร์ภายในเดินสายผิด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>เซ็นเซอร์ภายในหายไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>ตรวจไม่พบพัดลมเครื่องชาร์จ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>พัดลมชาร์จกระแสเกิน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>ขั้วชาร์จร้อนเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>เครื่องชาร์จลัดวงจร</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>ปัญหาสเตจกำลังไฟของเครื่องชาร์จ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>การป้องกันการชาร์จเกิน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>อินพุตไฟฟ้าแรงสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>การป้อนกระแสเกิน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>ป้อนพลังงานมากเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>ตรวจพบปัญหาที่ขั้วต่อขาเข้า</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>แรงดันไฟฟ้าขาเข้าขาด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>อินพุตปิด (ไม่มีการลองใหม่)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>อินพุตปิด (ลองอีกครั้ง)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>การป้อนเข้าภายในล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>การแยก PV ล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>ตรวจพบความผิดพลาดของกราวด์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>โอเวอร์โหลดอินเวอร์เตอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>อุณหภูมิอินเวอร์เตอร์สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>กระแสไฟสูงสุดของอินเวอร์เตอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>อินเวอร์เตอร์ระดับ DC ภายใน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>อินเวอร์เตอร์ผิดระดับ ACout</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>เกิดข้อผิดพลาดของ powerstage อินเวอร์เตอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>อินเวอร์เตอร์ที่เชื่อมต่อกับ AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>ความผิดพลาดในการทดสอบรีเลย์ ACIN1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>ข้อผิดพลาดในการทดสอบรีเลย์ ACIN2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>อุปกรณ์หายไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>อุปกรณ์ที่เข้ากันไม่ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>ขาดการเชื่อมต่อ BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>กำหนดค่าเครือข่ายไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>การหมุนเฟส</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>อินพุต AC หลายช่อง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>โอเวอร์โหลดเฟส</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>ข้อผิดพลาดในการเขียนหน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>อุณหภูมิ CPU สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>การสื่อสารขาดการเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>ข้อมูลการสอบเทียบสูญหาย</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>เฟิร์มแวร์ที่เข้ากันไม่ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>ฮาร์ดแวร์ที่เข้ากันไม่ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>การตั้งค่าไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>แรงดันอ้างอิงล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>ผู้ทดสอบล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>ประวัติไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>ตัวนับ kWh ไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>ข้อผิดพลาดของแรงดันไฟฟ้ากระแสตรง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>ข้อผิดพลาดของเซ็นเซอร์ GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>ข้อผิดพลาดในการจัดหา 3V3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>ข้อผิดพลาดในการจัดหา 5V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>ข้อผิดพลาดในการจ่ายไฟ 12V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>ข้อผิดพลาดในการจ่ายไฟ 15V</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>การปิดอินพุต PV</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับ L1 ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับ L1 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>ความถี่ AC L1 ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>ความถี่ AC ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>ความถี่ AC L1 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>ความถี่ไฟฟ้ากระแสสลับสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>กระแสไฟ AC L1 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>กระแสไฟ AC สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>ไฟ AC L1 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>ไฟ AC สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>หยุดฉุกเฉิน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>กระแสเซอร์โวสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>แรงดันน้ำมันเครื่องต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>แรงดันน้ำมันเครื่องสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>อุณหภูมิเครื่องยนต์ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>อุณหภูมิเครื่องยนต์สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>ไขลานอุณหภูมิต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>อุณหภูมิของขดลวดสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>อุณหภูมิไอเสียต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>อุณหภูมิไอเสียสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>อุณหภูมิอิเล็กทรอนิกส์ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>อุณหภูมิอิเล็คทรอนิกส์สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>แรงดันไฟสตาร์ทต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>กระแสไฟสตาร์ทสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>แรงดันไฟเรืองแสงต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>กระแสไฟเรืองแสงสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>แรงดันไฟช่วยสตาร์ทเครื่องเย็นสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>กระแสไฟช่วยสตาร์ทเย็นสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>แรงดันไฟแม่เหล็กยึดเชื้อเพลิงต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>กระแสแม่เหล็กดูดเชื้อเพลิงสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>หยุดขดลวดโซลินอยด์ยึดแรงดันไฟฟ้าต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>หยุดโซลินอยด์ถือกระแสคอยล์สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>หยุดขดลวดดึงโซลินอยด์แรงดันไฟฟ้าต่ำเกินไป </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>หยุดกระแสดึงขดลวดโซลินอยด์สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>แรงดันไฟพัดลม/ปั๊มน้ำต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>กระแสไฟพัดลม/ปั๊มน้ำสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>แรงดันไฟเซ็นเซอร์ปัจจุบันต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>เซ็นเซอร์กระแสไฟกระแสสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>แรงดันเอาท์พุตบูสต์ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>การเพิ่มกระแสไฟขาออกสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>แรงดันไฟจ่ายบัสต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>กระแสไฟจ่ายบัสสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>แรงดันแบตเตอรี่สตาร์ทต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>แรงดันไฟแบตเตอรี่สตาร์ทสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>การหมุนต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>หมุนสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>การหยุดกะทันหัน/ปัญหาการจ่ายน้ำมัน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>แรงดันไฟคอนแทคเตอร์ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>กระแสไฟคอนแทคสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับ L2 ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับ L2 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>ความถี่ AC L2 ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>ความถี่ AC L2 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>กระแสไฟ AC L2 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>ไฟ AC L2 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับ L3 ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>แรงดันไฟฟ้ากระแสสลับ L3 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>ความถี่ AC L3 ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>ความถี่ AC L3 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>กระแสไฟ AC L3 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>ไฟ AC L3 สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>แรงดันไฟเอาท์พุตของอินเวอร์เตอร์ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>กระแสอินเวอร์เตอร์เอาท์พุตสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>แรงดันไฟขาออกสากล (1A) ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>กระแสไฟขาออกสากล (1A) สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>แรงดันไฟขาออกสากล (5A) ต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>กระแสไฟขาออกสากล (5A) สูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT แรงดันไฟ DC 1 ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>แรงดันไฟ DC AGT 1 สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT กระแสไฟ DC 1 ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT กระแสไฟ DC 1 สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>AGT แรงดันไฟ DC 2 ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>แรงดันไฟ DC AGT 2 สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>กระแสไฟ DC AGT 2 ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT กระแสไฟ DC 2 สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 คูลเลอร์ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 คูลเลอร์สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>ราง AGT B6 (-) ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>ราง AGT B6 (-) สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>ราง AGT B6 (+) ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>ราง AGT B6 (+) สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>อุณหภูมิน้ำมันเชื้อเพลิงต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>อุณหภูมิน้ำมันเชื้อเพลิงสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>ระดับน้ำมันเชื้อเพลิงต่ำเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>หน่วยควบคุมหาย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>แผงหายไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>ต้องรับการตรวจเช็ค</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>โมดูล 3 เฟสหาย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>โมดูล AGT ที่หายไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>การซิงโครไนซ์ล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>สูญเสีย ECU ภายนอก</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>กรองอากาศเข้า</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>ข้อความวินิจฉัย (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>การซิงค์ที่หายไป โมดูล</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>โหลดบาลานซ์ล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>ปิดใช้งานโหมดซิงค์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>ไฟเบรกสีแดง (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>ไฟเตือนสีเหลืองอำพัน (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>ไฟแสดงการทำงานผิดปกติ (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>โคมไฟป้องกัน (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>การหมุนผิด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>เซ็นเซอร์ระดับน้ำมันเชื้อเพลิงหาย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>การสตาร์ทโดยไม่ต้องใช้อินเวอร์เตอร์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>รถบัสหมายเลข 1 เสีย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>คำขอเริ่มต้นถูกปฏิเสธ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>การเริ่มต้นระยะไกลถูกปฏิเสธ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>รีเลย์ปิดโหลดแบบบังคับ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>โมดูลการซิงโครไนซ์ออฟไลน์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>BMS หาย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>ตัวแปลง DC Link แรงดันไฟต่ำ/ย้อนกลับ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>ตัวแปลงกระแสตรงเชื่อมต่อกระแสต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>ตัวแปลง DC แรงดันไฟชาร์จล่วงหน้าต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>ตัวแปลง DC แรงดันไฟชาร์จล่วงหน้าสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>ข้อผิดพลาดไดรเวอร์ตัวแปลง IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>วงจรควบคุมพลังงานผิดพลาดของตัวแปลง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>การตรวจจับความถี่ตัวแปลงไฟฟ้ากระแสสลับ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>ค่าควบคุมตัวแปลงล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>การตั้งค่าจากโรงงานมีการเปลี่ยนแปลง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>พารามิเตอร์เปลี่ยนแปลงในโหมดผู้ดูแลระบบ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>การแทรกแซงด้วยตนเอง (ระบบภายนอก)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>การเริ่มต้นล้มเหลว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>สุนัขเฝ้าบ้าน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>อุณหภูมิอินเวอร์เตอร์สูง L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>อุณหภูมิอินเวอร์เตอร์สูง L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>อุณหภูมิอินเวอร์เตอร์สูง L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>อินเวอร์เตอร์อุณหภูมิสูง DC ลิงค์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>โอเวอร์โหลดอินเวอร์เตอร์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>การสื่อสารของอินเวอร์เตอร์สูญหาย</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>DC โอเวอร์โหลด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>DC แรงดันไฟเกิน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>ไม่มีการเชื่อมต่อ</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>ไม่มีข้อผิดพลาด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>แรงดันน้ำมัน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>หัวกระบอกสูบมีอุณหภูมิสูงเกินไป</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>การควบคุมการชาร์จ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>ความเร็วสูงเกินความคาดหวัง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>ความเร็วเกินกำหนด</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>อุณหภูมิน้ำมันสูงเกินกว่าที่คาดไว้</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>อุณหภูมิของน้ำมันวงจรเปิด / ไฟฟ้าลัดวงจร</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>อุณหภูมิของน้ำมันสั้นลงถึงพื้น</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>เซ็ตพอยต์อนาล็อกสูง/ลัดวงจร</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>เซ็ตพอยต์อนาล็อกต่ำ/ลัดวงจรลงกราวด์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>หมดเวลารับข้อความ TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>CM1 หมดเวลารับข้อความ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>แรงดันไฟแบตเตอรี่สูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>แรงดันไฟแบตเตอรี่ต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>สัญญาณความเร็วผิดเพี้ยน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>เซ็นเซอร์ภายใน 5V จ่ายไฟสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>เซ็นเซอร์ภายใน 5V จ่ายไฟต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>ความกดอากาศสูง</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>ความกดอากาศต่ำ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>ปั๊มเชื้อเพลิงเอาท์พุตลัดวงจร</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>ปั๊มเชื้อเพลิงเอาท์พุตลัดวงจรลงกราวด์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>หัวเทียนร้อนออกลัดวงจรต่อไฟ</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>หัวเทียนร้อนออกลัดวงจรลงกราวด์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>หัวฉีดเปิดวงจร/ด้านต่ำลัดวงจรลงกราวด์</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>วงจรภายในของคอยล์หัวฉีดลัดวงจร</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>หัวฉีดด้านต่ำลัดวงจรไฟฟ้า</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>ชั่วโมงบริการหมดเขตแล้ว</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>โปรเซสเซอร์ขัดข้อง</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>แบตเตอรี่</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>แบตเตอรี่</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>ตู้เย็น</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>ตู้เย็น</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>ทั่วไป</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>ทั่วไป</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>ห้อง</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>ห้อง</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>กลางแจ้ง</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>กลางแจ้ง</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>เครื่องทำน้ำอุ่น</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>เครื่องทำน้ำอุ่น</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>ช่องแช่แข็ง</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>ช่องแช่แข็ง</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับ L1 ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับ L1 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>ความถี่ AC L1 ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>ความถี่ AC ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>ความถี่ AC L1 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>ความถี่ไฟฟ้ากระแสสลับสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>กระแสไฟ AC L1 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>กระแสไฟ AC สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>ไฟ AC L1 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>ไฟ AC สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>หยุดฉุกเฉิน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>กระแสเซอร์โวสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>แรงดันน้ำมันเครื่องต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>แรงดันน้ำมันเครื่องสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>อุณหภูมิเครื่องยนต์ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>อุณหภูมิเครื่องยนต์สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>ไขลานอุณหภูมิต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>อุณหภูมิของขดลวดสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>อุณหภูมิไอเสียต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>อุณหภูมิไอเสียสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>อุณหภูมิอิเล็กทรอนิกส์ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>อุณหภูมิอิเล็คทรอนิกส์สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>แรงดันไฟสตาร์ทต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>กระแสไฟสตาร์ทสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>แรงดันไฟเรืองแสงต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>กระแสไฟเรืองแสงสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>แรงดันไฟช่วยสตาร์ทเครื่องเย็นสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>กระแสไฟช่วยสตาร์ทเย็นสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>แรงดันไฟแม่เหล็กยึดเชื้อเพลิงต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>กระแสแม่เหล็กดูดเชื้อเพลิงสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>หยุดขดลวดโซลินอยด์ยึดแรงดันไฟฟ้าต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>หยุดโซลินอยด์ถือกระแสคอยล์สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>หยุดขดลวดดึงโซลินอยด์แรงดันไฟฟ้าต่ำเกินไป </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>หยุดกระแสดึงขดลวดโซลินอยด์สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>แรงดันไฟพัดลม/ปั๊มน้ำต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>กระแสไฟพัดลม/ปั๊มน้ำสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>แรงดันไฟเซ็นเซอร์ปัจจุบันต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>เซ็นเซอร์กระแสไฟกระแสสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>แรงดันเอาท์พุตบูสต์ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>การเพิ่มกระแสไฟขาออกสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>แรงดันไฟจ่ายบัสต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>กระแสไฟจ่ายบัสสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>แรงดันแบตเตอรี่สตาร์ทต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>แรงดันไฟแบตเตอรี่สตาร์ทสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>การหมุนต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>หมุนสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>การหยุดกะทันหัน/ปัญหาการจ่ายน้ำมัน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>แรงดันไฟคอนแทคเตอร์ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>กระแสไฟคอนแทคสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับ L2 ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับ L2 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>ความถี่ AC L2 ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>ความถี่ AC L2 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>กระแสไฟ AC L2 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>ไฟ AC L2 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับ L3 ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับ L3 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>ความถี่ AC L3 ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>ความถี่ AC L3 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>กระแสไฟ AC L3 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>ไฟ AC L3 สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>แรงดันไฟเอาท์พุตของอินเวอร์เตอร์ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>กระแสอินเวอร์เตอร์เอาท์พุตสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>แรงดันไฟขาออกสากล (1A) ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>กระแสไฟขาออกสากล (1A) สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>แรงดันไฟขาออกสากล (5A) ต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>กระแสไฟขาออกสากล (5A) สูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT แรงดันไฟ DC 1 ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>แรงดันไฟ DC AGT 1 สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT กระแสไฟ DC 1 ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT กระแสไฟ DC 1 สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>AGT แรงดันไฟ DC 2 ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>แรงดันไฟ DC AGT 2 สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>กระแสไฟ DC AGT 2 ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT กระแสไฟ DC 2 สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 คูลเลอร์ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 คูลเลอร์สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>ราง AGT B6 (-) ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>ราง AGT B6 (-) สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>ราง AGT B6 (+) ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>ราง AGT B6 (+) สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>อุณหภูมิน้ำมันเชื้อเพลิงต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>อุณหภูมิน้ำมันเชื้อเพลิงสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>ระดับน้ำมันเชื้อเพลิงต่ำเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>หน่วยควบคุมหาย</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>แผงหายไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>ต้องรับการตรวจเช็ค</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>โมดูล 3 เฟสหาย</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>โมดูล AGT ที่หายไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>การซิงโครไนซ์ล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>สูญเสีย ECU ภายนอก</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>กรองอากาศเข้า</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>ข้อความวินิจฉัย (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>การซิงค์ที่หายไป โมดูล</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>โหลดบาลานซ์ล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>ปิดใช้งานโหมดซิงค์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>ไฟเบรกสีแดง (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>ไฟเตือนสีเหลืองอำพัน (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>ไฟแสดงการทำงานผิดปกติ (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>โคมไฟป้องกัน (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>การหมุนผิด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>เซ็นเซอร์ระดับน้ำมันเชื้อเพลิงหาย</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>การสตาร์ทโดยไม่ต้องใช้อินเวอร์เตอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>รถบัสหมายเลข 1 เสีย</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>คำขอเริ่มต้นถูกปฏิเสธ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>การเริ่มต้นระยะไกลถูกปฏิเสธ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>รีเลย์ปิดโหลดแบบบังคับ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>โมดูลการซิงโครไนซ์ออฟไลน์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>BMS หาย</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>ตัวแปลง DC Link แรงดันไฟต่ำ/ย้อนกลับ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>ตัวแปลงกระแสตรงเชื่อมต่อกระแสต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>ตัวแปลง DC แรงดันไฟชาร์จล่วงหน้าต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>ตัวแปลง DC แรงดันไฟชาร์จล่วงหน้าสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>ข้อผิดพลาดไดรเวอร์ตัวแปลง IGBT/MOSFET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>วงจรควบคุมพลังงานผิดพลาดของตัวแปลง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>การตรวจจับความถี่ตัวแปลงไฟฟ้ากระแสสลับ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>ค่าควบคุมตัวแปลงล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>การตั้งค่าจากโรงงานมีการเปลี่ยนแปลง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>พารามิเตอร์เปลี่ยนแปลงในโหมดผู้ดูแลระบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>การแทรกแซงด้วยตนเอง (ระบบภายนอก)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>การเริ่มต้นล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>สุนัขเฝ้าบ้าน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>อุณหภูมิอินเวอร์เตอร์สูง L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>อุณหภูมิอินเวอร์เตอร์สูง L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>อุณหภูมิอินเวอร์เตอร์สูง L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>อินเวอร์เตอร์อุณหภูมิสูง DC ลิงค์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>โอเวอร์โหลดอินเวอร์เตอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>การสื่อสารของอินเวอร์เตอร์สูญหาย</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>DC โอเวอร์โหลด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>DC แรงดันไฟเกิน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>ไม่มีการเชื่อมต่อ</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>แรงดันน้ำมัน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>หัวกระบอกสูบมีอุณหภูมิสูงเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>การควบคุมการชาร์จ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>ความเร็วสูงเกินความคาดหวัง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>ความเร็วเกินกำหนด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>อุณหภูมิน้ำมันสูงเกินกว่าที่คาดไว้</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>อุณหภูมิของน้ำมันวงจรเปิด / ไฟฟ้าลัดวงจร</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>อุณหภูมิของน้ำมันสั้นลงถึงพื้น</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>เซ็ตพอยต์อนาล็อกสูง/ลัดวงจร</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>เซ็ตพอยต์อนาล็อกต่ำ/ลัดวงจรลงกราวด์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>หมดเวลารับข้อความ TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>CM1 หมดเวลารับข้อความ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>แรงดันไฟแบตเตอรี่สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>แรงดันไฟแบตเตอรี่ต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>สัญญาณความเร็วผิดเพี้ยน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>เซ็นเซอร์ภายใน 5V จ่ายไฟสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>เซ็นเซอร์ภายใน 5V จ่ายไฟต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>ความกดอากาศสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>ความกดอากาศต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>ปั๊มเชื้อเพลิงเอาท์พุตลัดวงจร</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>ปั๊มเชื้อเพลิงเอาท์พุตลัดวงจรลงกราวด์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>หัวเทียนร้อนออกลัดวงจรต่อไฟ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>หัวเทียนร้อนออกลัดวงจรลงกราวด์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>หัวฉีดเปิดวงจร/ด้านต่ำลัดวงจรลงกราวด์</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>วงจรภายในของคอยล์หัวฉีดลัดวงจร</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>หัวฉีดด้านต่ำลัดวงจรไฟฟ้า</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>ชั่วโมงบริการหมดเขตแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>โปรเซสเซอร์ขัดข้อง</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>ตั้งสวิตช์ในตำแหน่งปลดล็อคเพื่อแก้ไขการตั้งค่า</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>ใช้แหล่งข้อมูล D-Bus: เชื่อมต่อกับที่อยู่ D-Bus ที่ระบุ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>ที่อยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>ใช้แหล่งข้อมูล D-Bus: เชื่อมต่อกับที่อยู่ D-Bus เริ่มต้น</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>ใช้แหล่งข้อมูล MQTT: เชื่อมต่อกับที่อยู่โบรกเกอร์ MQTT ที่ระบุ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>ที่อยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>รหัสพอร์ทัลอุปกรณ์แหล่งข้อมูล MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>รหัสพอร์ทัล</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>ชาร์ดเว็บโฮสต์ MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>เศษ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>ชื่อผู้ใช้แหล่งข้อมูล MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>ผู้ใช้</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>รหัสผ่านแหล่งข้อมูล MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>ผ่าน</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>โทเค็นแหล่งข้อมูล MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>โทเค็น</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>เปิดใช้งานตัวนับ FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>ข้ามหน้าจอเริ่มต้น</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>ใช้แหล่งข้อมูลจำลองสำหรับการทดสอบ</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>เวลามาตรฐานโมร็อกโก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>W. เวลามาตรฐานแอฟริกากลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>เวลามาตรฐานของแอฟริกาใต้</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>เวลามาตรฐานนามิเบีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>เวลามาตรฐานอียิปต์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>E. เวลามาตรฐานแอฟริกา</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>เวลามาตรฐานอาร์เจนตินา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>E. เวลามาตรฐานของอเมริกาใต้</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>เวลามาตรฐานกรีนแลนด์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>เวลามาตรฐานมอนเตวิเดโอ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>เวลามาตรฐานนิวฟันด์แลนด์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>SA เวลามาตรฐานตะวันออก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>เวลามาตรฐานแอตแลนติก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>เวลามาตรฐานของบราซิลตอนกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิก SA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>เวลามาตรฐานปารากวัย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>SA เวลามาตรฐานตะวันตก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>เวลามาตรฐานของเวเนซุเอลา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>เวลามาตรฐานตะวันออก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิกของ SA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>เวลามาตรฐานตะวันออกของสหรัฐอเมริกา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>เวลามาตรฐานกลางของแคนาดา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>เวลามาตรฐานของอเมริกากลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>เวลามาตรฐานตอนกลาง (เม็กซิโก)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>เวลามาตรฐานตอนกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>เวลามาตรฐานแถบภูเขาสูง (เม็กซิโก)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>เวลามาตรฐานบนภูเขา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>เวลามาตรฐานภูเขาของสหรัฐอเมริกา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>เวลามาตรฐานแปซิฟิก (เม็กซิโก)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>เวลามาตรฐานอลาสก้า</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>ฮาวาย-Aleutian</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>E. เวลามาตรฐานแอฟริกา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิก SA</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>SA เวลามาตรฐานตะวันตก</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>เวลามาตรฐานคัมชัตกา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>เวลามาตรฐานมากาดาน</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>เวลามาตรฐานวลาดีวอสตอค</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>เวลามาตรฐานยาคุตสค์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>เวลามาตรฐานโตเกียว</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>เวลามาตรฐานเกาหลี</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>เวลามาตรฐานสิงคโปร์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>เวลามาตรฐานอูลานบาตอร์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>เวลามาตรฐานไทเป</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียเหนือตะวันออก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>เวลามาตรฐานของจีน</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียเหนือ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>เวลามาตรฐานของเมียนมาร์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียกลางเหนือ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>เวลามาตรฐานบังกลาเทศ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>เวลามาตรฐานเนปาล</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>เวลามาตรฐานศรีลังกา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>เวลามาตรฐานอินเดีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>เวลามาตรฐานของปากีสถาน</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>เวลามาตรฐานเอคาเตรินเบิร์ก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>เวลามาตรฐานจอร์เจีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>เวลามาตรฐานคอเคซัส</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>เวลามาตรฐานอาเซอร์ไบจาน</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>เวลามาตรฐานอาหรับ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>เวลามาตรฐานอัฟกานิสถาน</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>เวลามาตรฐานอิหร่าน</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>เวลามาตรฐานภาษาอาหรับ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>เวลามาตรฐานอาหรับ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>เวลามาตรฐานซีเรีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>เวลามาตรฐานตะวันออกกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>เวลามาตรฐานจอร์แดน</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>เวลามาตรฐานของอิสราเอล</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>เวลามาตรฐานกรีนิช</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>เวลามาตรฐานอะซอเรส</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>เวลามาตรฐานเคปเวิร์ด</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>เวลามาตรฐานแทสเมเนีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>E. เวลามาตรฐานของออสเตรเลีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>เวลามาตรฐานตะวันออกของ AUS</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>เซน เวลามาตรฐานของออสเตรเลีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>เวลามาตรฐานกลาง AUS</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>เวลามาตรฐานกลางมหาสมุทรแอตแลนติก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Dateline เวลามาตรฐาน</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>เวลามาตรฐาน GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>เวลามาตรฐานยุโรปกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>เวลามาตรฐานยุโรปกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>เวลามาตรฐานโรแมนติก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>เวลามาตรฐานยุโรปตะวันออก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>เวลามาตรฐาน FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>เวลามาตรฐาน GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>เวลามาตรฐานเบลารุส</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>เวลามาตรฐานรัสเซีย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>เวลามาตรฐานของตุรกี</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>เวลามาตรฐานมอริเชียส</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>เวลามาตรฐานของเกาะคริสต์มาส</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>เวลามาตรฐานตองกา</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>เวลามาตรฐานฟิจิ</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>เวลามาตรฐานซามัว</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>เวลามาตรฐานฮาวาย</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>เวลามาตรฐานของเกาะอีสเตอร์</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">ข้อผิดพลาดภายใน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>ข้อผิดพลาดภายใน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>ไม่มีข้อผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>อุณหภูมิสูงแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>แบตเตอรี่ไฟฟ้าแรงสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>แรงดันไฟต่ำของแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>แรงดันแบตเตอรี่เกินการกำหนดค่าสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับอุณหภูมิสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับ RPM สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>ไดรฟ์ภาคสนาม FET อุณหภูมิสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>ขาดเซ็นเซอร์ที่จำเป็น</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับแรงดันต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>ออฟเซ็ตไฟฟ้าแรงสูงกระแสสลับ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>แรงดันไฟฟ้ากระแสสลับเกินกำหนดmax</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>เครื่องกำเนิดไฟฟ้ากระแสสลับแรงสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>ถอดแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>ตัดการเชื่อมต่อไฟฟ้าแรงสูงของแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>อินสแตนซ์แบตเตอรี่อยู่นอกช่วง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>BMS มากเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>เกี่ยวกับการตัดการเชื่อมต่อแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>มีอุปกรณ์ให้ติดตามมากเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>ตัดการเชื่อมต่อ แบตเตอรี่แรงดันต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>ตัดการเชื่อมต่อ กระแสไฟของแบตเตอรี่สูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>ตัดการเชื่อมต่อ แบตเตอรี่อุณหภูมิสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>ตัดการเชื่อมต่อ แบตเตอรี่อุณหภูมิต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>ขาดการเชื่อมต่อ BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC พิการ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>ตัวแปลง DC/DC ไม่พร้อมทำงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC แรงดันไฟฟ้าหลักสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC แรงดันไฟหลักต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC แรงดันไฟฟ้าทุติยภูมิสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC แรงดันไฟฟ้าทุติยภูมิต่ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC อุณหภูมิสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>การกำหนดค่า DC/DC ผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>เซ็นเซอร์อุณหภูมิแบตเตอรี่ชำรุด</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_tr.ts
+++ b/i18n/venus-gui-v2_tr.ts
@@ -1,7389 +1,8029 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="tr">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Devre dışı</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Devre dışı</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>İnvertör aşırı yüklü</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>İnvertör aşırı yüklü</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Güç</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Güç</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Kapalı</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Kapalı</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Otomatik</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Otomatik</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Akü</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Bağlandı</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Bağlantı kesildi</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Jeneratör</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Yüksek akü gerilimi</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Yüksek akü gerilimi</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>İnvertör / Şarj Cihazı</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>İnvertör / Şarj Cihazı</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Düşük akü gerilimi</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Düşük akü gerilimi</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>Manuel</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Manuel</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Yok</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Yok</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Konum</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Konum</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Hız</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Hız</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Durum</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Durum</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Yükleniyor %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Yükleniyor %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Bilinmeyen hata</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Bilinmeyen hata</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Minimüm SoC</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Minimüm SoC</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Bilinmiyor</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Parola Gir</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Parola Gir</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Kontrol etmek için basın</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Kontrol etmek için basın</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Şebeke</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Şebeke</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>Güneş enerjisi verimi</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>Güneş enerjisi verimi</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Extern kontrol</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Extern kontrol</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Tanklar</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Tanklar</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Çevre</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Çevre</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Güncel uyarı yok</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Güncel uyarı yok</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Genel</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Genel</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Firmware</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Tarih &amp; Saat</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Tarih &amp; Saat</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Sistem kurulumu</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Sistem kurulumu</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Ekran &amp; Dil</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Ekran &amp; Dil</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM online portal</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM online portal</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Enerji sayaçları</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Enerji sayaçları</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>PV İnvetörleri</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>PV İnvetörleri</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Eternet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Eternet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM modemi</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM modemi</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Jeneratör başlat/durdur</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Jeneratör başlat/durdur</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Tank pompası</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Tank pompası</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Services</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Services</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Venus OS Büyük özellikler</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Venus OS Büyük özellikler</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Akü ömrü sınırı: %1</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Akü ömrü sınırı: %1</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Otomatik başlatma devre dışı bırakılacak ve jeneratör yapılandırılan koşullara göre otomatik olarak başlamayacaktır.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Otomatik başlatma devre dışı bırakılacak ve jeneratör yapılandırılan koşullara göre otomatik olarak başlamayacaktır.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Manuel Durdurma</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Manuel Durdurma</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Manuel başlat</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Manuel başlat</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Konum</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Autostart</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Autostart</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Anahtarlar</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Anahtarlar</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Access level</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Access level</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Kullanıcı</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Kullanıcı</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Kullanıcı &amp; Yükleyici</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Kullanıcı &amp; Yükleyici</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Süper Kullanıcı</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Süper Kullanıcı</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Servis</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Servis</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>DVCC'yi devre dışı bıraktıktan sonra VE.Bus sistemini de sıfırladığınızdan emin olun</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>DVCC&apos;yi devre dışı bıraktıktan sonra VE.Bus sistemini de sıfırladığınızdan emin olun</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Ṣarj akımı limitle</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Ṣarj akımı limitle</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Maksimum şarj akımı</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Maksimum şarj akımı</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Başlat/durdur için %1 değerini kullan</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Başlat/durdur için %1 değerini kullan</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>1'den yüksek olduğunda başlat</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>1&apos;den yüksek olduğunda başlat</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>1'den düşük olduğunda başlat</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>1&apos;den düşük olduğunda başlat</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>1'den büyük olduğunda dur</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>1&apos;den büyük olduğunda dur</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>1'den küçük olduğunda dur</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>1&apos;den küçük olduğunda dur</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>IP adresini kaldırın?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>IP adresini kaldırın?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Max: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Max: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Bağlantı</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Bağlantı</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Ürün</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Ürün</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>İsim</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>İsim</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">İsim</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>Ürün ID'si</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>Ürün ID&apos;si</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Donanım sürümü</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Donanım sürümü</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Cihaz adı</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Cihaz adı</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Uzaktan kontrol anahtarı devre dışı</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Uzaktan kontrol anahtarı devre dışı</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Jeneratör arızalı durumda</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Jeneratör arızalı durumda</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>AC girişinde jeneratör algılanmadı</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>AC girişinde jeneratör algılanmadı</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Son testten  beri birikmiş çalışma süresi</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Son testten  beri birikmiş çalışma süresi</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Sonraki test zamanı</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Sonraki test zamanı</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Şimdi çalışıyor</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Şimdi çalışıyor</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Manuel başlat</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Manuel başlat</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Jeneratörü başlat</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Jeneratörü başlat</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Günlük çalışma süresi</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Günlük çalışma süresi</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Değer, durdurma değerinden yüksek olmalıdır</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Değer, durdurma değerinden yüksek olmalıdır</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Değer, başlangıç değerinden düşük olmalıdır</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Değer, başlangıç değerinden düşük olmalıdır</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>AC Çıkışı</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>AC Çıkışı</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">AC Çıkışı</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Başlatmak/durdurmak için AC Yükünü kullanın</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Başlatmak/durdurmak için AC Yükünü kullanın</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Ölçüm</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Ölçüm</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Toplam tüketim</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Toplam tüketim</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>İnvertör toplam AC çıkışı</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>İnvertör toplam AC çıkışı</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>İnvertör AC çıkışı en yüksek fazı</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>İnvertör AC çıkışı en yüksek fazı</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Güç şundan yüksekse başlat</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Güç şundan yüksekse başlat</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Güç şundan düşükse durdur</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Güç şundan düşükse durdur</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Akü Monitör</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Akü Monitör</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Monitör kullanılamıyor, yenisini ayarlayın</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Monitör kullanılamıyor, yenisini ayarlayın</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Akü Monitör</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Monitör kullanılamıyor, yenisini ayarlayın</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>İletişim kaybında</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>İletişim kaybında</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Jeneratörü durdur</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Jeneratörü durdur</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Jeneratörü çalıştırmaya devam et</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Jeneratörü çalıştırmaya devam et</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>AC girişi mevcut olduğunda jeneratörü durdurun</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>AC girişi mevcut olduğunda jeneratörü durdurun</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>Akü SOC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>Akü SOC</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">İnvertör yüksek sıcaklık</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>İnvertör yüksek sıcaklık</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>İnvertör yüksek sıcaklık</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Yüksek sıcaklık uyarısında başlat</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Yüksek sıcaklık uyarısında başlat</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Aşırı yük uyarısında başlat</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Aşırı yük uyarısında başlat</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Periyodik çalıştırma</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Periyodik çalıştırma</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Aralıklı çalıştır</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Aralıklı çalıştır</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>1 gün(ler)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>1 gün(ler)</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Şu kadar süre çalışırsa çalıştırmayı atla:</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Şu kadar süre çalışırsa çalıştırmayı atla:</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Her zaman başlat</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Her zaman başlat</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Aralıklı çalıştırma başlangıç tarihi</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Aralıklı çalıştırma başlangıç tarihi</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Çalıştırma süresi (sa:dk)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Çalıştırma süresi (sa:dk)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Akü tamamen şarj olana kadar çalıştır</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Akü tamamen şarj olana kadar çalıştır</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS TAMAM (sabit)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS TAMAM (sabit)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS bağlı, fakat GPS sabitleme yok</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS bağlı, fakat GPS sabitleme yok</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>Bağlı GPS yok</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>Bağlı GPS yok</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Enlem</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Enlem</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Boylam</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Boylam</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>1 km/saat</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>1 km/saat</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>1 mph</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>1 mph</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>1 m/s</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>1 m/s</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>Rota</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>Rota</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Yükseklik</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Yükseklik</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Uydu sayısı</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Uydu sayısı</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Grid Setpoint</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Grid Setpoint</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>AC-Girişi ayar noktası</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>AC-Girişi ayar noktası</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Akım: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Akım: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Voltaj: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Voltaj: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Sınırlar (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Sınırlar (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Ücret: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Ücret: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Deşarj: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Deşarj: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Sınırlar (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Sınırlar (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Görünür</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Görünür</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Gizli</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Gizli</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Aux ölçüm)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Aux ölçüm)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Çıkış %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Çıkış %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Aktif akü monitör</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Aktif akü monitör</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">İsim</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">İsim girin</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>İsim girin</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>İsim girin</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Sürekli tarama</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Sürekli tarama</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Bluetooth adaptörleri</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Bluetooth adaptörleri</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>Pin kodu</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>Pin kodu</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Bağlantıdan önce mevcut eşleştirme bilgilerini temizlemek gerekebilir.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Bağlantıdan önce mevcut eşleştirme bilgilerini temizlemek gerekebilir.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Faz tipi</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Faz tipi</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Tek faz</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Tek faz</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Çoklu faz</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Çoklu faz</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>Faz 2'deki PV invertörü</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>Faz 2&apos;deki PV invertörü</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>Faz 2'deki PV invertörü Konum</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>Faz 2&apos;deki PV invertörü Konum</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>CAN-bus profili</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>CAN-bus profili</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Devre dışı</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Açık, ancak hizmet yok (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Açık, ancak hizmet yok (250 kbit/s)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Cihazlar</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Cihazlar</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000-çıkış</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000-çıkış</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Benzersiz kimlik numarası seçicisi</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Benzersiz kimlik numarası seçicisi</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Lütfen bekleyin, benzersiz numaranın değiştirilmesi ve kontrol edilmesi biraz zaman alır</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Lütfen bekleyin, benzersiz numaranın değiştirilmesi ve kontrol edilmesi biraz zaman alır</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Yukarıdaki seçici PGN 60928 NAME alanındaki NAME Benzersiz Kimlik Numaraları için hangi benzersiz kimlik numarası bloğunun kullanılacağını ayarlar. Sadece bir VE.Can ağında birden fazla GX Cihazı kullanırken değiştirin.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Yukarıdaki seçici PGN 60928 NAME alanındaki NAME Benzersiz Kimlik Numaraları için hangi benzersiz kimlik numarası bloğunun kullanılacağını ayarlar. Sadece bir VE.Can ağında birden fazla GX Cihazı kullanırken değiştirin.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Yukarıdaki seçici, DGN 60928 ADDRESS_CLAIM alanındaki Seri numarası için hangi benzersiz kimlik numarası bloğunun kullanılacağını belirler. Yalnızca bir RV-C ağında birden fazla GX Cihazı kullanırken değiştirin.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Yukarıdaki seçici, DGN 60928 ADDRESS_CLAIM alanındaki Seri numarası için hangi benzersiz kimlik numarası bloğunun kullanılacağını belirler. Yalnızca bir RV-C ağında birden fazla GX Cihazı kullanırken değiştirin.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Benzersiz kimlik numaralarını kontrol et</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Benzersiz kimlik numaralarını kontrol et</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Kontrol etmek için basın</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>Bu benzersiz numaraya bağlı başka bir cihaz var, lütfen yeni bir numara seçin.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>Bu benzersiz numaraya bağlı başka bir cihaz var, lütfen yeni bir numara seçin.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>TAMAM: Bu benzersiz numaraya bağlı başka bir cihaz yok.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>TAMAM: Bu benzersiz numaraya bağlı başka bir cihaz yok.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Ağ durumu</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Ağ durumu</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Uyarlamalı parlaklık</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Uyarlamalı parlaklık</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Parlaklık</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Parlaklık</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Ekran kapanma süresi</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Ekran kapanma süresi</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 sn</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 sn</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 sn</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 sn</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 dak</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 dak</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 dak</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 dak</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 dak</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 dak</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Hiçbir zaman</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Hiçbir zaman</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Ekran modu</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Ekran modu</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Koyu</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Koyu</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Açık</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Açık</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Kısa görünüm seviyeleri</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Kısa görünüm seviyeleri</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Dil</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Dil</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Dil değiştirme</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Dil değiştirme</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Elektrik gücü göstergesi</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Elektrik gücü göstergesi</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Güç (Watt)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Güç (Watt)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Akım (Amper)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Akım (Amper)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Birimler</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Birimler</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Seviye %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Seviye %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Santigrat</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Santigrat</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Fahrenheit</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Fahrenheit</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;DİKKAT:&lt;/b&gt; Ayarlamadan önce kılavuzu okuyun.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;DİKKAT:&lt;/b&gt; Ayarlamadan önce kılavuzu okuyun.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Yönetilen-akü şarj voltajını sınırlayın</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Yönetilen-akü şarj voltajını sınırlayın</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Maksimum şarj voltajı</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Maksimum şarj voltajı</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS-Paylaşılan voltaj sensörü</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS-Paylaşılan voltaj sensörü</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Paylaşılan sıcaklık sensörü</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Paylaşılan sıcaklık sensörü</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Sensör kullanılamıyor, başka birini ayarlayın</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Sensör kullanılamıyor, başka birini ayarlayın</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Sensör kullanılamıyor, başka birini ayarlayın</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Kullanılmış sensör</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Kullanılmış sensör</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Paylaşılan akım sensörü</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Paylaşılan akım sensörü</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>SCS durumu</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>SCS durumu</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Devre dışı (extern kontrol)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Devre dışı (extern kontrol)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Devre dışı (şarj cihazı yok)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Devre dışı (şarj cihazı yok)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Devre dışı (akü monitörü yok)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Devre dışı (akü monitörü yok)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Otomatik seçim</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Otomatik seçim</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>BMS kontrolü yok</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>BMS kontrolü yok</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>BMS'yi Kontrol etme</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>BMS&apos;yi Kontrol etme</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Kullanılamıyor, başka bir tane ayarla</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Kullanılamıyor, başka bir tane ayarla</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Otomatik seçili</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Otomatik seçili</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Yok</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Yapım tarihi/saati</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Yapım tarihi/saati</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Online güncellemeler</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Online güncellemeler</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Firmware SD/USB'den yükle</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Firmware SD/USB&apos;den yükle</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Kayıtlı yedek firmware</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Kayıtlı yedek firmware</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>SD/USB'deki güncellemeleri kontrol edin</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>SD/USB&apos;deki güncellemeleri kontrol edin</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Firmware bulundu</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Firmware bulundu</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>1 Yükleniyor</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>1 Yükleniyor</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">%1 Güncellemesi için basın</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>%1 Güncellemesi için basın</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>%1 Güncellemesi için basın</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Güncelleme sürümü tarihi/zamanı</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Güncelleme sürümü tarihi/zamanı</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Otomatik güncelleme</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Otomatik güncelleme</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Sadece kontrol et</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Sadece kontrol et</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Sasdece kontrol et ve indir</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Sasdece kontrol et ve indir</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Kontrol et ve güncelle</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Kontrol et ve güncelle</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>Veri güncelleme</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Veri güncelleme</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Image tipi</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Image tipi</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Normal</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Normal</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Büyük</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Büyük</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Yeni Güncellemeleri kontrol et</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Yeni Güncellemeleri kontrol et</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Yeni Güncelleme</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Yeni Güncelleme</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Installing %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Installing %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Yükleniyor %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Güncelleme yapım tarihi/saati</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Güncelleme yapım tarihi/saati</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>İnvertörler</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>İnvertörler</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>PV invertörlerini bul</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>PV invertörlerini bul</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Algılanan IP adresleri</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Algılanan IP adresleri</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>IP adresini manuel olarak ekle</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>IP adresini manuel olarak ekle</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>TCP bağlantı noktası</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>TCP bağlantı noktası</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Çok fazlı</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Çok fazlı</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Bölünmüş faz (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Bölünmüş faz (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Göster</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Göster</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-Giriş1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-Giriş1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-Giriş1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-Giriş1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-Giriş1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-Giriş1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Çıkış MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Çıkış MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-Giriş1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-Giriş1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC Çıkış L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC Çıkış L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Çıkış --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Çıkış --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-Giriş2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-Giriş2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-Giriş2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-Giriş2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-Giriş2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-Giriş2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>IP adresleri için yeniden tarama?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>IP adresleri için yeniden tarama?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Tekrar tara</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Tekrar tara</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>LAN'daki SSH</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>LAN&apos;daki SSH</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Uzaktan Destek</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Uzaktan Destek</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Uzaktan destek tüneli</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Uzaktan destek tüneli</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>Uzaktan destek IP'si ve bağlantı noktası</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>Uzaktan destek IP&apos;si ve bağlantı noktası</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Şimdi çıkış yap</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Yeniden başlat</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Yeniden başlat</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Cihaz yeniden başlatıldı.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Sesli alarm</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Sesli alarm</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Demo modu</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Demo modu</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS demosu</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS demosu</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Tekne/Karavan demosu 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Tekne/Karavan demosu 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Tekne/Karavan demosu 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Tekne/Karavan demosu 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Demo modunun başlatılması bazı ayarları değiştirecek ve kullanıcı arayüzü bir süreliğine yanıt vermeyecektir.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Demo modunun başlatılması bazı ayarları değiştirecek ve kullanıcı arayüzü bir süreliğine yanıt vermeyecektir.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Koşullar</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Koşullar</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Minimum çalışma süresi</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Minimum çalışma süresi</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Isınma süresi</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Isınma süresi</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Soğuma süresi</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Soğuma süresi</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>AC girişinde jeneratörü algıla</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>AC girişinde jeneratörü algıla</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>AC girişlerinin hiçbiri jeneratöre ayarlanmamış. Bu fonksiyonu etkinleştirmek için sistem kurulum sayfasından jeneratöre doğru AC giriş değerini sağlayın.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>AC girişlerinin hiçbiri jeneratöre ayarlanmamış. Bu fonksiyonu etkinleştirmek için sistem kurulum sayfasından jeneratöre doğru AC giriş değerini sağlayın.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>İnvertör AC girişinde jeneratörden güç gelmediği algılandığında alarm çalacaktır. Sistem kurulum sayfasında jeneratöre doğru AC girişinin sağlandığından emin olun.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>İnvertör AC girişinde jeneratörden güç gelmediği algılandığında alarm çalacaktır. Sistem kurulum sayfasında jeneratöre doğru AC girişinin sağlandığından emin olun.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Sessiz saatler başlangıç zamanı</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Sessiz saatler başlangıç zamanı</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Durgun saatler bitiş zamanı</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Durgun saatler bitiş zamanı</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Çalışma süresi ve servis</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Çalışma süresi ve servis</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Günlük çalışma süresi sayaçlarını sıfırlayın</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Günlük çalışma süresi sayaçlarını sıfırlayın</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Günlük çalışma süresi sayacı sıfırlandı</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Günlük çalışma süresi sayacı sıfırlandı</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Jeneratör çalışırken sayaçları değiştiremezsiniz</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Jeneratör çalışırken sayaçları değiştiremezsiniz</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Jeneratör servis aralığı (saat)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Jeneratör servis aralığı (saat)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Servis zaman aralığı %1h olarak ayarlandı. Servis zamanlayıcısını sıfırlamak için 'Servis zamanlayıcısını sıfırla' düğmesini kullanın.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Servis zaman aralığı %1h olarak ayarlandı. Servis zamanlayıcısını sıfırlamak için &apos;Servis zamanlayıcısını sıfırla&apos; düğmesini kullanın.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Servis zamanlayıcısını sıfırla</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Servis zamanlayıcısını sıfırla</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>GPS Ayarları</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>GPS Ayarları</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Biçim</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Biçim</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41,6" K, 5° 13' 12,3" D</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41,6&quot; K, 5° 13&apos; 12,3&quot; D</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52,34489, 5,22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52,34489, 5,22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20,693 K, 5° 13,205 D</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20,693 K, 5° 13,205 D</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Hız Birimi</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Hız Birimi</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Saatte Kilometre</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Saatte Kilometre</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Saniye başına metre</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Saniye başına metre</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>mil/s</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>mil/s</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Deniz mili</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Deniz mili</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>GSM modemi bağlı değil</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>GSM modemi bağlı değil</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Internet</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Internet</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Operatör</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Operatör</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Bu sayfanın altında yer alan APN ayarlarını yapılandırmanız gerekebilir. Ayrıntılar için operatörünüze başvurun.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Bu sayfanın altında yer alan APN ayarlarını yapılandırmanız gerekebilir. Ayrıntılar için operatörünüze başvurun.
 Bu işlem işe yaramazsa sim kartı bir telefona takarak veri indirmek için yeterli kontörünün ve/veya tarifesinin bulunduğundan emin olun.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Roaming izin ver</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Roaming izin ver</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Sim durumu</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Sim durumu</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM takılı değil</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM takılı değil</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>PIN gerekli</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>PIN gerekli</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>PUK gerekli</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>PUK gerekli</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>SIM hatası</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>SIM hatası</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM meşgul</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM meşgul</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Yanlış SIM</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Yanlış SIM</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Yanlış PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Yanlış PIN</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Hazır</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Hazır</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Bilinmeyen hata</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>Varsayılan</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>Varsayılan</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Varsayılan APN'yi kullan</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Varsayılan APN&apos;yi kullan</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>APN adı</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>APN adı</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Kimlik doğrulamayı kullan</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Kimlik doğrulamayı kullan</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Kullanıcı adı</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Kullanıcı adı</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Self-Consumption</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Self-Consumption</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>ESS Assistant bulunamadı</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>ESS Assistant bulunamadı</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Şebeke Meter</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Şebeke Meter</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Harici Meter</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Harici Meter</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>İnvertör/Şarj cihazı</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>İnvertör/Şarj cihazı</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>İnvertör AC çıkışı kullanımda</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>İnvertör AC çıkışı kullanımda</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Çok fazlı düzenleme</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Çok fazlı düzenleme</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Tüm fazların toplamı</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Tüm fazların toplamı</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Tek faz</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Tek faz</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Her faz ayrı ayrı şebeke ayar noktasına ulaşmak için düzenlenir (sistem verimliliği azalır).
+        <translation>Her faz ayrı ayrı şebeke ayar noktasına ulaşmak için düzenlenir (sistem verimliliği azalır).
 
 DİKKAT: Yalnızca hizmet sağlayıcı tarafından isteniyorsa kullanın.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Tüm fazların toplamı, şebeke ayar noktasına ulaşmak için akıllı bir şekilde düzenlenir (sistem verimliliği optimize edilir).
+        <translation>Tüm fazların toplamı, şebeke ayar noktasına ulaşmak için akıllı bir şekilde düzenlenir (sistem verimliliği optimize edilir).
 
 Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Aktif değil</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dinamik ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Minimum Deşarj SoC (şebeke kesintisi olmadıkça)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Minimum Deşarj SoC (şebeke kesintisi olmadıkça)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Aktif SOC (aku deşarj seviye) limiti</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Aktif SOC (aku deşarj seviye) limiti</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Sürdür</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Re-Şarj</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Peak shaving</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Peak shaving</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Yalnızca minimum SOC'nin üzerinde</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Yalnızca minimum SOC&apos;nin üzerinde</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Herzaman</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Herzaman</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Deşarj devre dışı</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Deşarj devre dışı</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Yavaş şarj</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Yavaş şarj</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Sürdür</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Sürdür</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Re-Şarj</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Re-Şarj</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Şarj akımı sınırla</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Şarj akımı sınırla</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Maksimum şarj gücü</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Maksimum şarj gücü</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>İnvertör gücünü sınırla</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>İnvertör gücünü sınırla</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Maksimum invertör gücü</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Maksimum invertör gücü</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Grid Setpoint</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Grid Setpoint</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Şebeke'ye Satış</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Şebeke&apos;ye Satış</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>AC kuplajlı PV - fazlasi Şebeke'ye Satış</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>AC kuplajlı PV - fazlasi Şebeke&apos;ye Satış</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>MPPT kuplajlı PV - fazlasi Şebeke'ye Satış</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>MPPT kuplajlı PV - fazlasi Şebeke&apos;ye Satış</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Şebeke'ye Satış limitle</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Şebeke&apos;ye Satış limitle</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Maksimum Şebeke'ye Satış</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Maksimum Şebeke&apos;ye Satış</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Şebeke'ye Satış limiti etkin</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Şebeke&apos;ye Satış limiti etkin</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Analog Girişler</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Analog Girişler</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Dijital girişler</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Dijital girişler</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Dijital giriş %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Dijital giriş %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Atım ölçer</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Atım ölçer</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Kapı Alarmı</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Kapı Alarmı</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Tahliye pompası</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Tahliye pompası</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Tahliye alarmı</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Tahliye alarmı</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Hırsız alarmı</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Hırsız alarmı</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Duman alarmı</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Duman alarmı</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Yangın alarmı</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Yangın alarmı</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>CO2 alarmı</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>CO2 alarmı</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Bluetooth sensörleri</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Bluetooth sensörleri</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Bu özelliklerin Victron tarafından resmi olarak desteklenmediğini unutmayın. Sorularınız için lütfen community.victronenergy.com adresini ziyaret edin.
+        <translation>Bu özelliklerin Victron tarafından resmi olarak desteklenmediğini unutmayın. Sorularınız için lütfen community.victronenergy.com adresini ziyaret edin.
 
 Documentation at https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Etkin (güvenli mod)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Etkin (güvenli mod)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Deferred by %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Deferred by %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>VRM Portal ID</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>VRM Portal ID</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Kayıtlama için zaman aralığı</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Kayıtlama için zaman aralığı</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 dak</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 dak</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 dak</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 dak</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 Saat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 Saat</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 saat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 saat</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 Saat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 Saat</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 saat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 saat</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 gün</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 gün</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Güvenli bağlantı kullanın (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Güvenli bağlantı kullanın (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Son temas</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Son temas</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Beklenmeyen yanıt metni</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Beklenmeyen yanıt metni</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Beklenmeyen HTTP yanıtı</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Beklenmeyen HTTP yanıtı</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Bağlantı zaman aşımı</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Bağlantı zaman aşımı</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Bağlantı hatası</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Bağlantı hatası</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 DNS hatası</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 DNS hatası</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Yönlendirme hatası</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Yönlendirme hatası</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM kullanılamıyor</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM kullanılamıyor</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Bilinmeyen hata</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Bilinmeyen hata</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Hata mesajı:
+        <translation>Hata mesajı:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Temas olmadığında cihazı yeniden başlat</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Temas olmadığında cihazı yeniden başlat</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Temas olmadığında sıfırlama gecikmesi (sa:dk)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Temas olmadığında sıfırlama gecikmesi (sa:dk)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Bellek konumu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Bellek konumu</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Aktif arabellek yok</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Aktif arabellek yok</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Intern bellek</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Intern bellek</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Aktarılıyor</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Aktarılıyor</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Extern bellek</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Extern bellek</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Bilinmeyen hata</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Hata yok</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Hata yok</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Bellekte yer kalmadı</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Bellekte yer kalmadı</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>IO hatası</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>IO hatası</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Bağlama hatası</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Bağlama hatası</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Firmware görüntüsü içerir. Kullanılamıyor.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Firmware görüntüsü içerir. Kullanılamıyor.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD kart/USB bellek yazılabilir değil</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD kart/USB bellek yazılabilir değil</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Boş disk alanı</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Boş disk alanı</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>bayt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>bayt</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>bayt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>bayt</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Depolanmış kayıtlar</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Depolanmış kayıtlar</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 kayıt</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 kayıt</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>En eski kayıt yaşı</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>En eski kayıt yaşı</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Modbus/TCP'yi etkinleştir</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Modbus/TCP&apos;yi etkinleştir</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Hata bildirilmedi</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Hata bildirilmedi</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Son hata saati</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Son hata saati</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Kullanılabilir servisler</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Kullanılabilir servisler</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>Birim Kimliği: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>Birim Kimliği: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Fonksiyon (Röle 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Fonksiyon (Röle 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Fonksiyon</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Fonksiyon</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Alarm rölesi</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Alarm rölesi</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Tank pompası</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuel</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Alarm röle polaritesi</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Alarm röle polaritesi</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>Normalde açık</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>Normalde açık</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>Normalde kapalı</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>Normalde kapalı</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Röle 1 açık</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Röle 1 açık</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Röle Açık</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Röle Açık</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Fonksiyon (Röle 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Fonksiyon (Röle 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Röle 2 açık</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Röle 2 açık</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Sıcaklık kontrol kuralları</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Sıcaklık kontrol kuralları</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Sıcaklıkta röle aktivasyonu</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Sıcaklıkta röle aktivasyonu</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Hiçbir röle sıcaklık ile etkinleştirilmek üzere yapılandırılmamıştır. Ana ayarlar menüsünde bulunan röle ayarları sayfasına gidin ve röle işlevini "Sıcaklık" olarak ayarlayın.</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Hiçbir röle sıcaklık ile etkinleştirilmek üzere yapılandırılmamıştır. Ana ayarlar menüsünde bulunan röle ayarları sayfasına gidin ve röle işlevini &quot;Sıcaklık&quot; olarak ayarlayın.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Bu seçenek mevcut ve eski Firmware sürümü arasında geçiş yapmanıza imkan tanır. İnternet ve sd kartı gerekmez.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Bu seçenek mevcut ve eski Firmware sürümü arasında geçiş yapmanıza imkan tanır. İnternet ve sd kartı gerekmez.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Donanım yazılımı %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Donanım yazılımı %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Önyükleme için basın</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Önyükleme için basın</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Donanım yazılımı %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Rebooting to %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Rebooting to %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Otomatik güncelleme "Kontrol et ve güncelle" olarak ayarlandığında aygıt yazılımı sürümünün değiştirilmesi mümkün değildir. Bu seçeneği etkinleştirmek için otomatik güncellemeyi "Devre Dışı" veya "Yalnızca kontrol et" olarak ayarlayın.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Otomatik güncelleme &quot;Kontrol et ve güncelle&quot; olarak ayarlandığında aygıt yazılımı sürümünün değiştirilmesi mümkün değildir. Bu seçeneği etkinleştirmek için otomatik güncellemeyi &quot;Devre Dışı&quot; veya &quot;Yalnızca kontrol et&quot; olarak ayarlayın.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Yedek firmware mevcut değil</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Yedek firmware mevcut değil</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>VE.Direct 1 üzerindeki Konsol</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>TCP/IP üzerinden CAN-bus (Hata Ayıklama)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>TCP/IP üzerinden CAN-bus (Hata Ayıklama)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Sahil</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Sahil</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Araç</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Araç</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Tekne</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Tekne</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Sistem adı</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Sistem adı</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Otomatik</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Otomatik</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Şebeke</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Otomatik</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Kullanıcı tanımlı</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Kullanıcı tanımlı</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Kullanıcı tanımlı ad</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Kullanıcı tanımlı ad</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>AC Giriş 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>AC Giriş 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>AC Giriş 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>AC Giriş 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Şebeke arızasını izleyin</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Şebeke arızasını izleyin</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Sahil kesintisi izleyin</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Sahil kesintisi izleyin</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Otomatik seçili</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Otomatik seçili</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>DC sistemi var</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>DC sistemi var</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>VE.Bus SOC ile aküyü senkronize et</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>VE.Bus SOC ile aküyü senkronize et</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>VE.Bus SOC'u geliştirmek için solar şarj cihazı kullanın</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>VE.Bus SOC&apos;u geliştirmek için solar şarj cihazı kullanın</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Solar şarj cihazı voltaj kontrolü</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Solar şarj cihazı voltaj kontrolü</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Solar şarj cihazı akım kontrolü</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Solar şarj cihazı akım kontrolü</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS kontrolü</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS kontrolü</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS kontrolü</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Tank pompası başlatma/durdurma işlevi etkin değil. Röle ayarlarına gidin ve işlevi "Tank pompası" olarak ayarlayın.</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Tank pompası başlatma/durdurma işlevi etkin değil. Röle ayarlarına gidin ve işlevi &quot;Tank pompası&quot; olarak ayarlayın.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Pompa durumu</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Pompa durumu</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Otomatik</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Tank sensörü</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Tank sensörü</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Start level</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Start level</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Stop level</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Stop level</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>Bağlantı kaybedildi</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>Bağlantı kaybedildi</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Fiş takılı değil</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Fiş takılı değil</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Gizli]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Gizli]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Ağa bağlan?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Ağa bağlan?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Erişim talep etmek</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Erişim talep etmek</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Ağı unut?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Ağı unut?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Unut</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Unut</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Bu ağı unutmak istediğinizden emin misiniz?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Bu ağı unutmak istediğinizden emin misiniz?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC adresi</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC adresi</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>IP yapılandırması</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>IP yapılandırması</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Manuel</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Kapalı</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Sabitlendi</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Sabitlendi</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Netmask</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Netmask</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Gateway</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Gateway</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS sunucusu</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS sunucusu</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Bağlantı-yerel IP adresi</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Bağlantı-yerel IP adresi</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>ESS sistemlerinde, yönetimli akülü sistemlerde olduğu gibi CAN veri yolu cihazı örneğinin 0'a ayarlı olarak kalması gerektiğine dikkat edin. Daha fazla bilgi için GX kılavuzuna bakın.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>ESS sistemlerinde, yönetimli akülü sistemlerde olduğu gibi CAN veri yolu cihazı örneğinin 0&apos;a ayarlı olarak kalması gerektiğine dikkat edin. Daha fazla bilgi için GX kılavuzuna bakın.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Device Instance</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Device Instance</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Ağ Adresi</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Ağ Adresi</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>VE.CAN cihazları</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>VE.CAN cihazları</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Cihaz# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Cihaz# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Access noktası yok</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Access noktası yok</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Wi-Fi adaptörü yok</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Wi-Fi adaptörü yok</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Access noktası oluştur</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Access noktası oluştur</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Wi-Fi ağı</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Wi-Fi ağı</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Access Pointı devre dışı bırakmak istediğinizden emin misiniz?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Access Pointı devre dışı bırakmak istediğinizden emin misiniz?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Tarih/Saat UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Tarih/Saat UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Tarih/Saat yerel</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Tarih/Saat yerel</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Saat dilimi</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Saat dilimi</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Afrika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Afrika</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Amerika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Amerika</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Antartika</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Antartika</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Artic</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Artic</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Asya</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Asya</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Atlantik</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Atlantik</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Avustralya</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Avustralya</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Avrupa</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Avrupa</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Hint</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Hint</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Pasifik</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Pasifik</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Bağlantısız %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Bağlantısız %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Yeniden başlat?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Yeniden başlat?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>VRM örneği değişiklikleri cihaz yeniden başlatılana kadar uygulanmayacaktır.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>VRM örneği değişiklikleri cihaz yeniden başlatılana kadar uygulanmayacaktır.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Cihaz yeniden başlatılıyor...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Cihaz yeniden başlatılıyor...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Cihaz yeniden başlatıldı.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Cihaz yeniden başlatıldı.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Düşük akü voltaj alarmı</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Düşük akü voltaj alarmı</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Yüksek akü voltaj alarmı</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Yüksek akü voltaj alarmı</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Son hata</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Son hata</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>İkinci son hata</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>İkinci son hata</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Üçüncü son hata</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Üçüncü son hata</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Dördüncü son hata</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Dördüncü son hata</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>Ağa bağlı</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>Ağa bağlı</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Mod ayarı</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Mod ayarı</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Standalone</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Standalone</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Standalone</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Şarj</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Şarj</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Extern kontrol</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Şarj &amp; HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Şarj &amp; HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Şarj ve BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Şarj ve BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Ext. Kontrol ve BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Ext. Kontrol ve BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Şarj, HUB-1 ve BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Şarj, HUB-1 ve BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Master Ayarı</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Master Ayarı</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Slave</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Slave</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Slave</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Grup Ana Birimi</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Grup Ana Birimi</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Charge master</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Charge master</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Grup ve Şarj ana birimi</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Grup ve Şarj ana birimi</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Şarj voltajı</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Şarj voltajı</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Sıfırla</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Sıfırla</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>BMS mevcut olduğunda BMS kontrolü otomatik olarak etkinleştirilir. Sistem yapılandırması değişirse veya BMS yoksa sıfırlayın.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>BMS mevcut olduğunda BMS kontrolü otomatik olarak etkinleştirilir. Sistem yapılandırması değişirse veya BMS yoksa sıfırlayın.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Toplam PV gücü</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>Yük</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Yük</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 bulundu</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 bulundu</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Tarihçe</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Tarihçe</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Tarihçe</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Ağa bağlı işlem</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Ağa bağlı işlem</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Tablo görünümü</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Tablo görünümü</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Grafik</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Grafik</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Uyarı</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Uyarı</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Alarm</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Alarm</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Hacim</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Hacim</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Kısa devreli</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Kısa devreli</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Ters polarite</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Ters polarite</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Elektrikli Araç Şarj İstasyonları</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Elektrikli Araç Şarj İstasyonları</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Oturum</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Oturum</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Saat</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Saat</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Şarj modu</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Şarj modu</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Süreci kendiniz başlatın ve durdurun. Hızlı şarj ve yakın izleme için bunu kullanın.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Süreci kendiniz başlatın ve durdurun. Hızlı şarj ve yakın izleme için bunu kullanın.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Akü şarj seviyesine göre başlar ve durur. Aşırı şarjı önlemek için gece boyunca ve uzun süreli şarjlar için idealdir.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Akü şarj seviyesine göre başlar ve durur. Aşırı şarjı önlemek için gece boyunca ve uzun süreli şarjlar için idealdir.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Yoğun olmayan saatlerde daha düşük elektrik ücretleri veya elektrikli aracınızın belirli bir zamanda tamamen şarj olmasını ve kullanıma hazır olmasını sağlamak istiyorsanız.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Yoğun olmayan saatlerde daha düşük elektrik ücretleri veya elektrikli aracınızın belirli bir zamanda tamamen şarj olmasını ve kullanıma hazır olmasını sağlamak istiyorsanız.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Şarjı etkinleştir</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Şarjı etkinleştir</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Şarj cihazı ekranını kilitle</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Şarj cihazı ekranını kilitle</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Kaynak adresi</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Kaynak adresi</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Kurulum</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Kurulum</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Satır örneği #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Satır örneği #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Line instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Line instance</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Charger instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Charger instance</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Inverter instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Inverter instance</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC kaynağı #%1 örneği</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC kaynağı #%1 örneği</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>DC source instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>DC source instance</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>DC kaynağı #%1 öncelik</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>DC kaynağı #%1 öncelik</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>DC source priority</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>DC source priority</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Tank instance</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Tank instance</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>RV-C cihazları</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>RV-C cihazları</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Kare hızı görselleştiricisini etkinleştir</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Kare hızı görselleştiricisini etkinleştir</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Desteklenmiyor</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Desteklenmiyor</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Bağlantısı kesilen cihazları kaldırın</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Bağlantısı kesilen cihazları kaldırın</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Desteklenmeyen cihaz bulundu</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Desteklenmeyen cihaz bulundu</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Röle fonksiyonu</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Röle fonksiyonu</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Şarj cihazını ya da jeneratörü başlat/durdur</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Şarj cihazını ya da jeneratörü başlat/durdur</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Manuel kontrol</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Sigorta atmış</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>Manuel kontrol</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Manuel kontrol</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Herzaman açık (röleyi kullanma)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Herzaman açık (röleyi kullanma)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Düşük şarj durumu ayarının değiştirilmesinin akü menüsündeki Deşarj katına gitme süresi ayarını da değiştirdiğini unutmayın.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Düşük şarj durumu ayarının değiştirilmesinin akü menüsündeki Deşarj katına gitme süresi ayarını da değiştirdiğini unutmayın.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Sigorta atmış</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Sigorta atmış</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Durum LED'leri</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Durum LED&apos;leri</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Yok</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Ana Anahtar</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Ana Anahtar</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Isıtıcı</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Isıtıcı</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Intern Fan</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Intern Fan</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Uyarı Bayrakları</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Uyarı Bayrakları</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Alarm Bayrakları</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Alarm Bayrakları</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Anahtar</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Anahtar</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Başlatılıyor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Başlatılıyor</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Kapan</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Kapan</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Güncelleniyor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Güncelleniyor</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Çalışacak</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Çalışacak</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Ön-şarj oluyor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Ön-şarj oluyor</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Kontaktör kontrolü</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Kontaktör kontrolü</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Sağlık durumu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Sağlık durumu</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Akü sıcaklığı</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Akü sıcaklığı</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Hava sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Hava sıcaklığı</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Starter voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Starter voltaj</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Bara voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Bara voltaj</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Üst bölge voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Üst bölge voltaj</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">İletişim hatası</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Sağlık durumu</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Bara voltaj</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Alt bölge voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Alt bölge voltaj</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Orta nokta sapması</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Orta nokta sapması</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Tüketilmiş AmpSaatler</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Tüketilmiş AmpSaatler</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Kalan Zaman</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Kalan Zaman</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Ayrıntılar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Ayrıntılar</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Modül seviyesi alarmları</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Modül seviyesi alarmları</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Tanılama</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Tanılama</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Sigortalar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Sigortalar</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>Sistem</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>Sistem</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Parametreler</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Parametreler</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Aküyü Yeniden Algıla</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Aküyü Yeniden Algıla</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Yeniden algılamak için basın</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Yeniden algılamak için basın</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Yeniden algılamak için basın</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Akünün yeniden algılanması 60 saniye sürebilir. Bu esnada akünün adı hatalı olabilir.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Akünün yeniden algılanması 60 saniye sürebilir. Bu esnada akünün adı hatalı olabilir.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Yüksek şarj akımı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Yüksek şarj akımı</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Yüksek deşarj akımı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Yüksek deşarj akımı</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Düşük SOC</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Düşük SOC</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Yüksek akü gerilimi</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Düşük SOC</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Düşük starter voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Düşük starter voltaj</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Yüksek starter voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Yüksek starter voltaj</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Akü sıcaklık sensörü</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Akü sıcaklık sensörü</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Orta nokta voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Orta nokta voltaj</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Sigorta atmış</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Yüksek iç sıcaklık</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Yüksek iç sıcaklık</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Düşük şarj sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Düşük şarj sıcaklığı</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Yüksek şarj sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Yüksek şarj sıcaklığı</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Intern arıza</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Intern arıza</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Devre kesici tetiklenmiş</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Devre kesici tetiklenmiş</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Hücre dengesiz</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Hücre dengesiz</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Düşük hücre voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Düşük hücre voltaj</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>En düşük hücre voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>En düşük hücre voltaj</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>En yüksek hücre voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>En yüksek hücre voltaj</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Minimum hücre sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Minimum hücre sıcaklığı</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Maksimum hücre sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Maksimum hücre sıcaklığı</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Akü modülleri</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Akü modülleri</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 online</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 online</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 offline</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 offline</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Şarj/deşarjı engelleyen modül sayısı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Şarj/deşarjı engelleyen modül sayısı</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Kurulu / Kullanılabilir kapasite</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Kurulu / Kullanılabilir kapasite</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>En derin deşarj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>En derin deşarj</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Son deşarj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Son deşarj</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Ortalama deşarj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Ortalama deşarj</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Toplam şarj döngüsü</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Toplam şarj döngüsü</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Full deşarj sayısı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Full deşarj sayısı</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Çekilen kümülatif Ah</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Çekilen kümülatif Ah</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Minimum hücre voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Minimum hücre voltaj</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Maksimum hücre voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Maksimum hücre voltaj</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Son tam şarjdan bu yana geçen süre</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Son tam şarjdan bu yana geçen süre</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Senkronizasyon sayımı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Senkronizasyon sayımı</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Düşük marş aküsü voltajı alarmı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Düşük marş aküsü voltajı alarmı</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Minimum marş aküsü voltajı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Minimum marş aküsü voltajı</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Maksimum marş aküsü voltajı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Maksimum marş aküsü voltajı</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Deşarj edilen enerji</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Deşarj edilen enerji</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Şarj edilen enerji</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Şarj edilen enerji</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Şarj Voltaj Limiti (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Şarj Voltaj Limiti (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Şarj Akımı Limiti (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Şarj Akımı Limiti (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Deşarj Akımı Limiti (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Deşarj Akımı Limiti (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Düşük Voltaj Bağlantı Kesme (her zaman yoksayılır)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Düşük Voltaj Bağlantı Kesme (her zaman yoksayılır)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Akü Grubu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Akü Grubu</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Röle (akü ekranında)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Röle (akü ekranında)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Fabrika ayarlarına dön</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Fabrika ayarlarına dön</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Dönmek için basın</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Dönmek için basın</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Fabrika varsayılanlarını geri yükle?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Fabrika varsayılanlarını geri yükle?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth devrede</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth devrede</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Nomial Voltaj</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Nomial Voltaj</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Volt</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Volt</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Volt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Volt</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Kapasite</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Kapasite</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapasite</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Charged voltage</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Charged voltage</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Tail current</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Tail current</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Şarj edilen algılama süresi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Şarj edilen algılama süresi</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Peukert exponent</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Peukert exponent</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Charge efficiency factor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Charge efficiency factor</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Current threshold</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Current threshold</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Kalan zamanı ortalama süresi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Kalan zamanı ortalama süresi</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Kalan zamanı deşarj zemini</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Kalan zamanı deşarj zemini</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Akım ofseti</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Akım ofseti</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Şarj durumunu %100 olarak senkronize et</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Şarj durumunu %100 olarak senkronize et</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Senkronize etmek için basın</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Senkronize etmek için basın</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Calibrate zero current</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Calibrate zero current</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>0'a ayarlamak için basın</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>0&apos;a ayarlamak için basın</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Distributor %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Distributor %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Busbarda güç yok</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Busbarda güç yok</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">Bağlantı kaybedildi</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n sigorta atmış
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n sigorta atmış
 Çoğul: %n sigorta atmış</numerusform>
-        <numerusform>%n sigorta atmış
-Çoğul: %n sigorta atmış</numerusform>
-      </translation>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Bilgi yok, Distribütör durumu için önceki sayfaya bakın.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Bilgi yok, Distribütör durumu için önceki sayfaya bakın.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Sigorta %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Sigorta %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Kullanilmiyor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Kullanilmiyor</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Patlak</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Patlak</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Hataya bağlı kapanmalar</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Hataya bağlı kapanmalar</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Son hata</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">İkinci son hata</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">Üçüncü son hata</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">Dördüncü son hata</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Sistem Anahtarı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Sistem Anahtarı</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Extern röle</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Extern röle</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Programlanabilir Kontakt</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Programlanabilir Kontakt</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Aküler</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Aküler</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Kapasite</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Aküler</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Paralel</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Paralel</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Seri</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Seri</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Min/maks hücre voltajı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Min/maks hücre voltajı</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Min/maks. hücre sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Min/maks. hücre sıcaklığı</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Balanslama</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Balanslama</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Balanslama</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Bilinmiyor</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Çıkış</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Çıkış</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Field drive</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Field drive</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Motor hızı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Motor hızı</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Aux voltaj</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Aux voltaj</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Alarm yok</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Alarm yok</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Düşük voltaj</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Düşük voltaj</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Yüksek voltaj</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Yüksek voltaj</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Düşük aux voltaj</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Düşük aux voltaj</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Yüksek aux voltaj</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Yüksek aux voltaj</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Düşük aux voltaj alarmları</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Düşük aux voltaj alarmları</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Yüksek aux voltaj alarmları</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Yüksek aux voltaj alarmları</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Minimum aux voltaj</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Minimum aux voltaj</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Maksimum aux voltaj</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Maksimum aux voltaj</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Üretilen enerji</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Üretilen enerji</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Tüketilen enerji</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Tüketilen enerji</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Alarmı etkinleştir</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Alarmı etkinleştir</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Aktif seviye</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Aktif seviye</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Seviyeyi geri yükle</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Seviyeyi geri yükle</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Gecikme</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Gecikme</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Level</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Level</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Kalan</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Kalan</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Sensör akü</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Sensör akü</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Sensör akü</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Sensör tipi</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Sensör tipi</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Varsayılan</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Varsayılan</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Avrupa (0-180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Avrupa (0-180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>ABD (240-30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>ABD (240-30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Özel</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Özel</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Özel</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Boşken sensör değeri</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Boşken sensör değeri</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Sıvı türü</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Sıvı türü</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Bütan oranı</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Bütan oranı</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Özel şekil</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Özel şekil</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Ortalama süre</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Ortalama süre</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Sensör değeri</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Sensör değeri</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Tanımlanmış özel şekil yok. On noktaya kadar bir tane tanımlayabilirsiniz. 0 ve %100'ün ima edildiğini unutmayın.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Tanımlanmış özel şekil yok. On noktaya kadar bir tane tanımlayabilirsiniz. 0 ve %100&apos;ün ima edildiğini unutmayın.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Nokta %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Nokta %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Puan ekle</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Puan ekle</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Sensör Düzeyi</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Sensör Düzeyi</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Hacim</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Yinelenen sensör seviyesi değerlerine izin verilmez.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Yinelenen sensör seviyesi değerlerine izin verilmez.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Hacim değerleri artıyor olmalıdır.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Hacim değerleri artıyor olmalıdır.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Güvenlik zamanlayıcısı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Güvenlik zamanlayıcısı</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Unlocked (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Unlocked (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Unlocked (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Unlocked (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Unlocked (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Unlocked (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Locked</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Locked</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Faz yapılandırması</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Faz yapılandırması</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Switch position</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Switch position</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Tek faz</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2 fazlı</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2 fazlı</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3 fazlı</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3 fazlı</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Cihazlar</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Motor</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Hız</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Yük</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Soğutma suyu sıcaklığı</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Soğutma suyu sıcaklığı</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Egzoz sıcaklığı</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Egzoz sıcaklığı</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Sargı sıcaklığı</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Sargı sıcaklığı</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Marş akü voltajı</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Marş akü voltajı</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Başlangıç sayısı</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Başlangıç sayısı</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS kontrolü</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Ön seçici kilitli (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Ön seçici kilitli (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Hata yok (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Hata yok (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>AC Toplam</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>AC Toplam</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Enerji L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Enerji L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Faz Sırası</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Faz Sırası</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Veri yöneticisi sürümü</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Veri yöneticisi sürümü</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Yok</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Yanıp sönen LED, bu CT'yi belirtir</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Yanıp sönen LED, bu CT&apos;yi belirtir</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Smappee veri yolu cihazları</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Smappee veri yolu cihazları</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>PV Şarj Cihazı</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>PV Şarj Cihazı</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Bir Dijital Multi Kontrol bağlandığında bu ayar devre dışı bırakılır.</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Bir Dijital Multi Kontrol bağlandığında bu ayar devre dışı bırakılır.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Bir VE.Bus BMS bağlandığında bu ayar devre dışı bırakılır.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Bir VE.Bus BMS bağlandığında bu ayar devre dışı bırakılır.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC %1 içinde</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC %1 içinde</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Ters Çevrilmiş</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Ters Çevrilmiş</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Alarmı etkinleştir</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Ters Çevrilmiş</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Alarm mantığını tersine çevir</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Alarm mantığını tersine çevir</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Işınım</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Işınım</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Hücre sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Hücre sıcaklığı</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Dış sıcaklık (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Dış sıcaklık (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Extern sıcaklık</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Extern sıcaklık</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Dış sıcaklık (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Dış sıcaklık (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Rüzgar hızı</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Rüzgar hızı</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Otomatik algılama</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Otomatik algılama</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Rüzgar hızı sensörü</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Rüzgar hızı sensörü</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Harici sıcaklık sensörü</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Harici sıcaklık sensörü</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Küme</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Küme</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Çarpmak</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Çarpmak</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Sayacı sıfırla</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Sayacı sıfırla</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Kısa devreli</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Ters polarite</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Sensör akü düşük</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Sensör akü düşük</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Nem</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Nem</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Basınç</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Basınç</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Düşük</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Ofset</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Ofset</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Ölçek</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Ölçek</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Sensör voltajı</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Sensör voltajı</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Toplam PV gücü</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Toplam PV gücü</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Ürün sayfası</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Ürün sayfası</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>AC sensörü %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>AC sensörü %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Yeni bir MK3 sürümü mevcuttur.
+        <translation>Yeni bir MK3 sürümü mevcuttur.
 NOT: Güncelleme sistemi geçici olarak durdurabilir.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>MK3'ü güncelleyin</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>MK3&apos;ü güncelleyin</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Güncellemek için basın</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Güncellemek için basın</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>MK3 güncelleniyor, güncelleme tamamlandıktan sonra değerler yeniden görünecek</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>MK3 güncelleniyor, güncelleme tamamlandıktan sonra değerler yeniden görünecek</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Akü %100&apos;e kadar şarj et</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Akü %100'e kadar şarj et</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Akü %100&apos;e kadar şarj et</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Gelişmiş</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>Devam ediyor</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>Devam ediyor</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Durdurmak için basın</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Durdurmak için basın</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Başlatmak için basın</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Başlatmak için basın</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Akü'yü %100'e kadar şarj edin</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Akü&apos;yü %100&apos;e kadar şarj edin</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Sistem yenilenebilir enerjiye öncelik vererek normal çalışmaya dönecektir.
+        <translation>Sistem yenilenebilir enerjiye öncelik vererek normal çalışmaya dönecektir.
 Devam etmek istiyor musunuz?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Sahil gücü mevcut olduğunda kullanılacak ve "Güneş ve rüzgar önceliği" seçeneği göz ardı edilecektir.
+        <translation>Sahil gücü mevcut olduğunda kullanılacak ve &quot;Güneş ve rüzgar önceliği&quot; seçeneği göz ardı edilecektir.
 Devam etmek istiyor musunuz?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Sahil gücü bir kereliğine tam bir akü şarjını tamamlamak için kullanılacaktır.
+        <translation>Sahil gücü bir kereliğine tam bir akü şarjını tamamlamak için kullanılacaktır.
 Şarj işlemi tamamlandıktan sonra, sistem güneş ve rüzgar enerjisine öncelik vererek normal çalışmaya dönecektir.
 Devam etmek istiyor musunuz?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>DC Voltaj</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>DC Voltaj</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>DC Akımı</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>DC Akımı</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Gelişmiş</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Gelişmiş</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Alarm ayarı</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Alarm ayarı</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>VE.Bus BMS, aküyü korumak için gerektiğinde sistemi otomatik olarak kapatır. Bu nedenle, sistemi Color Control üzerinden kontrol etmek mümkün olmaz.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>VE.Bus BMS, aküyü korumak için gerektiğinde sistemi otomatik olarak kapatır. Bu nedenle, sistemi Color Control üzerinden kontrol etmek mümkün olmaz.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>VE.Bus BMS için bir BMS Assistant kurulup yapılandırıldı ama VE.Bus BMS bulunamadı!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>VE.Bus BMS için bir BMS Assistant kurulup yapılandırıldı ama VE.Bus BMS bulunamadı!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Uyarı: Solar şarj cihazlarıyla bir ESS sisteminde Equalization etkinleştirilmesi, akünün çok yüksek bir akımla yüksek voltajda şarj edilmesine neden olabilir.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Uyarı: Solar şarj cihazlarıyla bir ESS sisteminde Equalization etkinleştirilmesi, akünün çok yüksek bir akımla yüksek voltajda şarj edilmesine neden olabilir.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Equalization şarjı tamamlanır tamamlanmaz,  sistem otomatik olarak Float moduna geçecektir.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Equalization şarjı tamamlanır tamamlanmaz,  sistem otomatik olarak Float moduna geçecektir.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Equalization yarıda kes</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Equalization yarıda kes</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Equalization</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Equalization</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Yarıda kesiliyor...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Yarıda kesiliyor...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Başlatılıyor...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Başlatılıyor...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Başlatılıyor...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Yarıda kesmek için basın</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Yarıda kesmek için basın</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Yarıda kes ve Absorption yeniden başlat</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Yarıda kes ve Absorption yeniden başlat</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Yarıda kes ve Float moduna git</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Yarıda kes ve Float moduna git</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Yarıda kes</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Yarıda kes</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Yarıda kesme</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Yarıda kesme</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>VE.Bus sistemini Yeniden algıla</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>VE.Bus sistemini Yeniden algıla</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Yeniden algılıyor...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Yeniden algılıyor...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Restart VE.Bus system</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Restart VE.Bus system</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Yeniden Başlıyor...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Yeniden Başlıyor...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Yeniden Başlatmak için basın</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Yeniden Başlatmak için basın</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>AC girişi 1 yok sayıldı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>AC girişi 1 yok sayıldı</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>AC girişi 2 yok sayıldı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>AC girişi 2 yok sayıldı</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>ESS Röle testi</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>ESS Röle testi</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Tamamlandı</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Askıda olması...</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Tamamlandı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Tamamlandı</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Askıda olması...</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Askıda olması...</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>VE.Bus tanılama</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>VE.Bus tanılama</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Ağ kalitesi sayacı Faz L%1, cihaz %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Ağ kalitesi sayacı Faz L%1, cihaz %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.Bus Hata 8 / 11 raporu</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.Bus Hata 8 / 11 raporu</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Sadece alarm</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Sadece alarm</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Alarm ve uyarılar</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Alarm ve uyarılar</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>BMS Hatası</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>BMS Hatası</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Seri Numaralar</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Seri Numaralar</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Son VE.Bus Hata 11 raporu #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Son VE.Bus Hata 11 raporu #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>BF güvenlik testi devam ediyor</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>BF güvenlik testi devam ediyor</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>BF güvenlik testi TAMAM</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>BF güvenlik testi TAMAM</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>AC0 /AC1 uyuşmazlığı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>AC0 /AC1 uyuşmazlığı</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>İletişim hatası</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>İletişim hatası</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>GND Röle Hatası</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>GND Röle Hatası</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>UMains uyuşmazlığı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>UMains uyuşmazlığı</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Dönem Zaman uyuşmazlığı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Dönem Zaman uyuşmazlığı</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>BF rölesi sürücü uyuşmazlığı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>BF rölesi sürücü uyuşmazlığı</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Hata: PE2 açık</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Hata: PE2 açık</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Hata: PE2 kapalı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Hata: PE2 kapalı</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Başarısız adım: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Başarısız adım: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Faz L%1, cihaz %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Faz L%1, cihaz %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Ve.Bus Hatası 11'in bildirilmesi, VE.Bus firmware 454 veya daha yüksek bir versiyonu gerektirir.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Ve.Bus Hatası 11&apos;in bildirilmesi, VE.Bus firmware 454 veya daha yüksek bir versiyonu gerektirir.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>Beklenmedik VE.Bus Olayı</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>Beklenmedik VE.Bus Olayı</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>Enerji</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>Enerji</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>Güç</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>Güç</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>Voltaj</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>Voltaj</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>Akım</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>Akım</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>Konumu ayarla</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>Konumu ayarla</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>Faz</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>Faz</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Aktif AC Girişi</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Aktif AC Girişi</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Yüksek DC ripple</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Yüksek DC ripple</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Yüksek DC voltajı</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Yüksek DC voltajı</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Yüksek DC akımı</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Yüksek DC akımı</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Sıcaklık algılama hatası</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Sıcaklık algılama hatası</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Voltaj algılama hatası</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Voltaj algılama hatası</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Aşırı Yük</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Aşırı Yük</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>DC ripple</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>DC ripple</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Voltaj Sensörü</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Voltaj Sensörü</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Faz rotasyon</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Faz rotasyon</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Faz rotasyon</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>VE.Bus sürümü</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>VE.Bus sürümü</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2' cihazı</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2&apos; cihazı</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>MK2 sürümü</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>MK2 sürümü</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Multi Control sürümü</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Multi Control sürümü</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>VE.Bus BMS sürümü</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>VE.Bus BMS sürümü</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Şebeke kesinti olmadıkça</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Şebeke kesinti olmadıkça</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>AC Girişi</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>AC Girişi</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC Girişi</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC Girişi</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>AC Girişi 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>AC Girişi 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>AC Girişi 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>AC Girişi 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Rol</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC Yükü</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC Yükü</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>AC Çıkışı</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>AC Çıkışı</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>AC Çıkışı</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>AC Çıkışı</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Faz L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Faz L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>AC Sensörü %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>AC Sensörü %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>AC Sensörler</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>AC Sensörler</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Aktif</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Aktif</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Alarm</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Aşırı Yük</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Alarm durumu</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Alarm durumu</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Alarmlar</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Alarmlar</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Şarja izin verildi</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Şarja izin verildi</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Deşarja izin verildi</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Deşarja izin verildi</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Otomatik tarama</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Otomatik tarama</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Akü</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Akü</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Akü akımı</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Akü akımı</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Akü voltajı</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Akü voltajı</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Şarj akımı</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Şarj akımı</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Şarj</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Şarj</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Hatayı sil</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Hatayı sil</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Kapalı</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Kapalı</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Bağlandı</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Bağlandı</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Akım</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Akım</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Akım transformatörleri</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Akım transformatörleri</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Özel Ad</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Özel Ad</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Hata giderme</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Hata giderme</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Cihaz</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Cihaz</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Devre dışı</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Deşarj </translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Deşarj </translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Bağlantı kesildi</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Bağlantı kesildi</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Etkinleştir</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Etkinleştir</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Etkin</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Etkin</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Enerji</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Enerji</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Hata</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Hata</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Hata:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Hata:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Hata Kodu</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Hata Kodu</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Firmware sürümü</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Firmware sürümü</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Jeneratör</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Jeneratör</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Yüksek akü sıcaklığı</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Yüksek akü sıcaklığı</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Yüksek seviye alarmı</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Yüksek seviye alarmı</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Yüksek starter akü voltaj</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Yüksek starter akü voltaj</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Yüksek Sıcaklık</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Yüksek Sıcaklık</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Yüksek voltaj alarmları</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Yüksek voltaj alarmları</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Geçmiş</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Geçmiş</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>1 Saat(ler)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>1 Saat(ler)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Atıl</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Atıl</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Aktif değil</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Aktif değil</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">İnvertör / Şarj Cihazı</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP adresi</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP adresi</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Düşük akü sıcaklığı</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Düşük akü sıcaklığı</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Düşük seviye alarmı</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Düşük seviye alarmı</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Düşük starter akü voltaj</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Düşük starter akü voltaj</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Düşük şarj durumu</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Düşük şarj durumu</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Düşük sıcaklık</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Düşük sıcaklık</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Düşük voltaj alarmları</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Düşük voltaj alarmları</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Üretici</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Üretici</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Maksimum sıcaklık</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Maksimum sıcaklık</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Maksimum voltaj</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Maksimum voltaj</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Minimum sıcaklık</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Minimum sıcaklık</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Minimum voltaj</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Minimum voltaj</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Mod</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Mod</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Model Adı</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Model Adı</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Hayır</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Hayır</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Hata yok</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Hata yok</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Kullanılamıyor</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Kullanılamıyor</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Bağlı değil</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Bağlı değil</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Çevrimdışı</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Çevrimdışı</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>OK</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>OK</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Açık</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Açık</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Online</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Online</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Açık</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Açık</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Parola</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Parola</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Faz</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Faz</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Silmek için basın</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Silmek için basın</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Sıfırlamak için basın</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Sıfırlamak için basın</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Taramak için basın</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Taramak için basın</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>PV invertörü</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>PV invertörü</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>PV Güç</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>PV Güç</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Durgun saatler</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Durgun saatler</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Röle</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Röle</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Yeniden başlat</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Yeniden başlat</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Çıkar</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Çıkar</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>Çalışıyor</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>Çalışıyor</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Tarama %1</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Tarama %1</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Seri Numarası</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Seri Numarası</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Ayarlar</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Ayarlar</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Kurulum</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Kurulum</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Sinyal gücü</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Sinyal gücü</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Bekleme</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Bekleme</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Koşullara ulaşıldıktan sonra başlat</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Koşullara ulaşıldıktan sonra başlat</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Başlangıç zamanı</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Başlangıç zamanı</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Durgun saatlerdeki başlangıç değeri</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Durgun saatlerdeki başlangıç değeri</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Uyarı şunun için aktif olduğunda başlat</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Uyarı şunun için aktif olduğunda başlat</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Şarj durumu</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Şarj durumu</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Durum</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Durum</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Başlangıç (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Başlangıç (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Sessiz saatlerdeki durma değeri</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Sessiz saatlerdeki durma değeri</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Koşullara ulaşıldıktan sonra durdur</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Koşullara ulaşıldıktan sonra durdur</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Durduruldu</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Durduruldu</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Sıcaklık</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Sıcaklık</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Sıcaklık sensörü</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Sıcaklık sensörü</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Bugün</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Bugün</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Toplam</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Toplam</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Tracker</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Tracker</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Tip</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Tip</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Benzersiz Kimlik Numarası</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Benzersiz Kimlik Numarası</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Bilinmiyor</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Bilinmiyor</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>VE.Bus hatası</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>VE.Bus hatası</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Voltaj</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Voltaj</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>VRM instance</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>VRM instance</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Uyarı şundan sonra kaybolduğunda durdur:</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Uyarı şundan sonra kaybolduğunda durdur:</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Evet</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Evet</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Dün</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Dün</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Verim</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Verim</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Zero feed-in power limit</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Zero feed-in power limit</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Tarih belirleyin</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Tarih belirleyin</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Şimdi başla</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Şimdi başla</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>çalışmış süreç</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>çalışmış süreç</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Şimdi Dur</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Şimdi Dur</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Toplam çalışma süresi</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Toplam çalışma süresi</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Zamanı Ayarla %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Zamanı Ayarla %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Otomatik başlatma koşulu karşılandığında jeneratör çalışmaya devam edecektir.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Otomatik başlatma koşulu karşılandığında jeneratör çalışmaya devam edecektir.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>İnvertör / Şarj cihazı modu</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>İnvertör / Şarj cihazı modu</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Ayarla</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Ayarla</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>İptal</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>İptal</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Kapat</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Ayarlanan zaman</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Ayarlanan zaman</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Halihazırda kullanımda</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Halihazırda kullanımda</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Takas hatası</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Takas hatası</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Takas tamamlandı</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Takas tamamlandı</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Cihaz örneklerini değiştirme...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Cihaz örneklerini değiştirme...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Device instance %1 zaten '%3' tarafından kullanılıyor. Device instance değiştirin ve bunu %2'ye atayın?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Device instance %1 zaten &apos;%3&apos; tarafından kullanılıyor. Device instance değiştirin ve bunu %2&apos;ye atayın?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>%1 Device instance zaten aynı türde başka bir aygıt tarafından kullanılıyor. Device instance değiştirin ve bunu %2'ye atayın?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>%1 Device instance zaten aynı türde başka bir aygıt tarafından kullanılıyor. Device instance değiştirin ve bunu %2&apos;ye atayın?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Device instance değiştirilemiyor: işlem zaman aşımına uğradı.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Device instance değiştirilemiyor: işlem zaman aşımına uğradı.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Yeni Device instance yeniden başlatıldığında etkin olacaktır.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Yeni Device instance yeniden başlatıldığında etkin olacaktır.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Takas</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Takas</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Ürün firmware güncellemeleri kontrol edilirken hata oluştu</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Ürün firmware güncellemeleri kontrol edilirken hata oluştu</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Ürün firmware %1 indiriliyor ve kuruluyor...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Ürün firmware %1 indiriliyor ve kuruluyor...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Firmware yükleniyor...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Firmware yükleniyor...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Ürün firmware yüklemesi sırasında hata</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Ürün firmware yüklemesi sırasında hata</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Yeni versiyon yok</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Yeni versiyon yok</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Firmware bulunamadı</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Firmware bulunamadı</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Yakıt</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Yakıt</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Temiz su</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Temiz su</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Atık su</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Atık su</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Faal kuyu</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Faal kuyu</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Yağ</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Yağ</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Atık Su</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Atık Su</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Benzin</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Benzin</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Dizel</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Dizel</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Hidrolik yağ</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Hidrolik yağ</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Ham Su</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Ham Su</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Erişim seviyesi için kilitli ayarı</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Erişim seviyesi için kilitli ayarı</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Yanlış parola</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Yanlış parola</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Kısa</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Kısa</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Görünüm</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Görünüm</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Seviyeler</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Seviyeler</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Bildirimler</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Bildirimler</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>Şimdi</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>Şimdi</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>1m önce</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>1m önce</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>1 saat %2 dakika önce</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>1 saat %2 dakika önce</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Hergün</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Hergün</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Hafta içi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Hafta içi</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Haftasonu</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Haftasonu</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Pazartesi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Pazartesi</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Salı</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Salı</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Çarşamba</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Çarşamba</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Perşembe</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Perşembe</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>Cuma</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>Cuma</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Cumartesi</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Cumartesi</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Pazar</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Pazar</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 veya %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 veya %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Program %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Program %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>Gün</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>Gün</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Not set</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Not set</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>SOC sınırı</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>SOC sınırı</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Limitin üzerinde öz-tüketim</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Limitin üzerinde öz-tüketim</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>PV &amp; Akü</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>PV &amp; Akü</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Kontrol ediliyor...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Kontrol ediliyor...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Alarm durumu</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Alarm durumu</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Geçmişi Temizle</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Geçmişi Temizle</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Temizliyor</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Temizliyor</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Zorlama açık</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Zorlama açık</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Zorlama kapalı</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Zorlama kapalı</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Röle durumu</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Röle durumu</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Monitörün kendisinde geçmişi sıfırlama</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Monitörün kendisinde geçmişi sıfırlama</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Çıkarmak için basın</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Çıkarmak için basın</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Çıkarılıyor, lütfen bekleyin</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Çıkarılıyor, lütfen bekleyin</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Bellek bulunamadı</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Bellek bulunamadı</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 sıcaklık sensörü</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 sıcaklık sensörü</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>1 sıcaklık sensörü (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>1 sıcaklık sensörü (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Sıcaklık sensörü (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Sıcaklık sensörü (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Eylem yok</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Eylem yok</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Uyarı: Etkinleştirme ve devre dışı bırakma sıcaklıkları aynı değere ayarlanır. Bu, durumun göz ardı edilmesine yol açacaktır.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Uyarı: Etkinleştirme ve devre dışı bırakma sıcaklıkları aynı değere ayarlanır. Bu, durumun göz ardı edilmesine yol açacaktır.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Durum %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Durum %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>İşlem devre dışı</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>İşlem devre dışı</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Yok (Devre Dışı Bırak)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Yok (Devre Dışı Bırak)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Röle 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Röle 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Röle 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Röle 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Uyarı: Yukarıda seçilen röle sıcaklık için konfigüre edilmemiştir, bu durum göz ardı edilecektir.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Uyarı: Yukarıda seçilen röle sıcaklık için konfigüre edilmemiştir, bu durum göz ardı edilecektir.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Aktivasyon değeri</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Aktivasyon değeri</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Hacim birimi</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Hacim birimi</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Metreküp</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Metreküp</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Litre (L)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Litre (L)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Galon (ABD)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Galon (ABD)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Galon (İmparatorluk)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Galon (İmparatorluk)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Min voltaj</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Min voltaj</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Max voltaj</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Max voltaj</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Max voltaj</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Maksimum Akım</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Maksimum Akım</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Şarj süresi</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Şarj süresi</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Bulk</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Float</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">saat</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Bulk</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Bulk</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Abs</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Abs</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Float</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Float</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>saat</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>saat</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>1 hata(lar) oluştu</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>1 hata(lar) oluştu</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Yük</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Yük</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>2. son</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>2. son</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>3. son</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>3. son</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Son 4.</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Son 4.</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Maksimum Güç</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Maksimum Güç</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Bağlanılamıyor</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Bağlanılamıyor</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Bağlantı kesildi, yeniden bağlanmaya çalışılıyor</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Bağlantı kesildi, yeniden bağlanmaya çalışılıyor</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Bağlanıyor</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Bağlanıyor</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Bağlanıyor</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Bağlandı, broker mesajları bekleniyor</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Bağlandı, broker mesajları bekleniyor</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Bağlandı, broker mesajlarını alıyor</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Bağlandı, broker mesajlarını alıyor</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Bağlı, yüklenen kullanıcı arayüzü</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Bağlı, yüklenen kullanıcı arayüzü</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Geçersiz protokol sürümü</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Geçersiz protokol sürümü</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>Müşteri kimliği reddedildi</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>Müşteri kimliği reddedildi</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Broker hizmeti mevcut değil</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Broker hizmeti mevcut değil</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Hatalı kullanıcı adı veya şifre</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Hatalı kullanıcı adı veya şifre</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Müşteri yetkili değil</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Müşteri yetkili değil</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Aktarım bağlantı hatası</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Aktarım bağlantı hatası</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Protokol ihlali hatası</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Protokol ihlali hatası</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>MQTT protokolü seviye 5 hatası</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>MQTT protokolü seviye 5 hatası</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Sessiz alarm</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Sessiz alarm</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Toplam güç</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Toplam güç</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>min</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>min</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1g %2s</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1g %2s</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1g %2s</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1g %2s</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1d %2sn</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1d %2sn</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1d</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1d</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1sn</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1sn</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0m</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0m</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Hata</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Hata</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>IP adresi alınıyor</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>IP adresi alınıyor</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Bağlandı</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Bağlantıyı kes</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Bağlantıyı kes</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Bağlantı kesildi</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC Yükleri</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC Yükleri</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>dcLoads</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>dcLoads</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EVCS</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EVCS</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Rüzgar</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Rüzgar</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Sahil</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Sahil</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Şebeke Akım Sınırı</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Şebeke Akım Sınırı</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Jeneratör Akım Limiti</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Jeneratör Akım Limiti</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Sahil Akım Limiti</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Sahil Akım Limiti</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Duruyor</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Duruyor</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Duruyor</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>Gitmek için %1</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>Gitmek için %1</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>1 tank (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>1 tank (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>AC Şarj Cihazı</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>AC Şarj Cihazı</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Jeneratör</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Jeneratör</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>DC şarj cihazı</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>DC şarj cihazı</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>DC jeneratör</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>DC jeneratör</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC Sistem</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC Sistem</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Fuel Cell</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Fuel Cell</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Shaft Generator</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Shaft Generator</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Su Jeneratör</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Su Jeneratör</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Rüzgar Şarj Cihazı</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Rüzgar Şarj Cihazı</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Düşük</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Düşük</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Yüksek</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Yüksek</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Aküleri Dolu Tut</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Aküleri Dolu Tut</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Optimize - BatteryLife ile</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Optimize - BatteryLife ile</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Optimize - BatteryLife olmadan</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Optimize - BatteryLife olmadan</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Extern kontrol</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Ṣarj edildi</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Ṣarj edildi</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Güneşi beklemek</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Güneşi beklemek</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>RFID beklemek</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>RFID beklemek</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Başlangıç ​​için bekleniyor</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Başlangıç ​​için bekleniyor</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Zemin testi hatası</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Zemin testi hatası</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>CP giriş testi hatası</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>CP giriş testi hatası</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Kaçak akım algılandı</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Kaçak akım algılandı</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Düşük voltaj algılandı</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Düşük voltaj algılandı</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Aşırı voltaj algılandı</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Aşırı voltaj algılandı</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Aşırı ısınma algılandı</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Aşırı ısınma algılandı</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Şarj limiti</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Şarj limiti</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Şarjı Başlat</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Şarjı Başlat</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Planlanmış</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Planlanmış</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Planlanmış</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Isınma</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Isınma</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Soğuma</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Soğuma</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Test başlat</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Test başlat</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Manuel başlatıldı</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Manuel başlatıldı</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Önyükleme</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Önyükleme</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>Çalışıyor (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>Çalışıyor (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>Çalışıyor (Kısılmış)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>Çalışıyor (Kısılmış)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Röle %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Röle %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Hata</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Hata</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Absorption</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Absorption</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Storage</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Storage</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Equalize</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Equalize</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Extern kontrol</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Otomatik Enerji Tasaruf (AES) modu</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Otomatik Enerji Tasaruf (AES) modu</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Arıza durumu</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Arıza durumu</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Bulk Şarj</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Bulk Şarj</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Absorption şarjı</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Absorption şarjı</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Float şarjı</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Float şarjı</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Storage Mod</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Storage Mod</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Equalization şarjı</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Equalization şarjı</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Transfer</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Transfer</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Çevriliyor</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Çevriliyor</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Assist</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Assist</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Güç Kaynağı Modu</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Güç Kaynağı Modu</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Sürdür</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Uyan</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Uyan</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Tekrarlanan Absorption</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Tekrarlanan Absorption</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Otomatik equalize</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Otomatik equalize</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>Battery Safe</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>Battery Safe</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Yük algılama</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Yük algılama</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Bloke</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Bloke</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Test</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Test</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Dinamik ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Dinamik ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Dinamik ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Grup Ana Birimi</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Grup Ana Birimi</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Instance Master</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Instance Master</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Group &amp; Instance Master</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Group &amp; Instance Master</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Bağımsız ve Grup Yöneticisi</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Bağımsız ve Grup Yöneticisi</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Yalnızca Şarj</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Yalnızca Şarj</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Yalnız İnvertör</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Yalnız İnvertör</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Düşük akü voltaj alarmı</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Yüksek akü voltaj alarmı</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Kısa devre alarmı</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Kısa devre alarmı</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Access Point Devre Dışı Bırak</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Access Point Devre Dışı Bırak</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>DC Giriş</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>DC Giriş</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Lityum aküler için %10'un altında şarj önerilmez. Diğer pil türleri için, üretici tarafından önerilen minimum seviye için veri sayfasını kontrol edin.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Lityum aküler için %10&apos;un altında şarj önerilmez. Diğer pil türleri için, üretici tarafından önerilen minimum seviye için veri sayfasını kontrol edin.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Otomatik başlatmayı devre dışı bırak?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Otomatik başlatmayı devre dışı bırak?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>İnvertör / Şarj Cihazı (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>İnvertör / Şarj Cihazı (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>CPU kullanımını görüntüleme</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>CPU kullanımını görüntüleme</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Uygulamadan Çık</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Uygulamadan Çık</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Bırak</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Bırak</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Uygulama sürümü</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Uygulama sürümü</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Yağ sıcaklığı</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Yağ sıcaklığı</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Boşaltma katına gitme süresi ayarının değiştirilmesinin röle menüsündeki Düşük şarj durumu ayarını da değiştirdiğini unutmayın.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Boşaltma katına gitme süresi ayarının değiştirilmesinin röle menüsündeki Düşük şarj durumu ayarını da değiştirdiğini unutmayın.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Operasyon zamanı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Operasyon zamanı</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Ücretli Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Ücretli Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Döngüler başladı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Döngüler başladı</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Döngüler tamamlanan</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Döngüler tamamlanan</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>ilk-acilis sayısı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>ilk-acilis sayısı</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Derin deşarj sayısı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Derin deşarj sayısı</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Şarj döngüsü geçmişi</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Şarj döngüsü geçmişi</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Dolu olduğunda sensör değeri</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Dolu olduğunda sensör değeri</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Hizmet süresi</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Hizmet süresi</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Otomatik başlatma işlevi</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Otomatik başlatma işlevi</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Bu seçeneği kullanırken jeneratörün AC giriş %1'e bağlı olmadığından emin olun</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Bu seçeneği kullanırken jeneratörün AC giriş %1&apos;e bağlı olmadığından emin olun</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Servis zamanlayıcısı sıfırlandı</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Servis zamanlayıcısı sıfırlandı</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Sürekli tarama Wi-Fi çalışmasını engelleyebilir.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Sürekli tarama Wi-Fi çalışmasını engelleyebilir.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Minimum ve maksimum gösterge aralıkları</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Minimum ve maksimum gösterge aralıkları</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Başlangıç sayfası</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Uygulama yeniden başlatılıyor...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Uygulama yeniden başlatılıyor...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Dil değiştirilemedi!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Dil değiştirilemedi!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 dak</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 dak</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 dak</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Hiçbir zaman</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Dil değiştirilirken lütfen bekleyin.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Dil değiştirilirken lütfen bekleyin.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Kısa görünüm birimi</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Kısa görünüm birimi</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Etiket yok</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Etiket yok</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Tank hacimlerini göster</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Tank hacimlerini göster</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Yüzdeleri göster</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Yüzdeleri göster</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Not: Akım gösterilemiyorsa (örneğin, birleşik AC ve DC kaynakları için toplam gösterilirken), bunun yerine güç gösterilecektir.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Not: Akım gösterilemiyorsa (örneğin, birleşik AC ve DC kaynakları için toplam gösterilirken), bunun yerine güç gösterilecektir.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Şarj Akımı limitleri</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Şarj Akımı limitleri</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Resmi açıklama</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Resmi açıklama</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Beta release</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Beta release</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Test (Victron intern)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Test (Victron intern)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Geliştir (Victron intern)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Geliştir (Victron intern)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Yeniden başlatılıyor...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Yeniden başlatılıyor...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Durum LED'lerini etkinleştirin</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Durum LED&apos;lerini etkinleştirin</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Isınma ve soğuma</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Isınma ve soğuma</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Jeneratör durma süresi</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Jeneratör durma süresi</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Jeneratör otomatik başlatma modunda olmadığında alarm</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Jeneratör otomatik başlatma modunda olmadığında alarm</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Otomatik başlatma işlevi 10 dakikadan uzun süre devre dışı bırakıldığında bir alarm tetiklenecektir</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Otomatik başlatma işlevi 10 dakikadan uzun süre devre dışı bırakıldığında bir alarm tetiklenecektir</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Aküden öz tüketim</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Aküden öz tüketim</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Tüm sistem yükleri</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Tüm sistem yükleri</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Sadece kritik yükler</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Sadece kritik yükler</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Minimum Deşarj SoC (şebeke kesintisi olmadıkça)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Akü ömrü durumu</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Akü ömrü durumu</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>http://venus.local:3000 adresinden ve VRM aracılığıyla Sinyal K'ya erişin.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>http://venus.local:3000 adresinden ve VRM aracılığıyla Sinyal K&apos;ya erişin.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Node-RED'e https://venus.local:1881 adresinden ve VRM aracılığıyla erişin.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Node-RED&apos;e https://venus.local:1881 adresinden ve VRM aracılığıyla erişin.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Akü ölçümleri</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Akü ölçümleri</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Sistem Durumu</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Sistem Durumu</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Cihaz Listesi</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Cihaz Listesi</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Eternet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>VRM Cihaz Örnekleri</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>VRM Cihaz Örnekleri</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Yüksek sıcaklık alarmı</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Yüksek sıcaklık alarmı</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>BMS Kontrollü</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>BMS Kontrollü</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Alarmlar ve Hatalar</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Alarmlar ve Hatalar</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>fBu özellik için ürün firmware sürümü 400 veya üstü gerekir. Multi/Quattro'nuzu güncellemek için kurulumcunuzla iletişime geçin.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>fBu özellik için ürün firmware sürümü 400 veya üstü gerekir. Multi/Quattro&apos;nuzu güncellemek için kurulumcunuzla iletişime geçin.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Şarj cihazı hazır değil, dengeleme başlatılamıyor</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Şarj cihazı hazır değil, dengeleme başlatılamıyor</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Eşitleme, toplu şarj durumu sırasında tetiklenemez</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Eşitleme, toplu şarj durumu sırasında tetiklenemez</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Eko</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Eko</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Maksimum akım</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Maksimum akım</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Maksimum güç</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Maksimum güç</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Minimum akım</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Minimum akım</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Yok</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Kullanılamıyor</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Kapalı</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Genel geçmiş</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Genel geçmiş</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Ayarlar</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Bilinmiyor</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Verim bugün</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Verim bugün</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Ürün Firmware yüklendi, cihaz yeniden başlatılıyor</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Ürün Firmware yüklendi, cihaz yeniden başlatılıyor</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Touch input control</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Touch input control</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Kaynaklı kontaklar test hatası (kısa devre)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Kaynaklı kontaklar test hatası (kısa devre)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>3 faza geçiş</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>3 faza geçiş</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>1 faza geçiş</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>1 faza geçiş</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Şarj etmeyi durdurun</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Şarj etmeyi durdurun</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Ayrılmış</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Ayrılmış</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>İnvertör modu</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>İnvertör modu</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Çıkışı L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Çıkışı L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Giriş</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Giriş</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Geçiş</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Geçiş</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Sayfa, en son sürümü yüklemek için on saniye içinde otomatik olarak yeniden yüklenecektir.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Sayfa, en son sürümü yüklemek için on saniye içinde otomatik olarak yeniden yüklenecektir.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>İnvertör (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>İnvertör (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>İnvertörler/Şarj Cihazları</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>İnvertörler/Şarj Cihazları</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Enerji sayacı bulunamadı
+        <translation>Enerji sayacı bulunamadı
 
 Bu menünün sadece RS485 üzerinden bağlı Carlo Gavazzi sayaçlarını gösterdiğini unutmayın. Ethernet üzerinden bağlı Carlo Gavazzi sayaçları da dahil olmak üzere diğer tüm sayaçlar için Modbus TCP/UDP cihazları menüsüne bakın.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Otomatik değişen</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Otomatik değişen</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Etkinleştirildiğinde, göstergelerin ve grafiklerin minimum ve maksimum değerleri geçmiş değerlere göre otomatik olarak ayarlanır.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Etkinleştirildiğinde, göstergelerin ve grafiklerin minimum ve maksimum değerleri geçmiş değerlere göre otomatik olarak ayarlanır.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Tüm aralık değerlerini sıfıra sıfırla</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Tüm aralık değerlerini sıfıra sıfırla</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Aralık Değerlerini Sıfırla</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Aralık Değerlerini Sıfırla</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Tüm değerleri sıfırlamak istediğinizden emin misiniz?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Tüm değerleri sıfırlamak istediğinizden emin misiniz?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Maksimum akım: 1 bağlı AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Maksimum akım: 1 bağlı AC</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Maksimum akım: 2 bağlı AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Maksimum akım: 2 bağlı AC</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Maksimum akım: AC girişi yok</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Maksimum akım: AC girişi yok</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>DC çıkışı</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>DC çıkışı</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Solar</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Solar</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Motor RPM</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Motor RPM</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Motor sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Motor sıcaklığı</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Kontrolör sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Kontrolör sıcaklığı</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Aktif döngü</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Aktif döngü</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>% 1 döngüsü</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>% 1 döngüsü</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>DC Bağlantı Kesme</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>DC Bağlantı Kesme</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Güç kapatıldı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Güç kapatıldı</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>İşlev değişikliği</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>İşlev değişikliği</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Firmware güncelleyin</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Firmware güncelleyin</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Yazılım sıfırlama</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Yazılım sıfırlama</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Tamamlanmamış</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Tamamlanmamış</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Geçen süre</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Geçen süre</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Şarj / bakım (Ah)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Şarj / bakım (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Akü (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Akü (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Düşük AC çıkış voltajı</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Düşük AC çıkış voltajı</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Yüksek AC çıkış voltajı</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Yüksek AC çıkış voltajı</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Toplam verim</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Toplam verim</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Sistem verimi</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Sistem verimi</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Günlük geçmiş</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Günlük geçmiş</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Yapılandırılacak alarm yok</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Yapılandırılacak alarm yok</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Maksimum PV voltaj</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Maksimum PV voltaj</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Maksimum akü gerilimi</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Maksimum akü gerilimi</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Minimum akü gerilimi</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Minimum akü gerilimi</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Pil bankası hatası</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Pil bankası hatası</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Pil voltajı desteklenmiyor</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Pil voltajı desteklenmiyor</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Yanlış sayıda pil</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Yanlış sayıda pil</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Geçersiz pil yapılandırması</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Geçersiz pil yapılandırması</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Balancer durumu</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Balancer durumu</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Balans edildi</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Balans edildi</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Balans dengesiz</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Balans dengesiz</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Peak Shaving yapmayan sistemlerde bu seçeneği kullanın.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Peak Shaving yapmayan sistemlerde bu seçeneği kullanın.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Yoğun tıraş için bu seçeneği kullanın.</translation>
+        <translation>Yoğun tıraş için bu seçeneği kullanın.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Tepe tıraş eşiği, AC giriş akımı limit ayarı kullanılarak ayarlanır. Daha fazla bilgi için belgelere bakın.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Tepe tıraş eşiği, AC giriş akımı limit ayarı kullanılarak ayarlanır. Daha fazla bilgi için belgelere bakın.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>İçe ve dışa aktarma için en yüksek tıraş eşikleri bu ekranda değiştirilebilir. Daha fazla bilgi için belgelere bakın.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>İçe ve dışa aktarma için en yüksek tıraş eşikleri bu ekranda değiştirilebilir. Daha fazla bilgi için belgelere bakın.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Sistem AC ithalat akımını sınırlayın</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Sistem AC ithalat akımını sınırlayın</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Bu özelliği kullanmak için Izgara ölçümü Harici ölçüm olarak ayarlanmalı ve güncel bir ESS asistanı kurulmalıdır.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Bu özelliği kullanmak için Izgara ölçümü Harici ölçüm olarak ayarlanmalı ve güncel bir ESS asistanı kurulmalıdır.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Maksimum sistem ithalat akımı (faz başına)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Maksimum sistem ithalat akımı (faz başına)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Bu özelliği kullanmak için ızgara ölçümü Harici ölçüm olarak ayarlanmalıdır.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Bu özelliği kullanmak için ızgara ölçümü Harici ölçüm olarak ayarlanmalıdır.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Maksimum sistem ihracat akımı (faz başına)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Maksimum sistem ihracat akımı (faz başına)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>kablolu</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>kablolu</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Kısa</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Sistem yükü yüksek, CPU yükünü azaltmak için yan panel kapatılıyor</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Sistem yükü yüksek, CPU yükünü azaltmak için yan panel kapatılıyor</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Giriş akımı limiti</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Giriş akımı limiti</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Kısa devre</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Kısa devre</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Satınalma</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Satınalma</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Satış</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Satış</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Hedef SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Hedef SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC çıkışı %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC çıkışı %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Trackers</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Trackers</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>RS cihazları</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>RS cihazları</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Elektron animasyonlarını duraklatma</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Elektron animasyonlarını duraklatma</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Toplam Kapasite</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Toplam Kapasite</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>BMS Sayısı</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>BMS Sayısı</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Limit sistem AC ihracat akımı</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Limit sistem AC ihracat akımı</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Modbus TCP/UDP cihazları</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Modbus TCP/UDP cihazları</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Cihaz ekle</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Cihaz ekle</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Cihazları tara</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Cihazları tara</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Kaydedilen cihazlar</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Kaydedilen cihazlar</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Keşfedilen cihazlar</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Keşfedilen cihazlar</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Modbus TCP/UDP cihazı ekleme</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Modbus TCP/UDP cihazı ekleme</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Protokol</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Protokol</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Bağlantı noktası</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Bağlantı noktası</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Birim</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Birim</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Kayıtlı Modbus cihazı yok</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Kayıtlı Modbus cihazı yok</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Cihaz %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Cihaz %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Modbus cihazını kaldırın?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Modbus cihazını kaldırın?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Modbus cihazı bulunamadı</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Modbus cihazı bulunamadı</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Pil %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Pil %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>AC akımı</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>AC akımı</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Jeneratörü başlatma/durdurma devre dışı
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Jeneratörü başlatma/durdurma devre dışı
 </translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Jeneratörde uzaktan çalıştırma fonksiyonu devre dışıdır. GX artık jeneratör setini çalıştıramayacak veya durduramayacaktır. Jeneratör kontrol panelinden etkinleştirin.
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Jeneratörde uzaktan çalıştırma fonksiyonu devre dışıdır. GX artık jeneratör setini çalıştıramayacak veya durduramayacaktır. Jeneratör kontrol panelinden etkinleştirin.
 </translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Otomatik başlat fonksiyonu</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Otomatik başlat fonksiyonu</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Geçerli çalışma süresi</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Kontrol durumu</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Kontrol durumu</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Jeneratör durumu
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Jeneratör durumu
 </translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Uzaktan çalıştırma modu</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Uzaktan çalıştırma modu</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Yağ Basıncı</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Yağ Basıncı</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Planlanmış şarj seviyeleri</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Planlanmış şarj seviyeleri</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Active (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Active (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Manuel Durdurma</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Manuel Durdurma</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Açık devre</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Açık devre</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2
 </translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (not available)
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (not available)
 </translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Dokunmatik giriş açık</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Dokunmatik giriş açık</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Dokunmatik giriş kapalı</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Dokunmatik giriş kapalı</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Dokunmatik Girişi devre dışı</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Dokunmatik Girişi devre dışı</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Uyarıları onaylayın</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Uyarıları onaylayın</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Kontrol hata kodu</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Kontrol hata kodu</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Genel Bakış sayfasında Pil simgesine tıklandığında gösterilen pil verilerini tanımlamak için bu menüyü kullanın. Aynı seçim VRM Portalında da görülebilir.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Genel Bakış sayfasında Pil simgesine tıklandığında gösterilen pil verilerini tanımlamak için bu menüyü kullanın. Aynı seçim VRM Portalında da görülebilir.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Sistem voltajı [V]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Sistem voltajı [V]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Bağlantı bilgileri</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Bağlantı bilgileri</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Lütfen seçiniz...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Lütfen seçiniz...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Güvenli</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Güvenli</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Parola korumalı ve ağ iletişimi şifrelenmiştir</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Parola korumalı ve ağ iletişimi şifrelenmiştir</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Zayıf</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Zayıf</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Parola korumalı, ancak ağ iletişimi şifrelenmemiş</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Parola korumalı, ancak ağ iletişimi şifrelenmemiş</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Teminatsız</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Teminatsız</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Şifre yok ve ağ iletişimi şifrelenmemiş</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Şifre yok ve ağ iletişimi şifrelenmemiş</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Şifrenin en az 8 karakter uzunluğunda olması gerekir</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Parola Gir</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Şifrenin en az 8 karakter uzunluğunda olması gerekir</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Şifrenin en az 8 karakter uzunluğunda olması gerekir</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>'Güvenli' profili seçin?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>&apos;Güvenli&apos; profili seçin?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>'Zayıf' profili mi seçtiniz?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>&apos;Zayıf&apos; profili mi seçtiniz?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>'Güvencesiz' profili seçin?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>&apos;Güvencesiz&apos; profili seçin?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Yerel ağ hizmetleri parola korumalıdır
+        <translation>- Yerel ağ hizmetleri parola korumalıdır
 - Ağ iletişimi şifrelenmiştir
 - VRM ile güvenli bir bağlantı etkinleştirildi
 - Güvensiz ayarlar etkinleştirilemez</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Yerel ağ hizmetleri parola korumalıdır
+        <translation>- Yerel ağ hizmetleri parola korumalıdır
 - Yerel web sitelerine şifrelenmemiş erişim de etkinleştirilmiştir (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Yerel ağ hizmetlerinin parolaya ihtiyacı yoktur
+        <translation>- Yerel ağ hizmetlerinin parolaya ihtiyacı yoktur
 - Yerel web sitelerine şifrelenmemiş erişim de etkinleştirilmiştir (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Kök parola</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Kök parola</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Çıkış Yap</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Çıkış Yap</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Şimdi çıkış yap</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Şimdi çıkış yap</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Oturumu kapatayım mı?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Oturumu kapatayım mı?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Bu işlem tüm yerel ağ bağlantılarını kesecektir.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Bu işlem tüm yerel ağ bağlantılarını kesecektir.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Çıkış Yap</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Çıkış Yap</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Salt okunur</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Salt okunur</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Tam</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Tam</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Emin misin?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Emin misin?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Bu ayarı Salt Okunur veya Kapalı olarak değiştirmek sizi dışarıda bırakacaktır.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Bu ayarı Salt Okunur veya Kapalı olarak değiştirmek sizi dışarıda bırakacaktır.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>MQTT Erişimi</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>MQTT Erişimi</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' bir sayı değil.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; bir sayı değil.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Evet</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Evet</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>1 veya daha az basamaklı bir sayı kullanın.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>1 veya daha az basamaklı bir sayı kullanın.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' geçerli bir IP adresi değil.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; geçerli bir IP adresi değil.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' geçerli bir bağlantı noktası numarası değil. 0-65535 arasında bir sayı kullanın.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; geçerli bir bağlantı noktası numarası değil. 0-65535 arasında bir sayı kullanın.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>1 geçerli bir birim numarası değil. 1-247 arasında bir sayı kullanın.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>1 geçerli bir birim numarası değil. 1-247 arasında bir sayı kullanın.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Geçerli çalışma süresi</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Geçerli çalışma süresi</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Jeneratör hata kodları</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Jeneratör hata kodları</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Soğutucu sıcaklığı</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Soğutucu sıcaklığı</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Şarj voltajı</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Şarj voltajı şu anda BMS tarafından kontrol edilmektedir.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Şarj voltajı şu anda BMS tarafından kontrol edilmektedir.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Şarj Akımı Sınırı</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Şarj Akımı Sınırı</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>BMS Kontrollü</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>BMS Kontrollü</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Bir BMS mevcut olduğunda BMS kontrolü otomatik olarak etkinleştirilir. Sistem yapılandırması değişirse veya mevcut BMS yoksa sıfırlayın.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Bir BMS mevcut olduğunda BMS kontrolü otomatik olarak etkinleştirilir. Sistem yapılandırması değişirse veya mevcut BMS yoksa sıfırlayın.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Servis zamanlayıcısı devre dışı.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Servis zamanlayıcısı devre dışı.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>VRM Portalı</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>VRM Portalı</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (uzaktan VPN erişimi)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (uzaktan VPN erişimi)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Ağ hizmetlerinin etkinleştirilebilmesi için önce bir Güvenlik Profili yapılandırılmalıdır, bkz.</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Ağ hizmetlerinin etkinleştirilebilmesi için önce bir Güvenlik Profili yapılandırılmalıdır, bkz.</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' geçersiz karakterler içerdiği için '%2' ile değiştirildi.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; geçersiz karakterler içerdiği için &apos;%2&apos; ile değiştirildi.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Başlatılıyor...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Başlatılıyor...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Arka uç başlıyor...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Arka uç başlıyor...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Arka uç durduruldu.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Arka uç durduruldu.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>Bağlantı başarısız oldu.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>Bağlantı başarısız oldu.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Bu GX cihazının Tailscale oturumu kapatılmıştır.
+        <translation>Bu GX cihazının Tailscale oturumu kapatılmıştır.
 
 Lütfen bekleyin veya internet bağlantınızı kontrol edin.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Tailscale'den yanıt bekliyorum...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Tailscale&apos;den yanıt bekliyorum...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Bu bağlantıyı açarak bu GX cihazını Tailscale hesabınıza bağlayın:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Bu bağlantıyı açarak bu GX cihazını Tailscale hesabınıza bağlayın:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Lütfen bekleyin veya internet bağlantınızı kontrol edin.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Lütfen bekleyin veya internet bağlantınızı kontrol edin.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Bilinmeyen durum: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Bilinmeyen durum: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Hata: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Hata: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Bu ayarları düzenlemek için Tailscale'i devre dışı bırakın.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Bu ayarları düzenlemek için Tailscale&apos;i devre dışı bırakın.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Tailscale Ölçeğini Etkinleştir</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Tailscale Ölçeğini Etkinleştir</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Makine adı</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Makine adı</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Tailscale hesabından çıkış</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Tailscale hesabından çıkış</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Yerel ağ erişimi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Yerel ağ erişimi</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Yerel ethernet ağına erişim</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Yerel ethernet ağına erişim</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Yerel WiFi ağına erişim</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Yerel WiFi ağına erişim</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Özel ağ(lar)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Özel ağ(lar)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Örnek: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Örnek: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Açıklama:
+        <translation>Açıklama:
 
 Tailscale tarafından alt ağ rotaları olarak adlandırılan bu özellik, yerel ağ(lar)daki diğer cihazlara uzaktan erişim sağlar.
 
@@ -7392,2989 +8032,3056 @@ Tailscale tarafından alt ağ rotaları olarak adlandırılan bu özellik, yerel
 Yeni bir ağ ekledikten/etkinleştirdikten sonra, Tailscale yönetici konsolunda bir kez onaylamanız gerekir.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Özel "tailscale ölçeği büyütme" argümanları</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Özel &quot;tailscale ölçeği büyütme&quot; argümanları</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Özel sunucu URL'si (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Özel sunucu URL&apos;si (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Bu jeneratör kontrol ünitesinin kontrol edilebilmesi için bir yardımcı röleye ihtiyacı var ancak yardımcı röle yapılandırılmamış. Lütfen Ayarlar → Röle altındaki Röle 1'i "Bağlı jeneratör yardımcı rölesi" olarak yapılandırın.</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Bu jeneratör kontrol ünitesinin kontrol edilebilmesi için bir yardımcı röleye ihtiyacı var ancak yardımcı röle yapılandırılmamış. Lütfen Ayarlar → Röle altındaki Röle 1&apos;i &quot;Bağlı jeneratör yardımcı rölesi&quot; olarak yapılandırın.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Yüksek marş aküsü voltajı alarmları</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Yüksek marş aküsü voltajı alarmları</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Jeneratör ısınmasını atla</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Jeneratör ısınmasını atla</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Açık, ancak hizmet yok (500 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Açık, ancak hizmet yok (500 kbit/s)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Kök parolası %1 olarak değiştirildi</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Kök parolası %1 olarak değiştirildi</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Bağlı jeneratör yardımcı rölesi</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Bağlı jeneratör yardımcı rölesi</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>AC yüklerin konumu</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>AC yüklerin konumu</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>AC giriş ve çıkış</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>AC giriş ve çıkış</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Bu seçeneği İnvertör/Şarj Cihazının girişinde AC yükleri mevcut olduğunda kullanın. Emin değilseniz bu seçeneği kullanın.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Bu seçeneği İnvertör/Şarj Cihazının girişinde AC yükleri mevcut olduğunda kullanın. Emin değilseniz bu seçeneği kullanın.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Yalnızca AC çıkışı</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Yalnızca AC çıkışı</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Sistem bir şebeke ölçer kullanıyorsa ancak tüm AC yükleri İnvertör/Şarj Cihazının çıkışında ise bu seçeneği kullanın.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Sistem bir şebeke ölçer kullanıyorsa ancak tüm AC yükleri İnvertör/Şarj Cihazının çıkışında ise bu seçeneği kullanın.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Aylık</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Aylık</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>EVCS</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>EVCS</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Isı pompası</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Isı pompası</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Temel Yükler</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Temel Yükler</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Yapılandırılmış otomatik başlatma koşullarına göre jeneratörü başlatın ve durdurun.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Yapılandırılmış otomatik başlatma koşullarına göre jeneratörü başlatın ve durdurun.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>DC jeneratör ayarları</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>DC jeneratör ayarları</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Alternatör Sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Alternatör Sıcaklığı</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Motor Sıcaklığı</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Motor Sıcaklığı</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Toplam çalışma süresi</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Toplam çalışma süresi</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Ağ Güvenliği Profili</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Ağ Güvenliği Profili</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Son %1 gün</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Son %1 gün</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Çalışmaya devam etmesini sağlayan otomatik başlatma koşulları etkinleştirilmediği sürece jeneratör %1'de duracaktır.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Çalışmaya devam etmesini sağlayan otomatik başlatma koşulları etkinleştirilmediği sürece jeneratör %1&apos;de duracaktır.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Jeneratör, çalışmasını sağlayan otomatik başlatma koşulları etkinleştirilmediği sürece manuel olarak durdurulana kadar çalışacaktır.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Jeneratör, çalışmasını sağlayan otomatik başlatma koşulları etkinleştirilmediği sürece manuel olarak durdurulana kadar çalışacaktır.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Klasik UI</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Klasik UI</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Yeni UI</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Yeni UI</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Dil başarıyla değiştirildi!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Güç sınırlama</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Dil başarıyla değiştirildi!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Multi-RS ve HS19 cihazları için ESS ayarları RS Sistemi ürün sayfasında mevcuttur.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Multi-RS ve HS19 cihazları için ESS ayarları RS Sistemi ürün sayfasında mevcuttur.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Jeneratör çalıştırma/durdurma</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Jeneratör çalıştırma/durdurma</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>"Ayarlar / Genel" bölümündeki "Ağ Güvenlik Profili" seçilmeden ürün yazılımı sürümünü değiştirmek mümkün değildir.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>&quot;Ayarlar / Genel&quot; bölümündeki &quot;Ağ Güvenlik Profili&quot; seçilmeden ürün yazılımı sürümünü değiştirmek mümkün değildir.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Süre</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Süre</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Sistem alarmları</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Sistem alarmları</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Sistem alarmı yok</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Sistem alarmı yok</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Geri</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Geri</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Yeni</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Yeni</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>Atla</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>Atla</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Hoş geldiniz!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Hoş geldiniz!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>GX'inizin hem kullanılabilirliğini hem de estetiğini geliştiren, tamamen yeniden tasarlanmış bir arayüz sunmaktan heyecan duyuyoruz.
+        <translation>GX&apos;inizin hem kullanılabilirliğini hem de estetiğini geliştiren, tamamen yeniden tasarlanmış bir arayüz sunmaktan heyecan duyuyoruz.
 
 Kolaylaştırılmış navigasyon ve yeni bir görünümle, sevdiğiniz her şeye erişmek artık daha da kolay ve görsel olarak daha çekici.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Koyu - açık mod</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Koyu - açık mod</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Farklı ortamlar farklı ekran ayarları gerektirir. Karanlık ve Aydınlık Modları, nerede olursanız olun en iyi görüntüleme deneyimini sağlar.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Farklı ortamlar farklı ekran ayarları gerektirir. Karanlık ve Aydınlık Modları, nerede olursanız olun en iyi görüntüleme deneyimini sağlar.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>İhtiyacınız olan tüm önemli bilgiler, temiz ve basit bir düzende sunulur. En önemli parça, sistem bilgilerinize bir bakışta hızlı erişim sağlayan, halkalar içeren özelleştirilebilir bir widget'tır.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>İhtiyacınız olan tüm önemli bilgiler, temiz ve basit bir düzende sunulur. En önemli parça, sistem bilgilerinize bir bakışta hızlı erişim sağlayan, halkalar içeren özelleştirilebilir bir widget&apos;tır.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Kolay izleme için hepsi tek bir yerde bulunan gerçek zamanlı sistem verilerini içeren güncellenmiş Genel Bakış panelimizle daha fazla kontrol elde edin.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Kolay izleme için hepsi tek bir yerde bulunan gerçek zamanlı sistem verilerini içeren güncellenmiş Genel Bakış panelimizle daha fazla kontrol elde edin.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Kontroller:</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Kontroller:</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Tüm günlük kontroller artık yeni Kontroller bölmesinde bir araya getirilmiştir. </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Tüm günlük kontroller artık yeni Kontroller bölmesinde bir araya getirilmiştir. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Watt &amp; Amper</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Watt &amp; Amper</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Artık Watt ve Amper arasında geçiş yapabilirsiniz. Tercihinize en uygun birimi seçin.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Artık Watt ve Amper arasında geçiş yapabilirsiniz. Tercihinize en uygun birimi seçin.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Daha fazla bilgi edin</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Daha fazla bilgi edin</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Yenilenen UI hakkında daha fazla bilgi edinmek için aşağıdaki bağlantıya erişin.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Yenilenen UI hakkında daha fazla bilgi edinmek için aşağıdaki bağlantıya erişin.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Renewed UI hakkında daha fazla bilgi edinmek için QR kodunu tarayın.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Renewed UI hakkında daha fazla bilgi edinmek için QR kodunu tarayın.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Tamamlandı</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Tamamlandı</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Sonraki</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Sonraki</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Hata: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Hata: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Aktif Hata</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Aktif Hata</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Jeneratör toplam çalışma süresi (saat)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Jeneratör toplam çalışma süresi (saat)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Başlangıç sayfası</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Başlangıç sayfası</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Kullanıcı arayüzü</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Kullanıcı arayüzü</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Kullanıcı arayüzü (Uzak Konsol)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Kullanıcı arayüzü (Uzak Konsol)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>1 güncellendi</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>1 güncellendi</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>Kullanıcı arayüzü %1'e geçecektir.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>Kullanıcı arayüzü %1&apos;e geçecektir.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>1, %2 olarak ayarlanmıştır</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Bu PV inverter güç sınırlama desteğine sahiptir. Normal çalışmayı engelliyorsa bu ayarı devre dışı bırakın.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>1, %2 olarak ayarlanmıştır</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Yeniden başlatmak için 'OK' tuşuna basın</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Yeniden başlatmak için &apos;OK&apos; tuşuna basın</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Node-RED fabrika ayarlarına sıfırlama</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Node-RED fabrika ayarlarına sıfırlama</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Node-RED'i fabrika ayarlarına sıfırlamak istediğinizden emin misiniz? Bu, tüm akışlarınızı silecektir.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Node-RED&apos;i fabrika ayarlarına sıfırlamak istediğinizden emin misiniz? Bu, tüm akışlarınızı silecektir.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Bağlantı durumu</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Bağlantı durumu</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Bağlantı durumu (HTTPS kanalı)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Bağlantı durumu (HTTPS kanalı)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Bağlantı durumu (HTTP kanalı)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Bağlantı durumu (HTTP kanalı)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Bağlantı durumu (MQTT Gerçek zamanlı kanal)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Bağlantı durumu (MQTT Gerçek zamanlı kanal)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Bağlantı durumu (MQTT RPC kanalı)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Bağlantı durumu (MQTT RPC kanalı)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Otomatik başlatıldı - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Otomatik başlatıldı - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Devre dışı bırakma değeri</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Devre dışı bırakma değeri</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Çalışmıyor</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Çalışmıyor</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>İletişim kaybı</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>İletişim kaybı</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>SOC durumu</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>SOC durumu</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>AC yük durumu</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>AC yük durumu</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Akü akım durumu</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Akü akım durumu</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Akü voltaj durumu</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Akü voltaj durumu</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>İnvertör aşırı yük durumu</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>İnvertör aşırı yük durumu</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Şarj/Deşarj Devre Dışı</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Şarj/Deşarj Devre Dışı</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Şarj Devre Dışı</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Şarj Devre Dışı</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Deşarj Devre Dışı</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Deşarj Devre Dışı</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Kısa</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Bilgi  (yan panel açık)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Bilgi  (yan panel açık)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Görünüm</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Seviyeler (Tanklar)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Seviyeler (Tanklar)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Seviyeler (Çevre)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Seviyeler (Çevre)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Pil listesi</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Pil listesi</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>GX cihazı güncellendi</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>GX cihazı güncellendi</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>%n dakika sonra</numerusform>
-        <numerusform>%n dakika sonra</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>%n dakika sonra</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Uygulama başladığında bu sayfaya gidin.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Uygulama başladığında bu sayfaya gidin.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Zaman Aşımı</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Zaman Aşımı</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Uygulama etkin olmadığında başlangıç sayfasına geri dönün.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Uygulama etkin olmadığında başlangıç sayfasına geri dönün.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Bir dakikalık hareketsizlikten sonra, bu listede varsa geçerli sayfayı başlangıç sayfası olarak seçin.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Bir dakikalık hareketsizlikten sonra, bu listede varsa geçerli sayfayı başlangıç sayfası olarak seçin.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Bu akım limiti sistem konfigürasyonunda sabittir. Ayarlanamaz.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Bu akım limiti sistem konfigürasyonunda sabittir. Ayarlanamaz.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Mod, sistem yapılandırmasında sabittir. Ayarlanamaz.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Mod, sistem yapılandırmasında sabittir. Ayarlanamaz.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Jeneratör başlat/durdur işlevi etkin değil, röle ayarlarına gidin ve işlevi "Jeneratör başlat/durdur" olarak ayarlayın</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Fas Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Orta Batı Afrika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Güney Afrika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Namibya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Mısır Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Doğu Afrika Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Arjantin Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Güneydoğu Amerika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Grönland Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Montevideo Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Newfoundland Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Güney Amerika Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Orta Brezilya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Paraguay Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Güney Amerika Batı Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Venezuela Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>ABD Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Orta Kanada Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Orta Amerika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Orta Zaman Dilimi (Meksika)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Orta Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Dağ Zaman Dilimi (Meksika)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Dağ Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>ABD Dağ Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pasifik Zaman Dilimi (Meksika)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Alaska Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleut Adaları</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Yeni Zelanda Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Orta Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Batı Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Batı Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Güneydoğu Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Orta Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Batı Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Doğu Afrika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Güney Amerika Batı Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Batı Avrupa Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Kamçatka Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Magadan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Vladivostok Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Yakutistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Tokyo Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Kore Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Singapur Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ulan Batur Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Taipei Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Kuzay Asya Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Çin Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Güneydoğu Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Kuzey Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Kuzey Orta Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Orta Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Bangladeş Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Nepal Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Sri Lanka Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Hindistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Batı Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Pakistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Yekaterinburg Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Gürcistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Kafkasya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Azerbaycan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arap Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Afganistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>İran Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arap Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arap Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Suriye Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Orta Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Ürdün Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>İsrail Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Azorlar Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Yeşil Burun Adaları Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Tazmanya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Doğu Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Doğu Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Orta Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Orta Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Batı Avustralya Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Orta Atlantik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Dateline Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Orta Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Orta Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romanya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Batı Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Doğu Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB  Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Beyaz Rusya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Rusya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Türkiye Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Mauritius Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Christmas Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Tonga Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fiji Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Yeni Zelanda Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Orta Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Batı Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hawaii Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Easter Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Jeneratör başlat/durdur işlevi etkin değil, röle ayarlarına gidin ve işlevi &quot;Jeneratör başlat/durdur&quot; olarak ayarlayın</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Bilinmiyor</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">Güneş enerjisi verimi</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">DC Giriş</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC Yükleri</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">dcLoads</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Görünüm</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Durum</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Toplam verim</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Sistem verimi</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Sadece alarm</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Alarm ve uyarılar</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Uyarı</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Hata yok</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Hata yok</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Bilinmeyen hata: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Bilinmeyen hata: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Hata yok</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Hata yok</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Akü başlatma hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Akü başlatma hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Bağlı akü yok</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Bağlı akü yok</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Bilinmeyen akü</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Bilinmeyen akü</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Farklı akü türleri</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Farklı akü türleri</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Akü sayısı hatalı</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Akü sayısı hatalı</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt bulunamadı</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt bulunamadı</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Akü ölçüm hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Akü ölçüm hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>İntern hesap hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>İntern hesap hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Seri bağlı akü sayısı yanlış</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Seri bağlı akü sayısı yanlış</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Donanım hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Donanım hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Watchdog hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Watchdog hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Aşırı voltaj</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Aşırı voltaj</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Alçak gerilim</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Alçak gerilim</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Aşırı sıcaklık</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Aşırı sıcaklık</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Düşük sıcaklık</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Düşük sıcaklık</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Şarj oluyor beklemede</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Şarj oluyor beklemede</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>ADC hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>ADC hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Akü iletişim hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Akü iletişim hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Ön Şarj hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Ön Şarj hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Emniyet kontaktörü hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Emniyet kontaktörü hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Akü güncelleme hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Akü güncelleme hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>BMS kablo hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>BMS kablo hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Referans voltaj hatası</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Referans voltaj hatası</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Yanlış sistem voltajı</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Yanlış sistem voltajı</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Ön şarj zaman aşımı</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Ön şarj zaman aşımı</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>ATC/ATD hata</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>ATC/ATD hata</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibrasyon verileri kaybedildi</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibrasyon verileri kaybedildi</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Ayarlar geçersiz</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Ayarlar geçersiz</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>İnterlok</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>İnterlok</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Acil durdurma</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Acil durdurma</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>İletişim zaman aşımı</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>İletişim zaman aşımı</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Güvenlik kilidi</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Güvenlik kilidi</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Terminal aşırı sıcaklığı</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Terminal aşırı sıcaklığı</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Hata yok</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Akü yüksek sıcaklığı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Akü yüksek gerilimi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Akü Tsense hatalı kablolanmış</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Akü Tsense mevcut değil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Akü Vsense hatalı kablolanmış</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Akü Vsense mevcut değil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Akü yüksek kablo kayıpları</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Akü Düşük Voltaj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Akü yüksek dalgalanma gerilimi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Akü düşük şarj durumu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Akü orta nokta gerilim sorunu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Akü sıcaklığı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Şarj cihazı yüksek sıcaklığı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Şarj cihazı aşırı akımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Şarj cihazı negatif akımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Şarj cihazı Bulk süresi doldu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Şarj cihazı akım sensörü sorunu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>İç Tsensor hatalı kablolanmış</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>İç Tsensor mevcut değil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Şarj cihazı fanı algılanmadı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Şarj cihazı fanı aşırı akımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Şarj cihazı bağlantı ucu aşırı ısınmış</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Şarj cihazı kısa devresi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Şarj cihazı güç katı sorunu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Aşırı şarj koruması</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Giriş yüksek voltaj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Giriş aşırı akımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Giriş aşırı gücü</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Giriş polarite sorunu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Giriş gerilimi yok</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Girişin kapanması (yinelemesiz)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Giriş kapanması (yinelemeli)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Giriş dahili arızası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>PV izolasyon hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Topraklama hatası tespit edildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>İnvertör aşırı yüklü</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>İnvertör sıcaklığı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>İnvertör pik akımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>İnvertör intern DC düzeyi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>İnvertör yanlış AC çıkış düzeyi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>İnvertör güç katı hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>AC'ye bağlı invertör</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>ACIN1 röle testi hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>ACIN2 röle testi hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Cihaz ortadan kayboldu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Uyumsuz cihaz</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>BMS bağlantısı kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Ağ yanlış yapılandırılmış</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Faz rotasyon</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Çoklu AC girişleri</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Faz aşırı yüklemesi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Belleğe yazma hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>CPU sıcaklığı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>İletişim kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Kalibrasyon verileri kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Uyumsuz donanım yazılımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Uyumsuz donanım</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Ayarlar geçersiz</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Referans voltajı arızası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Test cihazı arızası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Geçmiş geçersiz</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>kWh sayaçları geçersiz</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>DC voltaj hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>GFCI sensor error</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>3V3 besleme hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>5V besleme hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>12V besleme hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>15V besleme hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>PV Girişi kapatma</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Ayarları değiştirmek için anahtarı kilitli olmayan bir konuma getirin.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>D-Bus veri kaynağını kullan: belirtilen D-Bus adresine bağlanın.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>D-Bus veri kaynağını kullanın: varsayılan D-Bus adresine bağlanın</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>MQTT veri kaynağını kullan: belirtilen MQTT aracı adresine bağlanın.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>MQTT veri kaynağı cihazı portal kimliği.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>Portal ID</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>MQTT VRM web barındırıcısı parçası</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>kırık</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>MQTT veri kaynağı kullanıcı adı</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Kullanıcı</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>MQTT veri kaynağı şifresi</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>Pass</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>MQTT veri kaynağı jetonu</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Jeton kodu</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>FPS sayacını etkinleştir</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Açılış ekranını atla</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Test için sahte veri kaynağı kullanın.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Cihaz kapatıldı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Yeni/eski MK2 karıştırıldı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Beklenen cihazlar hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Başka hiçbir cihaz algılanamadı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>AC-çıkışında aşırı gerilim</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>DDC program hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>Yardımsız VE veri yolu  BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Topraklama rölesi testi başarısız</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Sistem saati eşitleme hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Şebeke rölesi test hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Yapılandırma ikinci MCU ile uyumsuz</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Cihaz aktarım hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Yapılandırma veya dongle bekleniyor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Ana faz eksik</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Aşırı gerilim oluştu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Bağımlı birimin AC girişi yok!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Cihaz bağımlı birim olmuyor</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Sistem koruması başlatıldı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Firmware uyumsuzluğu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Dahili hata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Başarısız röle testi bağlantıyı engeller</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>VE.Veri yolu hatası</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Bilinmeyen hata:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Dahili hata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Hata yok</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Akü yüksek sıcaklığı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Akü yüksek gerilimi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Akü Düşük Voltaj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Akü voltajı yapılandırılan maks.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Alternatör yüksek sıcaklık</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Alternatör yüksek RPM</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Field drive FET high temperature</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Gerekli sensör eksik</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Alternatör düsük gerilim</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Alternatör yüksek voltaj ofseti</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Alternatör Voltajı yapılandırılan maks.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Alternatör yüksek voltajı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Akü bağlantısı kesildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Akü yüksek voltaj bağlantı kesme</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Menzil dışında akü örneği</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Çok fazla BMS cihazlar</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Akü bağlantısı kesilmek üzere</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>İzlenecek çok fazla cihaz</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Akü düşük voltaj bağlantı kesme</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Akü yüksek akım bağlantısı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Akü yüksek sıcaklık bağlantısı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Akü düşük sıcaklık bağlantısı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>BMS bağlantısı kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC Devre Dışı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>DC/DC dönüştürücü hazır değil</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC yüksek birincil voltaj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC düşük birincil voltaj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC yüksek ikincil voltaj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC düşük ikinci voltaj</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC yüksek sıcaklık</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>DC/DC yanlış yapılandırma</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Akü sıcaklık sensörü arızalı</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Bilinmeyen hata:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Bilinmeyen hata:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Hata yok</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Akü yüksek sıcaklığı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Akü yüksek gerilimi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Akü Tsense hatalı kablolanmış</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Akü Tsense mevcut değil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Akü Vsense hatalı kablolanmış</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Akü Vsense mevcut değil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Akü yüksek kablo kayıpları</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Akü Düşük Voltaj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Akü yüksek dalgalanma gerilimi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Akü düşük şarj durumu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Akü orta nokta gerilim sorunu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Akü sıcaklığı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Şarj cihazı yüksek sıcaklığı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Şarj cihazı aşırı akımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Şarj cihazı negatif akımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Şarj cihazı Bulk süresi doldu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Şarj cihazı akım sensörü sorunu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>İç Tsensor hatalı kablolanmış</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>İç Tsensor mevcut değil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Şarj cihazı fanı algılanmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Şarj cihazı fanı aşırı akımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Şarj cihazı bağlantı ucu aşırı ısınmış</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Şarj cihazı kısa devresi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Şarj cihazı güç katı sorunu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Aşırı şarj koruması</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Giriş yüksek voltaj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Giriş aşırı akımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Giriş aşırı gücü</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Giriş polarite sorunu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Giriş gerilimi yok</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Girişin kapanması (yinelemesiz)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Giriş kapanması (yinelemeli)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Giriş dahili arızası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>PV izolasyon hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Topraklama hatası tespit edildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>İnvertör aşırı yüklü</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>İnvertör sıcaklığı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>İnvertör pik akımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>İnvertör intern DC düzeyi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>İnvertör yanlış AC çıkış düzeyi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>İnvertör güç katı hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>AC&apos;ye bağlı invertör</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>ACIN1 röle testi hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>ACIN2 röle testi hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Cihaz ortadan kayboldu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Uyumsuz cihaz</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>BMS bağlantısı kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Ağ yanlış yapılandırılmış</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Faz rotasyon</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Çoklu AC girişleri</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Faz aşırı yüklemesi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Belleğe yazma hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>CPU sıcaklığı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>İletişim kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Kalibrasyon verileri kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Uyumsuz donanım yazılımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Uyumsuz donanım</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Ayarlar geçersiz</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Referans voltajı arızası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Test cihazı arızası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Geçmiş geçersiz</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>kWh sayaçları geçersiz</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>DC voltaj hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>GFCI sensor error</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>3V3 besleme hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>5V besleme hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>12V besleme hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>15V besleme hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>PV Girişi kapatma</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Bilinmeyen hata:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Bilinmeyen hata:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Bilinmeyen hata:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Bilinmeyen hata:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Hata yok</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>AC voltaj L1 çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>AC voltaj çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>AC voltaj L1 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>AC voltaj çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>AC frekansı L1 çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>AC frekansı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>AC frekansı L1 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>AC frekansı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC akımı L1 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>AC akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>AC gücü L1 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>AC gücü çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Acil durdurma</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Servo akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Yağ basıncı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Yağ basıncı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Motor sıcaklığı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Motor sıcaklığı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Sargı sıcaklığı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Sargı sıcaklığı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Egzoz sıcaklığı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Egzoz sıcaklığı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Elektronik sıcaklık düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Elektronik sıcaklık yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Marş motoru voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Marş akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Kızdırma gerilimi çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Isıtma akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Cold-Start-Aid voltajı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Cold-Start-Aid akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Yakıt tutma mıknatısı voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Yakıt tutucu mıknatıs akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Stop solenoidi tutma bobini voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Durdurma selenoidi tutma bobini akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Stop solenoidi çekme bobini voltajı çok düşük </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Durdurma selenoidi çekme bobini akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Fan/su pompası voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Fan/su pompası akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Akım sensörü voltajı düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Akım sensörü akımı yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Boost çıkış voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Güç Yükseltme çıkışı akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Bus besleme gerilimi çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Bus besleme akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Marş motoru akü voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Marş motoru akü voltajı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Devir çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Devir çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Beklenmedik duruş/yakıt beslemesinde sorun</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Güç kontaktörü voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Güç kontaktörü akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>AC voltajı L2 çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>AC voltajı L2 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>AC frekansı L2 çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>AC frekansı L2 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>AC akımı L2 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>AC gücü L2 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>AC voltajı L3 çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>AC voltajı L3 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>AC frekansı L3 çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>AC frekansı L3 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC akımı L3 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>AC gücü L3 çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Çıkış İnvertör voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Çıkış İnvertör akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Evrensel çıkış (1A) voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Evrensel çıkış (1A) akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Evrensel çıkış (5A) voltajı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Evrensel çıkış (5A) akımı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT DC gerilimi 1 düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>AGT DC gerilimi 1 yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT DC akımı 1 düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT DC akımı 1 yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>AGT DC gerilimi 2 düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>AGT DC gerilimi 2 yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT DC akımı 2 düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT DC akımı 2 yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 soğutucu düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 soğutucu yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 rayı (-) düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 ray (-) yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 rayı (+) düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 rayı (+) yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Yakıt sıcaklığı çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Yakıt sıcaklığı çok yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Yakıt seviyesi çok düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Kontrol birimi kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Panel Kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Bakım gerekmekte</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>3-fazlı modül kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>AGT modülü kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Senkronizasyon arızası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Kayıp harici ECU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Hava emme filtresi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Diyagnostik mesaj (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Senk. modülü kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Yük dengesi arızası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Senk. modu devre dışı bırakıldı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Kırmızı Durdurma Lambası (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Kehribar Uyarı Lambası (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Arıza Gösterge Lambası (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Koruma Lambası (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Döner alan hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Yakıt seviyesi sensörü kaybedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>İnverter olmadan çalıştırma</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>1 numaralı otobüs öldü.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Başlatma talebi reddedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Uzaktan çalıştırma reddedildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Yük rölesini zorla kapatma</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Senkronizasyon Modülü çevrimdışı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Kayıp BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Dönüştürücü DC Bağlantı Gerilimi Düşük/Ters</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Dönüştürücü DC Bağlantı Akımı Düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Dönüştürücü DC Ön Şarj Gerilimi Düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Dönüştürücü DC Ön Şarj Gerilimi Yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Dönüştürücü IGBT/MOSFET Sürücü Hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Dönüştürücü Hatası Güç Kontrol Döngüsü</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Dönüştürücü AC Frekans Algılama</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Dönüştürücü Kontrol Değeri Hatası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Fabrika ayarı değiştirildi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Yönetici modunda değiştirilen parametre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Manuel Müdahale (ext. Sistem)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Init arızası</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Güvenlik zamanlayıcısı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>İnvertör sıcaklığı yüksek L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>İnvertör sıcaklığı yüksek L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>İnvertör sıcaklığı yüksek L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>İnverter sıcaklığı yüksek DC bağlantısı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>İnvertör aşırı yüklü</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>İnvertör iletişim kayboldu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>DC aşırı yüklü</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>DC aşırı gerilimli</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Bağlantı yok</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Hata yok</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Bilinmeyen hata: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Bilinmeyen hata:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Yağ Basıncı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Silindir kapağı aşırı sıcaklığı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Şarj kontrolü</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Beklenenden daha yüksek hız</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Aşırı hız</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Petrol sıcaklığı beklenenden yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Yağ sıcaklığı açık devre / güce kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Yağ sıcaklığı toprağa kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analog ayar noktası yüksek / güce kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analog ayar noktası düşük / toprağa kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>TSC1 mesaj alma zaman aşımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>CM1 mesaj alma zaman aşımı</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Akü voltajı yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Akü voltajı düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Hız sinyali bozuk</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Dahili 5V sensör beslemesi yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Dahili 5V sensör beslemesi düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Barometrik basınç yüksek</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Barometrik basınç düşük</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Çıkış yakıt pompası güce kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Çıkış yakıt pompası şasiye kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Çıkış kızdırma bujisi güce kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Çıkış kızdırma bujisi şasiye kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Enjektör açık devre/alt taraf şasiye kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Enjektör bobini dahili kısa devresi</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Enjektör düşük tarafı güce kısa devre</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Hizmet saatlerinin süresi doldu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>İşlemci arızası</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Bilinmeyen hata:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Akü</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Akü</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Buzdolabı</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Buzdolabı</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Jenerik</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Jenerik</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Oda</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Oda</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Dış mekan</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>Dış mekan</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Su ısıtıcı</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Su ısıtıcı</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Dondurucu</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Dondurucu</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Bilinmeyen hata:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Hata yok</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>AC voltaj L1 çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>AC voltaj çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>AC voltaj L1 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>AC voltaj çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>AC frekansı L1 çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>AC frekansı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>AC frekansı L1 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>AC frekansı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC akımı L1 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>AC akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>AC gücü L1 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>AC gücü çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Acil durdurma</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Servo akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Yağ basıncı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Yağ basıncı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Motor sıcaklığı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Motor sıcaklığı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Sargı sıcaklığı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Sargı sıcaklığı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Egzoz sıcaklığı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Egzoz sıcaklığı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Elektronik sıcaklık düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Elektronik sıcaklık yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Marş motoru voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Marş akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Kızdırma gerilimi çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Isıtma akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Cold-Start-Aid voltajı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Cold-Start-Aid akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Yakıt tutma mıknatısı voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Yakıt tutucu mıknatıs akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Stop solenoidi tutma bobini voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Durdurma selenoidi tutma bobini akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Stop solenoidi çekme bobini voltajı çok düşük </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Durdurma selenoidi çekme bobini akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Fan/su pompası voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Fan/su pompası akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Akım sensörü voltajı düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Akım sensörü akımı yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Boost çıkış voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Güç Yükseltme çıkışı akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Bus besleme gerilimi çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Bus besleme akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Marş motoru akü voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Marş motoru akü voltajı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Devir çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Devir çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Beklenmedik duruş/yakıt beslemesinde sorun</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Güç kontaktörü voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Güç kontaktörü akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>AC voltajı L2 çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>AC voltajı L2 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>AC frekansı L2 çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>AC frekansı L2 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>AC akımı L2 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>AC gücü L2 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>AC voltajı L3 çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>AC voltajı L3 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>AC frekansı L3 çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>AC frekansı L3 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC akımı L3 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>AC gücü L3 çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Çıkış İnvertör voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Çıkış İnvertör akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Evrensel çıkış (1A) voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Evrensel çıkış (1A) akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Evrensel çıkış (5A) voltajı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Evrensel çıkış (5A) akımı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT DC gerilimi 1 düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>AGT DC gerilimi 1 yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT DC akımı 1 düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT DC akımı 1 yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>AGT DC gerilimi 2 düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>AGT DC gerilimi 2 yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT DC akımı 2 düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT DC akımı 2 yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 soğutucu düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 soğutucu yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 rayı (-) düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 ray (-) yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 rayı (+) düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 rayı (+) yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Yakıt sıcaklığı çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Yakıt sıcaklığı çok yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Yakıt seviyesi çok düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Kontrol birimi kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Panel Kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Bakım gerekmekte</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>3-fazlı modül kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>AGT modülü kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Senkronizasyon arızası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Kayıp harici ECU</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Hava emme filtresi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Diyagnostik mesaj (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Senk. modülü kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Yük dengesi arızası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Senk. modu devre dışı bırakıldı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Kırmızı Durdurma Lambası (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Kehribar Uyarı Lambası (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Arıza Gösterge Lambası (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Koruma Lambası (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Döner alan hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Yakıt seviyesi sensörü kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>İnverter olmadan çalıştırma</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>1 numaralı otobüs öldü.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Başlatma talebi reddedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Uzaktan çalıştırma reddedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Yük rölesini zorla kapatma</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Senkronizasyon Modülü çevrimdışı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>Kayıp BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Dönüştürücü DC Bağlantı Gerilimi Düşük/Ters</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Dönüştürücü DC Bağlantı Akımı Düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Dönüştürücü DC Ön Şarj Gerilimi Düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Dönüştürücü DC Ön Şarj Gerilimi Yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Dönüştürücü IGBT/MOSFET Sürücü Hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Dönüştürücü Hatası Güç Kontrol Döngüsü</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Dönüştürücü AC Frekans Algılama</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Dönüştürücü Kontrol Değeri Hatası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Fabrika ayarı değiştirildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Yönetici modunda değiştirilen parametre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Manuel Müdahale (ext. Sistem)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Init arızası</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Güvenlik zamanlayıcısı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>İnvertör sıcaklığı yüksek L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>İnvertör sıcaklığı yüksek L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>İnvertör sıcaklığı yüksek L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>İnverter sıcaklığı yüksek DC bağlantısı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>İnvertör aşırı yüklü</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>İnvertör iletişim kayboldu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>DC aşırı yüklü</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>DC aşırı gerilimli</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Bağlantı yok</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Hata yok</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Bilinmeyen hata: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Bilinmeyen hata:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Yağ Basıncı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Silindir kapağı aşırı sıcaklığı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Şarj kontrolü</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Beklenenden daha yüksek hız</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Aşırı hız</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>Petrol sıcaklığı beklenenden yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>Yağ sıcaklığı açık devre / güce kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>Yağ sıcaklığı toprağa kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Analog ayar noktası yüksek / güce kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Analog ayar noktası düşük / toprağa kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>TSC1 mesaj alma zaman aşımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>CM1 mesaj alma zaman aşımı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Akü voltajı yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Akü voltajı düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Hız sinyali bozuk</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Dahili 5V sensör beslemesi yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Dahili 5V sensör beslemesi düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Barometrik basınç yüksek</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Barometrik basınç düşük</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Çıkış yakıt pompası güce kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Çıkış yakıt pompası şasiye kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Çıkış kızdırma bujisi güce kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Çıkış kızdırma bujisi şasiye kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Enjektör açık devre/alt taraf şasiye kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Enjektör bobini dahili kısa devresi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Enjektör düşük tarafı güce kısa devre</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Hizmet saatlerinin süresi doldu</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>İşlemci arızası</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Ayarları değiştirmek için anahtarı kilitli olmayan bir konuma getirin.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>D-Bus veri kaynağını kullan: belirtilen D-Bus adresine bağlanın.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>adres</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>D-Bus veri kaynağını kullanın: varsayılan D-Bus adresine bağlanın</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>MQTT veri kaynağını kullan: belirtilen MQTT aracı adresine bağlanın.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>adres</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>MQTT veri kaynağı cihazı portal kimliği.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>Portal ID</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>MQTT VRM web barındırıcısı parçası</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>kırık</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>MQTT veri kaynağı kullanıcı adı</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>Kullanıcı</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>MQTT veri kaynağı şifresi</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>Pass</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>MQTT veri kaynağı jetonu</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>Jeton kodu</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>FPS sayacını etkinleştir</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Açılış ekranını atla</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Test için sahte veri kaynağı kullanın.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Fas Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Orta Batı Afrika Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Güney Afrika Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Namibya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Mısır Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Doğu Afrika Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Arjantin Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Güneydoğu Amerika Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Grönland Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Montevideo Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Newfoundland Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Güney Amerika Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Atlantik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Orta Brezilya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Paraguay Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Güney Amerika Batı Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Venezuela Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>ABD Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Orta Kanada Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Orta Amerika Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Orta Zaman Dilimi (Meksika)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Orta Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Dağ Zaman Dilimi (Meksika)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Dağ Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>ABD Dağ Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Pasifik Zaman Dilimi (Meksika)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Alaska Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Hawaii-Aleut Adaları</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Yeni Zelanda Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Orta Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Batı Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Batı Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Güneydoğu Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Orta Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Batı Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Doğu Afrika Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Güney Amerika Batı Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Batı Avrupa Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Kamçatka Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Magadan Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Vladivostok Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Yakutistan Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Tokyo Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Kore Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Singapur Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Ulan Batur Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Taipei Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Kuzay Asya Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Çin Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Güneydoğu Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Kuzey Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Myanmar Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Kuzey Orta Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Orta Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Bangladeş Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Nepal Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Sri Lanka Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Hindistan Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Batı Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Pakistan Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Yekaterinburg Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Gürcistan Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Kafkasya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Azerbaycan Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Arap Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Afganistan Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>İran Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Arap Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Arap Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Suriye Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Orta Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Ürdün Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>İsrail Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Greenwich Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Azorlar Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Yeşil Burun Adaları Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Tazmanya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Doğu Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Doğu Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Orta Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Orta Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Batı Avustralya Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Orta Atlantik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Dateline Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>GMT Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Orta Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Orta Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Romanya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Batı Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Doğu Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>FLE Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>GTB  Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Beyaz Rusya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Rusya Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Türkiye Zaman Dilimi</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Mauritius Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Christmas Island Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Tonga Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Fiji Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Yeni Zelanda Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Orta Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Batı Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Samoa Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Hawaii Zaman Dilimi</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Easter Island Standard Time</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Dahili hata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Bilinmeyen hata:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Dahili hata</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Hata yok</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Akü yüksek sıcaklığı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Akü yüksek gerilimi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Akü Düşük Voltaj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Akü voltajı yapılandırılan maks.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Alternatör yüksek sıcaklık</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Alternatör yüksek RPM</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Field drive FET high temperature</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Gerekli sensör eksik</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Alternatör düsük gerilim</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Alternatör yüksek voltaj ofseti</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Alternatör Voltajı yapılandırılan maks.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Alternatör yüksek voltajı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Akü bağlantısı kesildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Akü yüksek voltaj bağlantı kesme</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Menzil dışında akü örneği</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Çok fazla BMS cihazlar</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Akü bağlantısı kesilmek üzere</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>İzlenecek çok fazla cihaz</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Akü düşük voltaj bağlantı kesme</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Akü yüksek akım bağlantısı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Akü yüksek sıcaklık bağlantısı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Akü düşük sıcaklık bağlantısı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>BMS bağlantısı kaybedildi</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC Devre Dışı</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>DC/DC dönüştürücü hazır değil</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC yüksek birincil voltaj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC düşük birincil voltaj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC yüksek ikincil voltaj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC düşük ikinci voltaj</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC yüksek sıcaklık</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>DC/DC yanlış yapılandırma</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Akü sıcaklık sensörü arızalı</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_uk.ts
+++ b/i18n/venus-gui-v2_uk.ts
@@ -1,7394 +1,8025 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="uk">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>Вимкнено</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>Вимкнено</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>Перевантаження інвертора</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>Перевантаження інвертора</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>Потужність</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>Потужність</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>Вимкнено</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>Вимкнено</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>Авто</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>Авто</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">Батарея</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">Підключено</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Відключено</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">Генератор</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>Висока напруга батареї</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>Висока напруга батареї</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>Інв. / Зарядний</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>Інв. / Зарядний</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>Низька напруга батареї</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>Низька напруга батареї</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <extracomment>Is it Manua(tutorial) or Manual - by hand?</extracomment>
-      <translation>Вручну</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>Вручну</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>Жодного</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>Жодного</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>Позиція</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>Позиція</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>Швидкість</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>Швидкість</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>Стан</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>Стан</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Встановлення %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Встановлення %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>Невідома помилка</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>Невідома помилка</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>Мін. SOC:</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>Мін. SOC:</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Невідоме</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>Введіть пароль</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>Введіть пароль</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>Натисніть, щоб перевірити</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>Натисніть, щоб перевірити</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>Мережа</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>Мережа</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>PV генерація</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>PV генерація</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>Зовнішнє керування</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>Зовнішнє керування</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>Ємності</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>Ємності</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>Середовище</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>Середовище</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>Немає поточних тривог</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>Немає поточних тривог</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>Bluetooth</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>Головне</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>Головне</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>Прошивка</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>Прошивка</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>Дата, час</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>Дата, час</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>Налаштування системи</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>Налаштування системи</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC (розподілене керування напругою і струмом)</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC (розподілене керування напругою і струмом)</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>Дисплей і мова</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>Дисплей і мова</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>Онлайн-портал VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>Онлайн-портал VRM</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS (система збереження енергії)</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS (система збереження енергії)</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>Лічильники ел.енерг.</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>Лічильники ел.енерг.</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>PV інвертори</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>PV інвертори</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>Локальна мережа Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>Локальна мережа Ethernet</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM модем</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM модем</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>Пуск/зупинка генератора</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>Пуск/зупинка генератора</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>Насос ємності</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>Насос ємності</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>Служби</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>Служби</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O (ввід-вивід)</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O (ввід-вивід)</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Функції Великої Venus OS</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Функції Великої Venus OS</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>Обмеження життя батареї: %1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>Обмеження життя батареї: %1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">Автозапуск</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>Автозапуск буде вимкнено, і генератор не буде автоматично запускатися на основі налаштованих умов.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>Автозапуск буде вимкнено, і генератор не буде автоматично запускатися на основі налаштованих умов.</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>Ручна зупинка</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>Ручна зупинка</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>Ручний запуск</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>Ручний запуск</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">Позиція</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>Автозапуск</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>Автозапуск</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>Перемикачі</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>Перемикачі</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>Рівень доступу</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>Рівень доступу</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>Користувач</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>Користувач</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>Користувач і Інсталятор</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>Користувач і Інсталятор</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>Суперкористувач</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>Суперкористувач</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>Сервіс</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>Сервіс</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC (розподілене керування напругою і струмом)</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>Не забудьте також перезавантажити систему VE.Bus після відключення DVCC</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>Не забудьте також перезавантажити систему VE.Bus після відключення DVCC</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>Обмеження струму заряджання</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>Обмеження струму заряджання</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>Максимальний струм заряджання</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>Максимальний струм заряджання</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>Використовуйте значення %1 для запуску/зупинки</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>Використовуйте значення %1 для запуску/зупинки</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>Старт, коли %1 більше, ніж</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>Старт, коли %1 більше, ніж</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>Старт, коли %1 менше, ніж</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>Старт, коли %1 менше, ніж</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>Стоп, коли %1 більше, ніж</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>Стоп, коли %1 більше, ніж</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>Стоп, коли %1 менше, ніж</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>Стоп, коли %1 менше, ніж</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>Видалити IP-адресу?</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>Видалити IP-адресу?</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>Макс: %1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>Макс: %1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>Підключення</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>Підключення</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>Продукт</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>Продукт</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>Ім'я</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>Ім&apos;я</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">Ім&apos;я</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>ID продукту</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>ID продукту</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>Апаратна версія</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>Апаратна версія</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>Назва пристрою</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>Назва пристрою</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>Пульт дистанційного керування вимкнено</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>Пульт дистанційного керування вимкнено</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>Генератор у несправному стані</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>Генератор у несправному стані</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>Генератор не виявлено на вході AC</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>Генератор не виявлено на вході AC</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>Сукупний час роботи з моменту останнього тестового запуску</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>Сукупний час роботи з моменту останнього тестового запуску</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>Час до наступного тестового запуску</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>Час до наступного тестового запуску</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>Зараз працює</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>Зараз працює</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>Ручний запуск</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>Ручний запуск</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>Запустити генератор</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>Запустити генератор</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>Щоденна тривалість роботи</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>Щоденна тривалість роботи</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>Значення має бути більшим за кінцеве значення</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>Значення має бути більшим за кінцеве значення</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>Значення має бути нижчим за початкове значення</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>Значення має бути нижчим за початкове значення</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>Вихід AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>Вихід AC</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">Вихід AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>Використовуйте AC Load для запуску/зупинки</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>Використовуйте AC Load для запуску/зупинки</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>Вимірювання</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>Вимірювання</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>Загальне споживання</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>Загальне споживання</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>Загальний вихід AC інвертора</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>Загальний вихід AC інвертора</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>Найвища фаза інвертора</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>Найвища фаза інвертора</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>Почніть, коли потужність вище ніж</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>Почніть, коли потужність вище ніж</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>Зупиніться, коли потужність буде нижчою ніж</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>Зупиніться, коли потужність буде нижчою ніж</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>Монітор батареї</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>Монітор батареї</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>Монітор недоступний, встановіть інший</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>Монітор недоступний, встановіть інший</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">Монітор батареї</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">Монітор недоступний, встановіть інший</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>Про втрату зв'язку</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>Про втрату зв&apos;язку</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>Зупинити генератор</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>Зупинити генератор</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>Продовжуйте працювати генератор</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>Продовжуйте працювати генератор</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>Зупиніть генератор, коли буде струм на вході AC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>Зупиніть генератор, коли буде струм на вході AC</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>SOC Батареї</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>SOC Батареї</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">Висока температура інвертора</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>Висока температура інвертора</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>Висока температура інвертора</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>Почніть із попередження про високу температуру</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>Почніть із попередження про високу температуру</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>Запуск із попередження про перенавантаження</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>Запуск із попередження про перенавантаження</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>Періодична робота</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>Періодична робота</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>Інтервал роботи</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>Інтервал роботи</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <extracomment>days: %1
-
-could be better and more universal</extracomment>
-      <translation>днів: %1</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>днів: %1</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>Пропустіть біг, якщо бігав</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>Пропустіть біг, якщо бігав</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>Починайте завжди</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>Починайте завжди</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>Дата початку інтервалу виконання</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>Дата початку інтервалу виконання</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>Тривалість циклу (гг:хв)</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>Тривалість циклу (гг:хв)</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>Працювати до повного заряду батареї</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>Працювати до повного заряду батареї</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS OK (виправлено)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS OK (виправлено)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS підключено, але GPS не фіксується</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS підключено, але GPS не фіксується</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>GPS не підключено</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>GPS не підключено</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>Широта</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>Широта</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>Довгота</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>Довгота</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 км/год</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 км/год</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 миль/год</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 миль/год</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 knots</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 knots</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 м/с</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 м/с</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>курс</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>курс</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>Висота над рівнем моря</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>Висота над рівнем моря</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>Кількість супутників</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>Кількість супутників</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>Точка обміну з мережею</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>Точка обміну з мережею</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>Точка AC in</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>Точка AC in</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>Струм: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>Струм: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>Напруга: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>Напруга: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>Обмеження (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>Обмеження (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>Заряд: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>Заряд: %1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>Розряд: %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>Розряд: %1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>Ліміти (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>Ліміти (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>Видно</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>Видно</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>Прихований</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>Прихований</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1 (Додатковий - вимірювання)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1 (Додатковий - вимірювання)</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1 (Вихід %2)</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1 (Вихід %2)</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>Активний монітор батареї</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>Активний монітор батареї</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">Ім&apos;я</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">Введіть ім&apos;я</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>Введіть ім'я</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>Введіть ім&apos;я</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>Безперервне сканування</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>Безперервне сканування</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>Адаптери Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>Адаптери Bluetooth</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>PIN-код</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>PIN-код</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>Перед підключенням може знадобитися видалити наявну інформацію про сполучення.</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>Перед підключенням може знадобитися видалити наявну інформацію про сполучення.</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>Тип фази</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>Тип фази</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>Однофазний</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>Однофазний</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>Багатофазний</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>Багатофазний</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>Фотоелектричний інвертор на фазі 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>Фотоелектричний інвертор на фазі 2</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>PV інвертор на положенні фази 2</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>PV інвертор на положенні фази 2</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>Профіль CAN-шини</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>Профіль CAN-шини</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Вимкнено</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS (250 кбіт/с)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS (250 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS (250 кбіт/с)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 кбіт/с)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 кбіт/с)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>Працює, але без служб (250 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>Працює, але без служб (250 кбіт/с)</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>Пристрої</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>Пристрої</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>Вихід NMEA2000</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>Вихід NMEA2000</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>Селектор унікального ідентифікаційного номера</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>Селектор унікального ідентифікаційного номера</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>Будь ласка, зачекайте, зміна та перевірка унікального номера займає деякий час</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>Будь ласка, зачекайте, зміна та перевірка унікального номера займає деякий час</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>Вищевказаний селектор задає, який блок унікальних ідентифікаційних номерів використовувати для поля NAME Унікальні ідентифікаційні номери в полі PGN 60928 NAME. Змінюйте лише у разі використання декількох пристроїв GX в одній мережі VE.Can.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>Вищевказаний селектор задає, який блок унікальних ідентифікаційних номерів використовувати для поля NAME Унікальні ідентифікаційні номери в полі PGN 60928 NAME. Змінюйте лише у разі використання декількох пристроїв GX в одній мережі VE.Can.</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>Вищевказаний перемикач встановлює, який блок унікальних ідентифікаційних номерів використовувати для серійного номера в полі DGN 60928 ADDRESS_CLAIM. Змінюйте тільки у разі використання декількох пристроїв GX в одній мережі RV-C.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>Вищевказаний перемикач встановлює, який блок унікальних ідентифікаційних номерів використовувати для серійного номера в полі DGN 60928 ADDRESS_CLAIM. Змінюйте тільки у разі використання декількох пристроїв GX в одній мережі RV-C.</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>Перевірте унікальні ідентифікаційні номери</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>Перевірте унікальні ідентифікаційні номери</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">Натисніть, щоб перевірити</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>З цим унікальним номером підключено інший пристрій, будь ласка, виберіть новий номер.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>З цим унікальним номером підключено інший пристрій, будь ласка, виберіть новий номер.</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>OK: жоден інший пристрій не підключено до цього унікального номера.</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>OK: жоден інший пристрій не підключено до цього унікального номера.</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>Стан мережі</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>Стан мережі</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>Адаптивна яскравість</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>Адаптивна яскравість</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>Яскравість</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>Яскравість</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>Час вимкнення дисплея</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>Час вимкнення дисплея</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10 сек</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10 сек</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30 сек</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30 сек</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1 хв</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1 хв</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10 хв</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10 хв</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30 хв</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30 хв</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>Ніколи</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>Ніколи</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>Режим відображення</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>Режим відображення</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>Темний</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>Темний</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>Світлий</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>Світлий</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>Коротко дивитися рівні</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>Коротко дивитися рівні</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>Мова</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>Мова</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>Зміна мови</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>Зміна мови</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>Індикатор електричної потужності</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>Індикатор електричної потужності</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>Потужність (Вт)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>Потужність (Вт)</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>Струм (Ампер)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>Струм (Ампер)</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>Одиниці</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>Одиниці</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>Рівень %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>Рівень %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>Цельсій (°C)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>Цельсій (°C)</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>Фаренгейт (F)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>Фаренгейт (F)</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;УВАГА:&lt;/b&gt; Перед налаштуванням прочитайте посібник.</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;УВАГА:&lt;/b&gt; Перед налаштуванням прочитайте посібник.</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>Обмеження керованої напруги заряджання батареї</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>Обмеження керованої напруги заряджання батареї</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>Найвища напруга заряджання</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>Найвища напруга заряджання</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - спільний датчик напруги</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - спільний датчик напруги</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS - Спільне вимірювання температури</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS - Спільне вимірювання температури</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>Недоступний датчик, встановіть інший</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>Недоступний датчик, встановіть інший</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">Недоступний датчик, встановіть інший</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>Використаний датчик</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>Використаний датчик</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS - Спільне визначення струму</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS - Спільне визначення струму</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>Статус SCS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>Статус SCS</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>Вимкнено (Зовнішнє керування)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>Вимкнено (Зовнішнє керування)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>Вимкнено (без зарядних)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>Вимкнено (без зарядних)</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>Вимкнено (без моніторингу батареї)</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>Вимкнено (без моніторингу батареї)</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>Автоматичний вибір</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>Автоматичний вибір</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>Немає керування BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>Немає керування BMS</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>Керування BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>Керування BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>Недоступно, встановіть інший</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>Недоступно, встановіть інший</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>Автоматично вибрано</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>Автоматично вибрано</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">Жодного</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>Дата/час збірки</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>Дата/час збірки</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>Онлайн оновлення</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>Онлайн оновлення</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>Встановіть прошивку з SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>Встановіть прошивку з SD/USB</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>Збережена резервна копія прошивки</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>Збережена резервна копія прошивки</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>Перевірте наявність оновлень на SD/USB</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>Перевірте наявність оновлень на SD/USB</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>Прошивка знайдена</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>Прошивка знайдена</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Встановлення %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Встановлення %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Натисніть, щоб оновити до %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Натисніть, щоб оновити до %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Натисніть, щоб оновити до %1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>Дата/час збірки прошивки</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>Дата/час збірки прошивки</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>Автоматичне оновлення</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>Автоматичне оновлення</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>Тільки перевірка</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>Тільки перевірка</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>Перевірити та завантажити</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>Перевірити та завантажити</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>Перевірте та оновіть</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>Перевірте та оновіть</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <extracomment>Quite a confusing source, Update feed could be replaced as "Firmware Variant", because it is Beta or Stable as of now</extracomment>
-      <translation>Варіант прошивки</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>Варіант прошивки</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>Тип архіву</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>Тип архіву</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>Звичайний</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>Звичайний</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>Великий</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>Великий</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>Перевірити оновлення</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>Перевірити оновлення</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>Доступне оновлення</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>Доступне оновлення</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Встановлення %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>Встановлення %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">Встановлення %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>Оновлення дата/час збірки</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>Оновлення дата/час збірки</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>Інвертори</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>Інвертори</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>Знайдіть фотоелектричні інвертори</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>Знайдіть фотоелектричні інвертори</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>Виявлені IP-адреси</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>Виявлені IP-адреси</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>Додайте IP-адресу вручну</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>Додайте IP-адресу вручну</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>порт TCP</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>порт TCP</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>Багатофазний</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>Багатофазний</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>Спліт фаза (L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>Спліт фаза (L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>Показати</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>Показати</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <extracomment>MP is for MultiPhase?</extracomment>
-      <translation>AC-In1 МультиФаза</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 МультиФаза</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>AC-Out МультиФаза</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>AC-Out МультиФаза</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>AC-Out L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>AC-Out L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>AC-Out --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>AC-Out --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 МультиФаза</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 МультиФаза</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2.</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2.</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>Повторне сканування IP-адрес?</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>Повторне сканування IP-адрес?</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>Повторне сканування</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>Повторне сканування</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>SSH в локальній мережі</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>SSH в локальній мережі</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>Віддалена підтримка</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>Віддалена підтримка</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>Тунель віддаленої підтримки</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>Тунель віддаленої підтримки</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>IP та порт віддаленої підтримки</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>IP та порт віддаленої підтримки</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">Вийдіть з системи</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>Перезавантажити зараз</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>Перезавантажити зараз</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">Пристрій перезавантажено.</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>Звукова тривога</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>Звукова тривога</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>Демонстраційний режим</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>Демонстраційний режим</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>Демо ESS</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>Демо ESS</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>Демо човна/дома на колесах 1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>Демо човна/дома на колесах 1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>Демо човна/дома на колесах 2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>Демо човна/дома на колесах 2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>Запуск демо режиму призведе до зміни деяких налаштувань, а інтерфейс користувача на мить не відповідає.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>Запуск демо режиму призведе до зміни деяких налаштувань, а інтерфейс користувача на мить не відповідає.</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>Умови</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>Умови</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>Найкоротший час роботи</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>Найкоротший час роботи</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>Час розігріву</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>Час розігріву</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>Час охолодження</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>Час охолодження</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>Виявлення генератора на вході AC</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>Виявлення генератора на вході AC</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>Жоден із входів AC не налаштований на генератор. Перейдіть на сторінку налаштування системи та встановіть правильний вхід AC для генератора, щоб увімкнути цю функцію.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>Жоден із входів AC не налаштований на генератор. Перейдіть на сторінку налаштування системи та встановіть правильний вхід AC для генератора, щоб увімкнути цю функцію.</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>Якщо на вході AC інвертора не буде виявлено живлення від генератора, буде спрацьовувати тривога. Переконайтеся, що правильний вхід AC налаштовано на генератор на сторінці налаштування системи.</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>Якщо на вході AC інвертора не буде виявлено живлення від генератора, буде спрацьовувати тривога. Переконайтеся, що правильний вхід AC налаштовано на генератор на сторінці налаштування системи.</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>Час початку тихих годин</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>Час початку тихих годин</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>Час закінчення тихих годин</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>Час закінчення тихих годин</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>Час роботи та обслуговування</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>Час роботи та обслуговування</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>Скидання щоденних лічильників часу роботи</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>Скидання щоденних лічильників часу роботи</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>Щоденний лічильник часу роботи скинуто</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>Щоденний лічильник часу роботи скинуто</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>Неможливо змінити лічильники під час роботи генератора</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>Неможливо змінити лічильники під час роботи генератора</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>Інтервал обслуговування генератора (годин)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>Інтервал обслуговування генератора (годин)</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>Інтервал сервісного часу встановлено на %1 год. Використовуйте кнопку "Скинути сервісний таймер" для скидання сервісного таймера.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>Інтервал сервісного часу встановлено на %1 год. Використовуйте кнопку &quot;Скинути сервісний таймер&quot; для скидання сервісного таймера.</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>Скидання таймера обслуговування</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>Скидання таймера обслуговування</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>Налаштування GPS</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>Налаштування GPS</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>Формат</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>Формат</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>52° 20' 41,6" пн. ш., 5° 13' 12,3" сх.д.</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>52° 20&apos; 41,6&quot; пн. ш., 5° 13&apos; 12,3&quot; сх.д.</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>52° 20,693 пн.ш., 5° 13,205 сх.д</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>52° 20,693 пн.ш., 5° 13,205 сх.д</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>Одиниця швидкості</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>Одиниця швидкості</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>Кілометри на годину</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>Кілометри на годину</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>Метри в секунду</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>Метри в секунду</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>Милі на годину</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>Милі на годину</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>Вузли</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>Вузли</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>GSM модем не підключений</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>GSM модем не підключений</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>Інтернет</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>Інтернет</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>Оператор</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>Оператор</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>Може виникнути потреба налаштувати параметри APN, наведені нижче на цій сторінці. Зверніться до свого оператора для отримання докладної інформації.
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>Може виникнути потреба налаштувати параметри APN, наведені нижче на цій сторінці. Зверніться до свого оператора для отримання докладної інформації.
 Якщо це не допомагає, переконайтеся, що на вашій SIM-картці є кошти і/або що вона зареєстрована для передачі даних.</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>Дозволити роумінг</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>Дозволити роумінг</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>Стан SIM-картки</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>Стан SIM-картки</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>SIM-картка не вставлена</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>SIM-картка не вставлена</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>Потрібен PIN-код</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>Потрібен PIN-код</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>Потрібен PUK-код</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>Потрібен PUK-код</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>Збій SIM-картки</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>Збій SIM-картки</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM-картка зайнята</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM-картка зайнята</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>Неправильна SIM-картка</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>Неправильна SIM-картка</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>Неправильний PIN-код</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>Неправильний PIN-код</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>Готово</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>Готово</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Невідома помилка</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN-код</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN-код</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>За замовчуванням</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>За замовчуванням</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>Використовувати стандартний APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>Використовувати стандартний APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>Назва APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>Назва APN</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>Використовуйте автентифікацію</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>Використовуйте автентифікацію</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>Ім’я користувача</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>Ім’я користувача</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>Власне споживання</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>Власне споживання</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>Асистента ESS не знайдено</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>Асистента ESS не знайдено</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>Вимірювання мережі</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>Вимірювання мережі</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>Зовнішній лічильник</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>Зовнішній лічильник</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>Інв./Зарядний</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>Інв./Зарядний</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>Вихід AC інвертора використовується</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>Вихід AC інвертора використовується</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>Багатофазне регулювання</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>Багатофазне регулювання</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>Сумарно за всіма фазами</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>Сумарно за всіма фазами</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>Окрема фаза</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>Окрема фаза</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>Кожна фаза регулюється для індивідуального досягнення заданого значення мережі (ефективність системи знижується).
+        <translation>Кожна фаза регулюється для індивідуального досягнення заданого значення мережі (ефективність системи знижується).
 
 УВАГА: Використовуйте тільки якщо цього вимагає постачальник електроенергії.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>Сумарна потужність всіх фаз інтелектуально регулюється для досягнення заданого значення мережі (ефективність системи оптимізується).
+        <translation>Сумарна потужність всіх фаз інтелектуально регулюється для досягнення заданого значення мережі (ефективність системи оптимізується).
 
 Використовуйте, якщо це не заборонено постачальником електроенергії.</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">Неактивний</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Динамічна ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>Найнижчий рівень заряду (якщо немає збоїв у мережі)</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>Найнижчий рівень заряду (якщо немає збоїв у мережі)</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>Активне обмеження рівня заряду</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>Активне обмеження рівня заряду</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Підтримувати</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">Повторне заряджання</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>Обмеження піків</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>Обмеження піків</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>Більше мінімуму Тільки для SoC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>Більше мінімуму Тільки для SoC</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>Завжди</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>Завжди</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>Розряджання вимкнене</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>Розряджання вимкнене</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>Повільне заряджання</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>Повільне заряджання</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>Підтримувати</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>Підтримувати</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>Повторне заряджання</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>Повторне заряджання</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>Обмежити потужність заряджання</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>Обмежити потужність заряджання</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>Максимальна потужність заряджання</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>Максимальна потужність заряджання</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>Обмежте потужність інвертора</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>Обмежте потужність інвертора</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>Максимальна потужність інвертора</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>Максимальна потужність інвертора</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>Точка обміну з мережею</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>Точка обміну з мережею</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>Подача живлення в мережу</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>Подача живлення в мережу</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>Зв’язана-AC PV система — віддавати надлишки</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>Зв’язана-AC PV система&#xa0;— віддавати надлишки</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>Зв’язана-DC PV система — віддавати надлишки</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>Зв’язана-DC PV система&#xa0;— віддавати надлишки</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>Обмежити віддачу надлишків</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>Обмежити віддачу надлишків</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>Найбільша віддача надлишків</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>Найбільша віддача надлишків</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>Обмеження віддачі надлишків активне</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>Обмеження віддачі надлишків активне</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>Аналогові входи</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>Аналогові входи</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>Цифрові входи</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>Цифрові входи</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>Цифровий вхід %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>Цифровий вхід %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>Вимірювач пульсу</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>Вимірювач пульсу</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>Тривога дверей</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>Тривога дверей</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>Трюмний насос</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>Трюмний насос</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>Трюмна Тривога</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>Трюмна Тривога</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>Тривога взлому</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>Тривога взлому</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>Димова тривога</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>Димова тривога</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>Пожежна тривога</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>Пожежна тривога</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>CO2 тривога</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>CO2 тривога</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>Датчики Bluetooth</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>Датчики Bluetooth</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>Зверніть увагу, що ці функції офіційно не підтримуються Victron. Запитання можна поставити на порталі community.victronenergy.com.
+        <translation>Зверніть увагу, що ці функції офіційно не підтримуються Victron. Запитання можна поставити на порталі community.victronenergy.com.
 
 Документація доступна за адресою https://ve3.nl/vol</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>Увімкнено (безпечний режим)</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>Увімкнено (безпечний режим)</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>Відкладено на %1 с</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>Відкладено на %1&#xa0;с</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>ID порталу VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>ID порталу VRM</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>Інтервал реєстрації</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>Інтервал реєстрації</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5 хв</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5 хв</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15 хв</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15 хв</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1 година</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1 година</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2 години</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2 години</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4 години</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4 години</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12 годин</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12 годин</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1 доба</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1 доба</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>Використовуйте безпечне з’єднання (HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>Використовуйте безпечне з’єднання (HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>Останній контакт</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>Останній контакт</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 Неочікуваний текст відповіді</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 Неочікуваний текст відповіді</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 Неочікувана відповідь HTTP</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 Неочікувана відповідь HTTP</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 Тайм-аут з'єднання</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 Тайм-аут з&apos;єднання</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 Помилка підключення</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 Помилка підключення</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 Збій DNS</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 Збій DNS</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 Помилка маршрутизації</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 Помилка маршрутизації</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM недоступний</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM недоступний</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 Невідома помилка</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 Невідома помилка</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>Повідомлення про помилку:
+        <translation>Повідомлення про помилку:
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>Перезавантаження пристрою за відсутності звʼязку</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>Перезавантаження пристрою за відсутності звʼязку</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>Затримка скидання за відсутності контакту (гг:хвхв)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>Затримка скидання за відсутності контакту (гг:хвхв)</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>Місце зберігання</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>Місце зберігання</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>Немає активного буферу</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>Немає активного буферу</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>Внутрішня пам’ять</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>Внутрішня пам’ять</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>Передача</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>Передача</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>Зовнішній накопичувач</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>Зовнішній накопичувач</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">Невідома помилка</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>Помилки немає</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>Помилки немає</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>Не залишилося вільного місця в пам’яті</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>Не залишилося вільного місця в пам’яті</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>Помилка введення-виведення</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>Помилка введення-виведення</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>Помилка монтування</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>Помилка монтування</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>Містить образ прошивки. Не використовується.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>Містить образ прошивки. Не використовується.</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD-картка/USB-накопичувач недоступні для запису</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD-картка/USB-накопичувач недоступні для запису</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>Вільне місце на диску</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>Вільне місце на диску</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>байт</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>байт</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>байтів</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>байтів</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>Збережені записи</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>Збережені записи</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 записів</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 записів</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>Найстаріший запис</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>Найстаріший запис</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>Увімкнути Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>Увімкнути Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>Помилок не виявлено</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>Помилок не виявлено</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>Час останньої помилки</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>Час останньої помилки</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>Доступні служби</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>Доступні служби</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>Ідентифікатор підрозділу: %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>Ідентифікатор підрозділу: %1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>Функція (реле 1)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>Функція (реле 1)</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>Функція</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>Функція</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>Реле тривоги</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>Реле тривоги</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">Насос ємності</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">Вручну</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>Полярність реле тривоги</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>Полярність реле тривоги</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>З нормально розімкненими контактами</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>З нормально розімкненими контактами</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>З нормально замкненими контактами</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>З нормально замкненими контактами</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>Реле 1 увімк.</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>Реле 1 увімк.</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>Реле увімк.</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>Реле увімк.</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>Функція (реле 2)</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>Функція (реле 2)</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>Реле 2 увімк.</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>Реле 2 увімк.</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>Правила контролю температури</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>Правила контролю температури</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>Спрацювання реле за температурою</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>Спрацювання реле за температурою</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>Жодне реле не налаштоване на активацію за температурою. Перейдіть на сторінку налаштувань реле, розташовану в головному меню налаштувань, і встановіть функцію реле на "Температура".</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>Жодне реле не налаштоване на активацію за температурою. Перейдіть на сторінку налаштувань реле, розташовану в головному меню налаштувань, і встановіть функцію реле на &quot;Температура&quot;.</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>Ця опція дає змогу перемикатися між поточною та попередньою версією прошивки. Не потребує з’єднання з Інтернетом або SD-картки.</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>Ця опція дає змогу перемикатися між поточною та попередньою версією прошивки. Не потребує з’єднання з Інтернетом або SD-картки.</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>Прошивка %1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>Прошивка %1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>Натисніть для завантаження</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>Натисніть для завантаження</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">Прошивка %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>Перезавантаження до %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>Перезавантаження до %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>Зміна версії прошивки неможлива, якщо для автооновлення встановлено значення "Перевіряти й оновлювати". Щоб увімкнути цю опцію, встановіть значення автооновлення "Відключено" або "Лише перевіряти".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>Зміна версії прошивки неможлива, якщо для автооновлення встановлено значення &quot;Перевіряти й оновлювати&quot;. Щоб увімкнути цю опцію, встановіть значення автооновлення &quot;Відключено&quot; або &quot;Лише перевіряти&quot;.</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>Резервне копіювання прошивки недоступне</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>Резервне копіювання прошивки недоступне</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>Пульт на VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>CAN-шина через TCP/IP (дебаг)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>CAN-шина через TCP/IP (дебаг)</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>Зовнішнє джерело живлення</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>Зовнішнє джерело живлення</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>Транспортний засіб</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>Транспортний засіб</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>Човен</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>Човен</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>Назва системи</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>Назва системи</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>Автоматична</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>Автоматична</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">Мережа</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">Автоматична</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>Задана користувачем</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>Задана користувачем</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>Ім'я, визначене користувачем</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>Ім&apos;я, визначене користувачем</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>Вхід AC 1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>Вхід AC 1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>Вхід AC 2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>Вхід AC 2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>Контроль збою в енергомережі</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>Контроль збою в енергомережі</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>Контроль від’єднання зовнішнього джерела живлення</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>Контроль від’єднання зовнішнього джерела живлення</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>Автоматично вибрано</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>Автоматично вибрано</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>Має систему постійного струму</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>Має систему постійного струму</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>Синхронізувати VE.Bus SOC з батареєю</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>Синхронізувати VE.Bus SOC з батареєю</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <extracomment>to improve means - calibration ?</extracomment>
-      <translation>Враховувати струм від PV для точнішого визначення рівня SOC VE.Bus</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>Враховувати струм від PV для точнішого визначення рівня SOC VE.Bus</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>Регулювання напруги сонячного зарядного</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>Регулювання напруги сонячного зарядного</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>Регулювання струму сонячного зарядного</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>Регулювання струму сонячного зарядного</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Керування BMS</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>Керування BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>Керування BMS</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>Функція запуску/зупинки насоса ємності не ввімкнена. Перейдіть до налаштувань реле та встановіть функцію на "Насос ємності".</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>Функція запуску/зупинки насоса ємності не ввімкнена. Перейдіть до налаштувань реле та встановіть функцію на &quot;Насос ємності&quot;.</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>Стан насоса</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>Стан насоса</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">Авто</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>Датчик ємності</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>Датчик ємності</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>Рівень запуску</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>Рівень запуску</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>Рівень зупинки</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>Рівень зупинки</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>З’єднання втрачено</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>З’єднання втрачено</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>Від’єднано від мережі</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>Від’єднано від мережі</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[Приховано]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[Приховано]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>Під’єднатись до мережі?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>Під’єднатись до мережі?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>Підʼєднатися</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>Підʼєднатися</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>Забути мережу?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>Забути мережу?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>Забути</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>Забути</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>Ви впевнені, що хочете забути цю мережу?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>Ви впевнені, що хочете забути цю мережу?</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC-адреса</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC-адреса</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>Конфігурація IP</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>Конфігурація IP</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">Вручну</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">Вимкнено</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>Фіксована</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>Фіксована</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>Маска мережі</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>Маска мережі</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>Шлюз</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>Шлюз</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS-сервер</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS-сервер</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>Локальна IP-адреса каналу</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>Локальна IP-адреса каналу</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>Увага! Для систем ESS, а також систем з керованою батареєю екземпляр пристрою CAN-шини має залишатися налаштованим на 0. Для отримання додаткової інформації див. посібник GX.</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>Увага! Для систем ESS, а також систем з керованою батареєю екземпляр пристрою CAN-шини має залишатися налаштованим на 0. Для отримання додаткової інформації див. посібник GX.</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>Примірник пристрою</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>Примірник пристрою</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>Мережева адреса</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>Мережева адреса</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>Пристрої VE.CAN</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>Пристрої VE.CAN</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>Пристрій# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>Пристрій# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>Немає точок доступу</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>Немає точок доступу</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>Адаптер Wi-Fi не під’єднано</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>Адаптер Wi-Fi не під’єднано</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>Створити точку доступу</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>Створити точку доступу</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Мережі Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Мережі Wi-Fi</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>Вимкнути точку доступу?</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>Вимкнути точку доступу?</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>Дата/час у форматі UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>Дата/час у форматі UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>Дата/час місцевий</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>Дата/час місцевий</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>Часовий пояс</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>Часовий пояс</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>Африка</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>Африка</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>Америка</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>Америка</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>Антартика</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>Антартика</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>Арктика</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>Арктика</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>Азія</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>Азія</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>Атлантика</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>Атлантика</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>Австралія</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>Австралія</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>Європа</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>Європа</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>Індійський</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>Індійський</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>Тихоокеанський</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>Тихоокеанський</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>Etc</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>Etc</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>Не підключено %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>Не підключено %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>Перезавантажити зараз?</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>Перезавантажити зараз?</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>Зміни в екземплярі VRM не будуть застосовані до перезавантаження пристрою.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>Зміни в екземплярі VRM не будуть застосовані до перезавантаження пристрою.</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>Пристрій перезавантажується...</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>Пристрій перезавантажується...</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>Пристрій перезавантажено.</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>Пристрій перезавантажено.</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>Тривога низької напруги батареї</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>Тривога низької напруги батареї</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>Тривога через високу напругу батареї</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>Тривога через високу напругу батареї</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Остання помилка</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Остання помилка</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>передостання помилка</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>передостання помилка</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>третя помилка</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>третя помилка</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>четверта помилка</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>четверта помилка</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>У мережі</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>У мережі</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>Налаштування режиму</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>Налаштування режиму</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>Окремо</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>Окремо</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">Окремо</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>Зарядка</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>Зарядка</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">Зовнішнє керування</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>Заряджання і HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>Заряджання і HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>Заряджання і BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>Заряджання і BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>Зовн. керування і BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>Зовн. керування і BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>Заряджання, Hub-1 і BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>Заряджання, Hub-1 і BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>Головні опції</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>Головні опції</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">Керований</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>Керований</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>Керований</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>Головний груп</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>Головний груп</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>Головний заряджання</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>Головний заряджання</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>Головний груп і екземплярів</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>Головний груп і екземплярів</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>Напруга заряджання</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>Напруга заряджання</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>Скинути</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>Скинути</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>Керування BMS вмикається автоматично за наявності BMS. Скидається, якщо конфігурація системи змінилася або якщо BMS відсутня.</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>Керування BMS вмикається автоматично за наявності BMS. Скидається, якщо конфігурація системи змінилася або якщо BMS відсутня.</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">Загальна PV потужність</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <extracomment>Is it load as power or load as unit?</extracomment>
-      <translation>Спожив.</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>Спожив.</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 знайдено</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 знайдено</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 Історія</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 Історія</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 Історія</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>Робота в мережі</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>Робота в мережі</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>Табличний</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>Табличний</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>Діаграма</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>Діаграма</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>Попередження</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>Попередження</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Тривога</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>Тривога</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>Тривога</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>Об’єм</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>Об’єм</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>Коротке замикання</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>Коротке замикання</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>Зворотня полярність</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>Зворотня полярність</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>Зарядні для електромобілів</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>Зарядні для електромобілів</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>Сесія</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>Сесія</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>Трив.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>Трив.</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>Режим заряджання</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>Режим заряджання</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>Починайте та зупиняйте процес самостійно. Використовуйте це для швидкої зарядки та ретельного моніторингу.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>Починайте та зупиняйте процес самостійно. Використовуйте це для швидкої зарядки та ретельного моніторингу.</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>Починає і зупиняє роботу залежно від рівня заряду батареї. Оптимально підходить для нічних і тривалих зарядок, щоб уникнути перезарядки.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>Починає і зупиняє роботу залежно від рівня заряду батареї. Оптимально підходить для нічних і тривалих зарядок, щоб уникнути перезарядки.</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>Нижчі тарифи на електроенергію в непікові години або якщо ви хочете бути впевненими, що ваш електромобіль повністю заряджений і готовий до поїздки в певний час.</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>Нижчі тарифи на електроенергію в непікові години або якщо ви хочете бути впевненими, що ваш електромобіль повністю заряджений і готовий до поїздки в певний час.</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>Увімкнути заряджання</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>Увімкнути заряджання</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>Блокування дисплея зарядного</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>Блокування дисплея зарядного</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>Вихідна адреса</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>Вихідна адреса</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>Налаштування</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>Налаштування</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>Екземпляр рядка #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>Екземпляр рядка #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>Екземпляр лінії</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>Екземпляр лінії</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>Екземпляр зарядного</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>Екземпляр зарядного</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>Екземпляр інвертора</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>Екземпляр інвертора</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Екземпляр джерела DC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Екземпляр джерела DC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>Екземпляр джерела пост. струму</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>Екземпляр джерела пост.&#xa0;струму</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>Пріоритет джерела DC #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>Пріоритет джерела DC #%1</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>Пріоритет джерела пост. струму</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>Пріоритет джерела пост.&#xa0;струму</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>Екземпляр ємності</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>Екземпляр ємності</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>Пристрої RV-C</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>Пристрої RV-C</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>Увімкнути візуалізатор частоти кадрів</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>Увімкнути візуалізатор частоти кадрів</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>Не підтримується</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>Не підтримується</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>Видалити від’єднані пристрої</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>Видалити від’єднані пристрої</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>Знайдено пристрій, що не підтримується</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>Знайдено пристрій, що не підтримується</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>Функція реле</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>Функція реле</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">Тривога</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>Пуск/зупинка зарядного або генератора</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>Пуск/зупинка зарядного або генератора</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">Ручне управління</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Перегорів запобіжник</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <extracomment>Looks like this one should be used in Relay submenu, instead of "Manual" from CommonWords</extracomment>
-      <translation>Ручне управління</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>Ручне управління</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>Завжди відкритий (не використовувати реле)</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>Завжди відкритий (не використовувати реле)</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>Зверніть увагу, що зміна параметра "Низький рівень заряду" також змінює значення параметра "Граничний рівень розряду" в меню батареї.</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>Зверніть увагу, що зміна параметра &quot;Низький рівень заряду&quot; також змінює значення параметра &quot;Граничний рівень розряду&quot; в меню батареї.</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>Перегорів запобіжник</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>Перегорів запобіжник</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>Світлодіоди стану</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>Світлодіоди стану</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">Жодного</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>Головний перемикач</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>Головний перемикач</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>Обігрівач</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>Обігрівач</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>Внутрішній вентилятор</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>Внутрішній вентилятор</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>Попереджувальні прапорці</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>Попереджувальні прапорці</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>Прапорці тривог</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>Прапорці тривог</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>Перемикач</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>Перемикач</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>Ініціалізація</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>Ініціалізація</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>Вимкнення</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>Вимкнення</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>Оновлення</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>Оновлення</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>Перейти до запуску</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>Перейти до запуску</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>Попередня зарядка</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>Попередня зарядка</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>Перевірка контактора</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>Перевірка контактора</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>Стан здоров'я</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>Стан здоров&apos;я</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>Температура батареї</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>Температура батареї</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>Температура повітря</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>Температура повітря</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>Напруга стартера</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>Напруга стартера</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>Напруга шини</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>Напруга шини</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>Напруга верхньої секції</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>Напруга верхньої секції</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">Помилка зв&apos;язку</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">Стан здоров&apos;я</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">Напруга шини</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>Напруга нижньої секції</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>Напруга нижньої секції</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>Відхилення середньої точки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>Відхилення середньої точки</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>Спожиті ампер-години</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>Спожиті ампер-години</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>Час до вимкнення</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>Час до вимкнення</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>Подробиці</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>Подробиці</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>Тривоги на рівні модуля</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>Тривоги на рівні модуля</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>Діагностика</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>Діагностика</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>Запобіжники</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>Запобіжники</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>СТАТУС</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>СТАТУС</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>Параметри</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>Параметри</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>Повторне виявлення батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>Повторне виявлення батареї</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">Натисніть , щоб знайти</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>Натисніть , щоб знайти</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>Натисніть , щоб знайти</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>Повторне виявлення батареї може зайняти 60 секунд. При цьому назва батареї може бути неправильною.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>Повторне виявлення батареї може зайняти 60 секунд. При цьому назва батареї може бути неправильною.</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>Високий струм заряду</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>Високий струм заряду</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>Високий струм розряду</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>Високий струм розряду</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>Низький SOC</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>Низький SOC</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">Висока напруга батареї</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">Низький SOC</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>Низька напруга стартера</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>Низька напруга стартера</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>Висока напруга стартера</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>Висока напруга стартера</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>Датчик температури батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>Датчик температури батареї</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>Напруга в середній точці</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>Напруга в середній точці</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">Перегорів запобіжник</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>Висока внутрішня температура</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>Висока внутрішня температура</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>Низька температура заряду</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>Низька температура заряду</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>Висока температура заряду</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>Висока температура заряду</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>Внутрішній збій</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>Внутрішній збій</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>Спрацював автоматичний вимикач</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>Спрацював автоматичний вимикач</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>Дисбаланс комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>Дисбаланс комірки</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>Низька напруга комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>Низька напруга комірки</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>Найнижча напруга комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>Найнижча напруга комірки</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>Найвища напруга комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>Найвища напруга комірки</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>Найнижча температура комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>Найнижча температура комірки</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>Найвища температура комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>Найвища температура комірки</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>Модулі батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>Модулі батареї</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 увімкнено</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 увімкнено</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 вимкнено</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 вимкнено</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>Кількість модулів, що блокують заряд/розряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>Кількість модулів, що блокують заряд/розряд</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>Встановлена/Доступна потужність</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>Встановлена/Доступна потужність</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>Найглибший розряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>Найглибший розряд</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>Останній розряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>Останній розряд</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>Середній розряд</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>Середній розряд</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>Загальна кількість циклів заряду</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>Загальна кількість циклів заряду</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>Кількість повних розрядів</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>Кількість повних розрядів</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>Сукупний обсяг набраних А·год</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>Сукупний обсяг набраних А·год</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>Найнижча напруга комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>Найнижча напруга комірки</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>Максимальна напруга комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>Максимальна напруга комірки</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>Час з моменту останньої повної зарядки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>Час з моменту останньої повної зарядки</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>Кількість синхронізацій</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>Кількість синхронізацій</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>Тривога про низький рівень напруги стартерної батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>Тривога про низький рівень напруги стартерної батареї</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>Мінімальна напруга стартерної батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>Мінімальна напруга стартерної батареї</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>Максимальна напруга батареї стартера</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>Максимальна напруга батареї стартера</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>Розряджено енергії</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>Розряджено енергії</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>Заряджено енергії</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>Заряджено енергії</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>Обмеження напруги заряду (CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>Обмеження напруги заряду (CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>Обмеження струму заряду (CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>Обмеження струму заряду (CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>Обмеження струму розряду (DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>Обмеження струму розряду (DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>Відключення по низькій напрузі (завжди ігнорується)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>Відключення по низькій напрузі (завжди ігнорується)</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>Масив батарей</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>Масив батарей</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>Реле (на моніторі батареї)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>Реле (на моніторі батареї)</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>Відновлення заводських налаштувань</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>Відновлення заводських налаштувань</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>Натисніть, щоб відновити</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>Натисніть, щоб відновити</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>Відновити заводські налаштування?</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>Відновити заводські налаштування?</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>Bluetooth увімкнено</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>Bluetooth увімкнено</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>Номінальна напруга</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>Номінальна напруга</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12 Вольт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12 Вольт</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24 Вольт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24 Вольт</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48 Вольт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48 Вольт</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>Обʼєм</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>Обʼєм</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Обʼєм</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>Напруга "заряджено"</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>Напруга &quot;заряджено&quot;</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>Залишковий струм</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>Залишковий струм</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>Час визначення заряду</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>Час визначення заряду</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Показник Пейкерта</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Показник Пейкерта</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>Коефіцієнт ефективності заряду</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>Коефіцієнт ефективності заряду</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>Порогове значення струму</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>Порогове значення струму</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>Період усереднення "залишилось"</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>Період усереднення &quot;залишилось&quot;</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>Мінімум розраду "залишилось"</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>Мінімум розраду &quot;залишилось&quot;</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>Поточний зсув</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>Поточний зсув</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>Синхронізувати стан заряду до 100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>Синхронізувати стан заряду до 100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>Натисніть, щоб синхронізувати</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>Натисніть, щоб синхронізувати</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>Відкалібруйте нульовий струм</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>Відкалібруйте нульовий струм</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>Натисніть, щоб встановити значення 0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>Натисніть, щоб встановити значення 0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>Розподільник %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>Розподільник %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>Немає живлення на шині</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>Немає живлення на шині</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">З’єднання втрачено</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation type="unfinished">
-        <numerusform>%n запобіжник згорів</numerusform>
-        <numerusform>%n запобіжників згоріло</numerusform>
-        <numerusform>%n запобіжників згоріло</numerusform>
-        <numerusform>%n запобіжників згоріло</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation type="unfinished">
+            <numerusform>%n запобіжник згорів</numerusform>
+            <numerusform>%n запобіжників згоріло</numerusform>
+            <numerusform>%n запобіжників згоріло</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>Інформація недоступна, див. попередню сторінку про стан розподільника.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>Інформація недоступна, див. попередню сторінку про стан розподільника.</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>Запобіжник %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>Запобіжник %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>Не використовується</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>Не використовується</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>Перегорів</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>Перегорів</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>Вимкнення через помилку</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>Вимкнення через помилку</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">Остання помилка</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">передостання помилка</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">третя помилка</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">четверта помилка</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>Перемикач системи</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>Перемикач системи</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>Зовнішнє реле</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>Зовнішнє реле</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>Програмований контакт</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>Програмований контакт</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>Батареї</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>Батареї</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">Обʼєм</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">Батареї</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>Паралельний</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>Паралельний</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>Серія</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>Серія</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>Мін./макс. напруга комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>Мін./макс. напруга комірки</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>Мін./макс. температура комірки</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>Мін./макс. температура комірки</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">Балансування</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>Балансування</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>Балансування</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Невідоме</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>Вихід</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>Вихід</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>Польовий привід</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>Польовий привід</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>Оберти двигуна</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>Оберти двигуна</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>Допоміжна напруга</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>Допоміжна напруга</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>Немає тривог</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>Немає тривог</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>Низька напруга</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>Низька напруга</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>Висока напруга</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>Висока напруга</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>Низька допоміжна напруга</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>Низька допоміжна напруга</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>Висока додаткова напруга</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>Висока додаткова напруга</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>Тривоги через низьку допоміжна напругу</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>Тривоги через низьку допоміжна напругу</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>Тривоги через високу допоміжна напругу</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>Тривоги через високу допоміжна напругу</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>Найнижча додаткова напруга</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>Найнижча додаткова напруга</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>Найвища додаткова напруга</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>Найвища додаткова напруга</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>Вироблена енергія</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>Вироблена енергія</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>Спожита енергія</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>Спожита енергія</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>Увімкнути тривогу</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>Увімкнути тривогу</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>Активний рівень</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>Активний рівень</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>Відновити рівень</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>Відновити рівень</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>Затримка</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>Затримка</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>Рівень</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>Рівень</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>Залишилось</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>Залишилось</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">Батарея датчика</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>Батарея датчика</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>Батарея датчика</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>Тип датчика</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>Тип датчика</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>Стандарт</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>Стандарт</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>Євро (від 0 до 180 Ом)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>Євро (від 0 до 180&#xa0;Ом)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>США (від 240 до 30 Ом)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>США (від 240 до 30&#xa0;Ом)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>Власний</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>Власний</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">Власний</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>Значення датчика в порожньому стані</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>Значення датчика в порожньому стані</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>Тип рідини</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>Тип рідини</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>Вміст бутану</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>Вміст бутану</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>Власна форма</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>Власна форма</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>Час усереднення</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>Час усереднення</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>Значення датчика</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>Значення датчика</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>Власну форму не визначено. Ви можете визначити одну з десятьма точками. Зверніть увагу, що 0% і 100% маються на увазі.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>Власну форму не визначено. Ви можете визначити одну з десятьма точками. Зверніть увагу, що 0% і 100% маються на увазі.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>Точка %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>Точка %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>Додати точку</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>Додати точку</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>Рівень датчика</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>Рівень датчика</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">Об’єм</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>Повторення значень рівня датчика не допускається.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>Повторення значень рівня датчика не допускається.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>Об'ємні значення повинні збільшуватися.</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>Об&apos;ємні значення повинні збільшуватися.</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>Сторожовий таймер</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>Сторожовий таймер</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>Розблоковано (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>Розблоковано (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>Розблоковано (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>Розблоковано (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>Розблоковано (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>Розблоковано (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>Заблоковано</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>Заблоковано</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>Фазова конфігурація</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>Фазова конфігурація</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>Положення перемикача</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>Положення перемикача</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">Однофазний</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>2-фазний</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>2-фазний</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>3-фазний</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>3-фазний</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">Пристрої</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>AC</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>AC</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>Двигун</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>Двигун</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">Швидкість</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">Спожив.</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>Температура теплоносія</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>Температура теплоносія</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>Температура вихлопу</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>Температура вихлопу</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>Температура обмотки</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>Температура обмотки</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>Напруга стартерної батареї</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>Напруга стартерної батареї</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>Кількість стартів</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>Кількість стартів</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">Керування BMS</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Передній селектор заблоковано (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Передній селектор заблоковано (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>Немає помилки (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>Немає помилки (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>Усього AC</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>Усього AC</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Енергія L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Енергія L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>Послідовність фаз</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>Послідовність фаз</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>Версія диспетчера даних</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>Версія диспетчера даних</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>КТ %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>КТ %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">Жодного</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>Світлодіод, що блимає, вказує на цей CT(трансформатор струму)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>Світлодіод, що блимає, вказує на цей CT(трансформатор струму)</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Шинні пристрої Smappee</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Шинні пристрої Smappee</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>PV Зарядний</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>PV Зарядний</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Цей параметр вимкнено, якщо підключено цифровий мульти контроль ( DMC ).</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Цей параметр вимкнено, якщо підключено цифровий мульти контроль ( DMC ).</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>Цей параметр вимкнено, якщо підключено VE.Bus BMS.</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>Цей параметр вимкнено, якщо підключено VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC вхід %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC вхід %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>DC</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>DC</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>Перевернутий</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>Перевернутий</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">Увімкнути тривогу</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">Перевернутий</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>Інвертувати логіку тривоги</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>Інвертувати логіку тривоги</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>Опромінення</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>Опромінення</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>Температура комірки</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>Температура комірки</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>Зовнішня температура (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>Зовнішня температура (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>Зовнішня температура</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>Зовнішня температура</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>Зовнішня температура (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>Зовнішня температура (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>Швидкість вітру</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>Швидкість вітру</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>Автовизначення</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>Автовизначення</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>Датчик швидкості вітру</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>Датчик швидкості вітру</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>Зовнішній датчик температури</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>Зовнішній датчик температури</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>Агрегація</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>Агрегація</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>Множник</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>Множник</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>Скинути лічильник</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>Скинути лічильник</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">Коротке замикання</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">Зворотня полярність</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>Батарея датчика розряджена</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>Батарея датчика розряджена</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>Вологість</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>Вологість</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>Тиск</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>Тиск</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">Низький</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>Зміщення</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>Зміщення</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>Шкала</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>Шкала</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>Напруга датчика</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>Напруга датчика</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>Загальна PV потужність</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>Загальна PV потужність</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>Сторінка продукту</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>Сторінка продукту</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>Датчик AC %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>Датчик AC %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>Доступна нова версія MK3.
+        <translation>Доступна нова версія MK3.
 ПРИМІТКА: Оновлення може тимчасово зупинити роботу системи.</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>Оновлення MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>Оновлення MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>Натисніть, щоб оновити</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>Натисніть, щоб оновити</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>Значення з’являться знову після завершення оновлення MK3.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>Значення з’являться знову після завершення оновлення MK3.</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">Заряджання батареї до 100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>Заряджання батареї до 100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>Заряджання батареї до 100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">Розширено</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>Працюю</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>Працюю</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>Натисніть, щоб зупинити</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>Натисніть, щоб зупинити</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>Натисніть, щоб запустити</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>Натисніть, щоб запустити</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>Зарядіть батареї до 100%.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>Зарядіть батареї до 100%.</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>Система повернеться до нормального режиму роботи, надаючи пріоритет відновлюваним джерелам енергії.
+        <translation>Система повернеться до нормального режиму роботи, надаючи пріоритет відновлюваним джерелам енергії.
 Бажаєте продовжити?</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>Прибережна енергія буде використовуватися, якщо вона доступна, а опція "Пріоритет сонця та вітру" буде проігнорована.
+        <translation>Прибережна енергія буде використовуватися, якщо вона доступна, а опція &quot;Пріоритет сонця та вітру&quot; буде проігнорована.
 Ви хочете продовжити?</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>Портова енергія буде використовуватися для повної зарядки батареї за один раз.
+        <translation>Портова енергія буде використовуватися для повної зарядки батареї за один раз.
 Після завершення процесу заряджання система повернеться до нормального режиму роботи, віддаючи пріоритет сонячній та вітровій енергії.
 Бажаєте продовжити?</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>Напруга DC</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>Напруга DC</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>DC струм</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>DC струм</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>Розширено</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>Розширено</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>Налаштування сигналу тривоги</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>Налаштування сигналу тривоги</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>VE.Bus BMS автоматично вимикає систему, коли це потрібно для захисту батареї. А отже, керування системою за допомогою Color Control неможливе.</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>VE.Bus BMS автоматично вимикає систему, коли це потрібно для захисту батареї. А отже, керування системою за допомогою Color Control неможливе.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>Встановлено BMS-асистент, налаштований на VE.Bus BMS, але VE.Bus BMS не знайдено!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>Встановлено BMS-асистент, налаштований на VE.Bus BMS, але VE.Bus BMS не знайдено!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>Попередження: активація вирівнювання в системі ESS із сонячними зарядними може призвести до того, що батарея заряджатиметься під високою напругою із надто високим струмом.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>Попередження: активація вирівнювання в системі ESS із сонячними зарядними може призвести до того, що батарея заряджатиметься під високою напругою із надто високим струмом.</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>Система автоматично перейде на плаваючий заряд після завершення стадії вирівнювання.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>Система автоматично перейде на плаваючий заряд після завершення стадії вирівнювання.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>Зупинка вирівнювання</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>Зупинка вирівнювання</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>Вирівнювання</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>Вирівнювання</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>Зупиняю...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>Зупиняю...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>Запускаю...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>Запускаю...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">Запускаю...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>Натисніть, щоб перервати</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>Натисніть, щоб перервати</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>Перервати і перезапустити поглинання</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>Перервати і перезапустити поглинання</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>Перервати і перейти до підтримання заряду</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>Перервати і перейти до підтримання заряду</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>Перервати</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>Перервати</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>Не переривати</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>Не переривати</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>Повторно виявити систему VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>Повторно виявити систему VE.Bus</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>Повторне виявлення...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>Повторне виявлення...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>Перезапустити систему VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>Перезапустити систему VE.Bus</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>Перезапуск...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>Перезапуск...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>Натисніть для перезапуску</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>Натисніть для перезапуску</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>Вхід AC 1 ігнорується</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>Вхід AC 1 ігнорується</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>Вхід AC 2 ігнорується</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>Вхід AC 2 ігнорується</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>Тестування реле ESS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>Тестування реле ESS</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">Завершено</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">Очікується...</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>Завершено</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>Завершено</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>Очікується...</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>Очікується...</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>Діагностика VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>Діагностика VE.Bus</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>Лічильник якості мережі Фаза L%1, пристрій %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>Лічильник якості мережі Фаза L%1, пристрій %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>Звіт про помилку VE.Bus 8 / 11</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>Звіт про помилку VE.Bus 8 / 11</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>Тільки тривоги</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>Тільки тривоги</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>Тривоги та попередження</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>Тривоги та попередження</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>Помилка BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>Помилка BMS</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>Серійні номери</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>Серійні номери</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>Останній звіт про помилку VE.Bus Error 11 #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>Останній звіт про помилку VE.Bus Error 11 #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>Триває випробування на безпеку доменної печі</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>Триває випробування на безпеку доменної печі</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>Випробування на безпеку BF OK</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>Випробування на безпеку BF OK</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>Невідповідність AC0 /AC1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>Невідповідність AC0 /AC1</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>Помилка зв'язку</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>Помилка зв&apos;язку</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>Помилка реле землі</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>Помилка реле землі</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>Невідповідність UMains</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>Невідповідність UMains</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>Період Невідповідність часу</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>Період Невідповідність часу</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>Привід реле неузгодженості BF</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>Привід реле неузгодженості BF</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>Помилка: PE2 відкритий</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>Помилка: PE2 відкритий</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>Помилка: PE2 закрито</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>Помилка: PE2 закрито</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>Невдалий крок: %1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>Невдалий крок: %1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>Фаза L%1, пристрій %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>Фаза L%1, пристрій %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>Для повідомлення про помилку 11 VE.Bus потрібно мати мінімальну версію прошивки VE.Bus 454.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>Для повідомлення про помилку 11 VE.Bus потрібно мати мінімальну версію прошивки VE.Bus 454.</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>Особливості VE.Bus</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>Особливості VE.Bus</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>енергія</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>енергія</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>потужність</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>потужність</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>напруга</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>напруга</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <extracomment>is it "Ampers" or "this"?</extracomment>
-      <translation>струм</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>струм</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>розташування</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>розташування</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>фаза</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>фаза</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>Активний вхід AC</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>Активний вхід AC</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>Високі пульсації DC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>Високі пульсації DC</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>Висока напруга DC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>Висока напруга DC</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>Високий струм DC</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>Високий струм DC</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>Помилка датчика температури</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>Помилка датчика температури</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>Помилка датчика напруги</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>Помилка датчика напруги</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>Перевантаження</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>Перевантаження</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>Пульсації DC</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>Пульсації DC</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>Датчик напруги</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>Датчик напруги</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">Чергування фаз</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>Чергування фаз</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>Чергування фаз</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>Версія VE.Bus</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>Версія VE.Bus</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>Пристрій MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>Пристрій MK2</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>Версія MK2</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>Версія MK2</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Версія Multi Control</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Версія Multi Control</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>Версія VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>Версія VE.Bus BMS</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>Якщо мережа не зникає</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>Якщо мережа не зникає</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>Вхід АС</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>Вхід АС</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>AC вхід</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>AC вхід</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>Вхід AC 1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>Вхід AC 1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>Вхід AC 2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>Вхід AC 2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>Роль</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>Роль</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>AC спожив.</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>AC спожив.</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>Вихід AC</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>Вихід AC</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>Вихід AC</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>Вихід AC</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Фаза AC L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>Фаза AC L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>Датчик AC %1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>Датчик AC %1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>Датчики AC</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>Датчики AC</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>Активний</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>Активний</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">Тривога</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">Перевантаження</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>Стан тривоги</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>Стан тривоги</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>Тривоги</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>Тривоги</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>Дозвіл на заряджання</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>Дозвіл на заряджання</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>Дозвіл на розряджання</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>Дозвіл на розряджання</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>Автоматичне сканування</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>Автоматичне сканування</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>Батарея</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>Батарея</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>Струм батареї</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>Струм батареї</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>Напруга батареї</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>Напруга батареї</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>Зар. струм</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>Зар. струм</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>Зарядка</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>Зарядка</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>Очистити помилку</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>Очистити помилку</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>Закрито</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>Закрито</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>Підключено</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>Підключено</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>Струм</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>Струм</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>Трансформатори струму</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>Трансформатори струму</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>Користувацька назва</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>Користувацька назва</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>Відладка</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>Відладка</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>Пристрій</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>Пристрій</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">Вимкнено</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>Розрядка</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>Розрядка</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>Відключено</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>Відключено</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>Увімкнути</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>Увімкнути</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>Увімкнено</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>Увімкнено</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>Енергія</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>Енергія</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>Помилка</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>Помилка</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>Помилка:</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>Помилка:</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>Код помилки</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>Код помилки</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>Версія прошивки</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>Версія прошивки</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>Генератор</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>Генератор</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>Висока температура батареї</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>Висока температура батареї</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>Тривога через високий рівень</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>Тривога через високий рівень</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>Висока напруга батареї стартера</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>Висока напруга батареї стартера</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>Висока температура</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>Висока температура</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>Тривога високої напруги</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>Тривога високої напруги</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>Історія</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>Історія</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 Година(и)</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 Година(и)</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>Релаксую</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>Релаксую</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>Неактивний</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>Неактивний</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">Інв. / Зарядний</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP-адреса</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP-адреса</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>Низька температура батареї</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>Низька температура батареї</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>Тривога через низький рівень</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>Тривога через низький рівень</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>Низька напруга батареї стартера</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>Низька напруга батареї стартера</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>Низький рівень заряду</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>Низький рівень заряду</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>Низька температура</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>Низька температура</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>Тривога низької напруги</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>Тривога низької напруги</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>Виробник</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>Виробник</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>Максимальна температура</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>Максимальна температура</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>Максимальна напруга</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>Максимальна напруга</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>Найнижча температура</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>Найнижча температура</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>Найнижча напруга</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>Найнижча напруга</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>Режим</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>Режим</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>Назва моделі</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>Назва моделі</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>Ні</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>Ні</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>Помилки немає</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>Помилки немає</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>Недоступний</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>Недоступний</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>Не під'єднано</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>Не під&apos;єднано</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>Офлайн</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>Офлайн</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>ОК</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>ОК</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>Увімкнено</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>Увімкнено</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>Онлайн</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>Онлайн</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>Відкрито</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>Відкрито</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>Пароль</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>Пароль</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>Фаза</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>Фаза</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>Натисніть, щоб очистити</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>Натисніть, щоб очистити</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>Натисніть, щоб скинути</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>Натисніть, щоб скинути</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>Натисніть для сканування</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>Натисніть для сканування</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>PV інвертор</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>PV інвертор</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>PV Потужність</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>PV Потужність</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>Тихі години</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>Тихі години</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>Реле</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>Реле</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>Перезавантажити</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>Перезавантажити</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>Видалити</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>Видалити</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>Працює</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>Працює</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>Сканування %1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>Сканування %1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>Серійний номер</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>Серійний номер</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>Налаштування</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Налаштування</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>Конфігурування</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>Конфігурування</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>Рівень сигналу</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>Рівень сигналу</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>Режим очікування</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>Режим очікування</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>Почніть після досягнення умови</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>Почніть після досягнення умови</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>Час початку</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>Час початку</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>Початкове значення в тихий час</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>Початкове значення в тихий час</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>Почати, коли активне попередження для</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>Почати, коли активне попередження для</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>Стан заряду</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>Стан заряду</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>Стан</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>Стан</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>Запуск (%1)</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>Запуск (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>Кінцеве значення в тихий час</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>Кінцеве значення в тихий час</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>Зупинка після досягнення умови для</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>Зупинка після досягнення умови для</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>Зупинено</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>Зупинено</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>Температура</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>Температура</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>Температурний сенсор</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>Температурний сенсор</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>Сьогодні</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>Сьогодні</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>Всього</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>Всього</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>Трекер</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>Трекер</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>Тип</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>Тип</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>Унікальний ідентифікаційний номер</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>Унікальний ідентифікаційний номер</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>Невідоме</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>Невідоме</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>Помилка VE.Bus</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>Помилка VE.Bus</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>Напруга</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>Напруга</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>Екземпляр VRM</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>Екземпляр VRM</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>Після зникнення попередження зупинитися</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>Після зникнення попередження зупинитися</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>Так</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>Так</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>Вчора</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>Вчора</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>Генерація</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>Генерація</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>Нульове обмеження відачі залишків</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>Нульове обмеження відачі залишків</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>Встановити дату</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>Встановити дату</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>Почати зараз</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>Почати зараз</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>Запуск за часом</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>Запуск за часом</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>Зупинись зараз.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>Зупинись зараз.</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>Загальний час роботи</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>Загальний час роботи</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>Встановити час %1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>Встановити час %1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>Генератор продовжить роботу, якщо буде виконано умову автозапуску.</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>Генератор продовжить роботу, якщо буде виконано умову автозапуску.</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>Режим інвертора / зарядного пристрою</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>Режим інвертора / зарядного пристрою</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>Встановити</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>Встановити</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>Скасувати</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>Скасувати</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>Закрити</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>Закрити</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>Встановлення часу</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>Встановлення часу</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>Вже використовується</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>Вже використовується</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>Помилка заміни</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>Помилка заміни</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>Заміна завершена</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>Заміна завершена</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>Заміна екземплярів пристроїв...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>Заміна екземплярів пристроїв...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>Пристрій %1 вже використовується "%3". Поміняти місцями екземпляри пристроїв і призначити його %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>Пристрій %1 вже використовується &quot;%3&quot;. Поміняти місцями екземпляри пристроїв і призначити його %2?</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>Екземпляр пристрою %1 вже використовується іншим пристроєм того ж типу. Поміняти місцями екземпляри пристроїв і призначити їх %2?</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>Екземпляр пристрою %1 вже використовується іншим пристроєм того ж типу. Поміняти місцями екземпляри пристроїв і призначити їх %2?</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>Неможливо замінити екземпляри пристроїв: завершився термін дії.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>Неможливо замінити екземпляри пристроїв: завершився термін дії.</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>Нові екземпляри пристроїв будуть активні після перезавантаження.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>Нові екземпляри пристроїв будуть активні після перезавантаження.</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>Заміна.</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>Заміна.</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>Помилка під час перевірки оновлень прошивки</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>Помилка під час перевірки оновлень прошивки</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>Завантаження і встановлення прошивки %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>Завантаження і встановлення прошивки %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>Встановлення прошивки...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>Встановлення прошивки...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>Помилка під час встановлення прошивки</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>Помилка під час встановлення прошивки</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>Немає новішої версії</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>Немає новішої версії</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>Прошивка не знайдена</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>Прошивка не знайдена</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>Паливо</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>Паливо</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>Прісна вода</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>Прісна вода</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>Стічні води</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>Стічні води</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>Свердловина</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>Свердловина</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>Олива</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>Олива</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>Стічні води з каналізації</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>Стічні води з каналізації</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>Бензин</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>Бензин</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>Дизельне паливо</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>Дизельне паливо</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>Гідравлічна олива</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>Гідравлічна олива</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>Неочищена вода</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>Неочищена вода</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>Налаштування заблоковано для рівня доступу</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>Налаштування заблоковано для рівня доступу</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>Неправильний пароль</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>Неправильний пароль</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>Коротко</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>Коротко</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>Огляд</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>Огляд</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>Рівні</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>Рівні</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>Сповіщення</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>Сповіщення</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>зараз</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>зараз</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1 хв тому</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1 хв тому</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1 г %2 хв тому</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1 г %2 хв тому</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>Кожен день</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>Кожен день</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>Будні</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>Будні</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>Вихідні</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>Вихідні</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>Понеділок</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>Понеділок</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>Вівторок</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>Вівторок</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>Середа</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>Середа</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>Четвер</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>Четвер</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>П'ятниця</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>П&apos;ятниця</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>Субота</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>Субота</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>Неділя</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>Неділя</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 або %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 або %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>Розклад %1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>Розклад %1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>День</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>День</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>Не задано</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>Не задано</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>Ліміт SOC</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>Ліміт SOC</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>Власне споживання вище ліміту</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>Власне споживання вище ліміту</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>PV</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>PV</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>PV і Батарея</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>PV і Батарея</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>Перевірка...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>Перевірка...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>Стан тривоги</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>Стан тривоги</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">Тривога</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>Очищення історії</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>Очищення історії</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>Очищення</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>Очищення</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>Примусово вкл</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>Примусово вкл</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>Примусово вимк</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>Примусово вимк</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>Стан реле</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>Стан реле</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>Скидання історії на самому моніторі</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>Скидання історії на самому моніторі</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>Натисніть, щоб вийняти</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>Натисніть, щоб вийняти</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>Виймання, зачекайте</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>Виймання, зачекайте</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>Накопичувач не знайдено</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>Накопичувач не знайдено</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD/USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD/USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1 датчик температури</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1 датчик температури</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>Датчик температури %1 (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>Датчик температури %1 (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>Датчик температури (%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>Датчик температури (%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>Жодних дій</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>Жодних дій</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>Попередження: Температура активації та деактивації встановлена на однакове значення. Це призведе до ігнорування умови.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>Попередження: Температура активації та деактивації встановлена на однакове значення. Це призведе до ігнорування умови.</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>Умова %1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>Умова %1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>Функція вимкнена</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>Функція вимкнена</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>Немає (Вимкнено)</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>Немає (Вимкнено)</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>Реле 1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>Реле 1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>Реле 2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>Реле 2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>Попередження: вибране вище реле не налаштовано для температури. Цю умову буде проігноровано.</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>Попередження: вибране вище реле не налаштовано для температури. Цю умову буде проігноровано.</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>Значення активації</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>Значення активації</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>Одиниця об’єму</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>Одиниця об’єму</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>Кубічні метри</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>Кубічні метри</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>Літри (л)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>Літри (л)</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>Галони (США)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>Галони (США)</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>Галони (Imperial)</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>Галони (Imperial)</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>Мін. напруга</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>Мін. напруга</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>Макс. напруга</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>Макс. напруга</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">Макс. напруга</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>Максимальний струм</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>Максимальний струм</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>Час зарядки</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>Час зарядки</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">Основний</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">Плаваючий</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">год</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>Основний</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>Основний</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>Погл.</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>Погл.</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>Плаваючий</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>Плаваючий</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>год</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>год</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>Виникла %1 помилка(и)</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>Виникла %1 помилка(и)</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>Остання</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>Остання</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>Передостання</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>Передостання</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>Третя тому</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>Третя тому</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>Четверта тому</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>Четверта тому</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>Пік потужності</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>Пік потужності</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>Не вдається виконати з’єднання</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>Не вдається виконати з’єднання</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>Від'єднано, спроба повторного підключення</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>Від&apos;єднано, спроба повторного підключення</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>Підключення...</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>Підключення...</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">Підключення...</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>Підключено, чекаємо на повідомлення від брокера</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>Підключено, чекаємо на повідомлення від брокера</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>Підключено, отримую повідомлення від брокера</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>Підключено, отримую повідомлення від брокера</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>Підключено, завантажується користувацький інтерфейс</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>Підключено, завантажується користувацький інтерфейс</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>Неправильна версія протоколу</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>Неправильна версія протоколу</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>ID клієнта відхилено</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>ID клієнта відхилено</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>Послуга брокера недоступна</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>Послуга брокера недоступна</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>Неправильне ім'я користувача або пароль</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>Неправильне ім&apos;я користувача або пароль</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>Клієнт не авторизований</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>Клієнт не авторизований</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>Помилка транспортного з'єднання</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>Помилка транспортного з&apos;єднання</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>Помилка порушення протоколу</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>Помилка порушення протоколу</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>Помилка 5-го рівня протоколу MQTT</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>Помилка 5-го рівня протоколу MQTT</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>Беззвучна тривога</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>Беззвучна тривога</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>Загальна потужність</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>Загальна потужність</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>мін.</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>мін.</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1д %2год</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1д %2год</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1г %2хв</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1г %2хв</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1х %2с</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1х %2с</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1хв</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1хв</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1с</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1с</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0 хв</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0&#xa0;хв</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>Збій</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>Збій</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>Отримання IP-адреси</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>Отримання IP-адреси</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">Підключено</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>Відключити</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>Відключити</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">Відключено</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>AC Спож.</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>AC Спож.</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>DC спож.</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>DC спож.</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>EV заряд.</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>EV заряд.</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>Вітер</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>Вітер</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>Порт</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>Порт</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>Обмеження струму мережі</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>Обмеження струму мережі</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>Обмеження струму генератора</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>Обмеження струму генератора</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>Обмеження портового струму</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>Обмеження портового струму</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">Зупинка</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>Зупинка</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>Зупинка</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>%1 залиш.</translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>%1 залиш.</translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>Ємність %1 (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>Ємність %1 (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>AC Зарядний</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>AC Зарядний</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>Генератор</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>Генератор</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>DC Зарядний</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>DC Зарядний</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>Генератор DC</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>Генератор DC</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>DC система</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>DC система</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>Паливна комірка</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>Паливна комірка</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>Валогенератор</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>Валогенератор</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>Водяний генератор</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>Водяний генератор</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>Зарядний від вітру</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>Зарядний від вітру</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>Низький</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>Низький</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>Високий</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>Високий</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>Тримати батареї зарядженими</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>Тримати батареї зарядженими</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>Оптимізовано з BatteryLife</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>Оптимізовано з BatteryLife</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>Оптимізовано без BatteryLife</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>Оптимізовано без BatteryLife</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">Зовнішнє керування</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>Заряджено</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>Заряджено</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>Очікування сонця</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>Очікування сонця</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>Очікування RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>Очікування RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>Очікування запуску</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>Очікування запуску</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>Помилка тесту на заземлення</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>Помилка тесту на заземлення</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>Помилка перевірки входу CP</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>Помилка перевірки входу CP</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>Виявлено залишковий струм</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>Виявлено залишковий струм</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>Виявлено знижену напругу</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>Виявлено знижену напругу</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>Виявлено перевищення напруги</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>Виявлено перевищення напруги</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>Виявлено перегрів</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>Виявлено перегрів</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>Межа заряджання</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>Межа заряджання</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>Запустити заряджання</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>Запустити заряджання</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">Заплановано</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>Заплановано</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>Заплановано</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>Розігрів</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>Розігрів</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>Охолодження</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>Охолодження</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>Тестовий запуск</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>Тестовий запуск</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>Запущено вручну</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>Запущено вручну</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>Завантаження</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>Завантаження</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>Запуск (MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>Запуск (MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>Працює (придушений)</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>Працює (придушений)</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>Реле %1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>Реле %1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>Несправність</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>Несправність</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>Поглинання</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>Поглинання</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>Зберігання</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>Зберігання</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>Вирівнювання</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>Вирівнювання</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">Зовнішнє керування</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>Режим AES</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>Режим AES</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>Стан несправності</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>Стан несправності</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>Осн. зарядж.</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>Осн. зарядж.</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>Заряджання на стадії поглинання</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>Заряджання на стадії поглинання</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>Плаваючий заряд</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>Плаваючий заряд</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>Режим збереження</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>Режим збереження</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>Заряджання вирівнювання</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>Заряджання вирівнювання</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>Прохідна.</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>Прохідна.</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>Інвертування</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>Інвертування</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>Астистування</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>Астистування</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>Режим живлення</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>Режим живлення</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">Підтримувати</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>Прокидайся.</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>Прокидайся.</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>Повторне поглинання</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>Повторне поглинання</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>Автоматичне вирівнювання</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>Автоматичне вирівнювання</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>Збереження батареї</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>Збереження батареї</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>Виявл. Спож.</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>Виявл. Спож.</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>Заблоковано</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>Заблоковано</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>Тест</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>Тест</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">Динамічна ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>Динамічна ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>Динамічна ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>Майстер групи</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>Майстер групи</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>Майстер екземплярів</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>Майстер екземплярів</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>Майстер груп і екземплярів</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>Майстер груп і екземплярів</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>Автономно і майстер груп</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>Автономно і майстер груп</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>Тільки зарядний</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>Тільки зарядний</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>Тільки інвертор</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>Тільки інвертор</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">Тривога низької напруги батареї</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">Тривога через високу напругу батареї</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>Тривога через коротке замикання</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>Тривога через коротке замикання</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>Вимкнути точку доступу</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>Вимкнути точку доступу</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>Вхід DC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>Вхід DC</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>Для літієвих батарей не рекомендується розряджати їх нижче 10%. Для інших типів батарей перевірте в технічному паспорті мінімальний рівень заряду, рекомендований виробником.</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>Для літієвих батарей не рекомендується розряджати їх нижче 10%. Для інших типів батарей перевірте в технічному паспорті мінімальний рівень заряду, рекомендований виробником.</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>Вимкнути автозапуск?</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>Вимкнути автозапуск?</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>Інвертор/зарядний (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>Інвертор/зарядний (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>Відображати використання процесора</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>Відображати використання процесора</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>Вийти з програми</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>Вийти з програми</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>Вихід</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>Вихід</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>Версія програми</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>Версія програми</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>Температура масла</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>Температура масла</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>Зверніть увагу, що зміна параметра Час до розряду також змінює значення параметра Низький рівень заряду в меню реле.</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>Зверніть увагу, що зміна параметра Час до розряду також змінює значення параметра Низький рівень заряду в меню реле.</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>Час роботи</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>Час роботи</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>Заряджено А·год</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>Заряджено А·год</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>Запущених циклів</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>Запущених циклів</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>Завершених циклів</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>Завершених циклів</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>Кількість під’єднань живлення</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>Кількість під’єднань живлення</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>Кількість глибоких розрядів</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>Кількість глибоких розрядів</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>Історія циклів заряду</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>Історія циклів заряду</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>Значення датчика, ємність повна</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>Значення датчика, ємність повна</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>Час для обслуговування</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>Час для обслуговування</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>Функція автозапуску</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>Функція автозапуску</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>Переконайтеся, що генератор не підключений до входу AC %1 під час використання цієї опції</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>Переконайтеся, що генератор не підключений до входу AC %1 під час використання цієї опції</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>Сервісний таймер було скинуто</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>Сервісний таймер було скинуто</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>Безперервне сканування може перешкоджати роботі Wi-Fi.</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>Безперервне сканування може перешкоджати роботі Wi-Fi.</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>Мінімальний і максимальний діапазони індикаторів</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>Мінімальний і максимальний діапазони індикаторів</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">Початкова сторінка</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>Перезапуск програми...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>Перезапуск програми...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>Не вдалося змінити мову!</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>Не вдалося змінити мову!</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1 хв</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10 хв</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30 хв</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">Ніколи</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>Будь ласка, зачекайте, поки мова зміниться.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>Будь ласка, зачекайте, поки мова зміниться.</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>Блок короткого перегляду</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>Блок короткого перегляду</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>Ніяких міток</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>Ніяких міток</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>Показати об'єми резервуарів</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>Показати об&apos;єми резервуарів</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>Показати відсотки</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>Показати відсотки</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>Примітка: Якщо струм неможливо відобразити (наприклад, коли відображається загальна сума для комбінованих джерел AC і DC), замість нього буде показано потужність.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>Примітка: Якщо струм неможливо відобразити (наприклад, коли відображається загальна сума для комбінованих джерел AC і DC), замість нього буде показано потужність.</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>Обмеження струму заряду</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>Обмеження струму заряду</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>Офіційний реліз</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>Офіційний реліз</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Бета версія</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Бета версія</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>Тестування (внутрішнє Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>Тестування (внутрішнє Victron)</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>Розробка (внутрішнє Victron)</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>Розробка (внутрішнє Victron)</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>Перезавантаження...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>Перезавантаження...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>Увімкнути індикатори стану</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>Увімкнути індикатори стану</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>Розігрів та охолодження</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>Розігрів та охолодження</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>Час зупинки генератора</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>Час зупинки генератора</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>Тривога, коли генератор не в режимі автозапуску</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>Тривога, коли генератор не в режимі автозапуску</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>Тривога спрацьовує, якщо функцію автозапуску вимкнено більше ніж на 10 хвилин</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>Тривога спрацьовує, якщо функцію автозапуску вимкнено більше ніж на 10 хвилин</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>Самоспоживання від батареї</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>Самоспоживання від батареї</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>Всі навантаження системи</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>Всі навантаження системи</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>Тільки критичні навантаження</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>Тільки критичні навантаження</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">Найнижчий рівень заряду (якщо немає збоїв у мережі)</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>Стан заряду батареї</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>Стан заряду батареї</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>Доступ до Signal K на http://venus.local:3000 та через VRM.</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>Доступ до Signal K на http://venus.local:3000 та через VRM.</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>Доступ до Node-RED на https://venus.local:1881 та через VRM.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>Доступ до Node-RED на https://venus.local:1881 та через VRM.</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>Вимірювання батареї</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>Вимірювання батареї</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>Стан системи</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>Стан системи</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>Список пристроїв</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>Список пристроїв</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">Локальна мережа Ethernet</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>Екземпляри пристроїв VRM</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>Екземпляри пристроїв VRM</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>Тривога через високу температуру</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>Тривога через високу температуру</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>Під керуванням BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>Під керуванням BMS</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>Тривоги та помилки</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>Тривоги та помилки</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>Ця функція потребує прошивки версії 400 або новішої. Зверніться до інсталятора, щоб оновити ваш Multi/Quattro.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>Ця функція потребує прошивки версії 400 або новішої. Зверніться до інсталятора, щоб оновити ваш Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>Зарядний пристрій не готовий, вирівнювання не може бути запущено</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>Зарядний пристрій не готовий, вирівнювання не може бути запущено</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>Вирівнювання не може спрацювати під час стану об'ємного заряду</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>Вирівнювання не може спрацювати під час стану об&apos;ємного заряду</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>Еко</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>Еко</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>Макс. струм</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>Макс. струм</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>Максимальна потужність</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>Максимальна потужність</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>Мін. струм</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>Мін. струм</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">Жодного</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">Недоступний</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">Вимкнено</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">ОК</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>Загальна історія</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>Загальна історія</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">Налаштування</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">Невідоме</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>Ген.сьогодні</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>Ген.сьогодні</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>Встановлено прошивку, пристрій перезавантажено</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>Встановлено прошивку, пристрій перезавантажено</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>Керування сенсорним введенням</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>Керування сенсорним введенням</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>Помилка тесту зварних контактів (закорочені)</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>Помилка тесту зварних контактів (закорочені)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>Перехід на 3 фази</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>Перехід на 3 фази</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>Перемикання на 1 фазу</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>Перемикання на 1 фазу</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>Припинити заряджання</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>Припинити заряджання</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>Зарезервовано</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>Зарезервовано</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>Інверторний режим</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>Інверторний режим</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>AC Out L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>AC Out L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>Вхід</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>Вхід</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>Транзит</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>Транзит</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Сторінка автоматично перезавантажиться через десять секунд, щоб завантажити останню версію.</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>Сторінка автоматично перезавантажиться через десять секунд, щоб завантажити останню версію.</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>Інвертор (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>Інвертор (%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>Інвертор/Зарядні</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>Інвертор/Зарядні</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>Лічильників енергії не знайдено
+        <translation>Лічильників енергії не знайдено
 
 Зверніть увагу, що в цьому меню відображаються лише лічильники Carlo Gavazzi, підключені через RS485. Для будь-яких інших лічильників, включаючи лічильники Carlo Gavazzi, підключені через Ethernet, дивіться меню Пристрої Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Автопідбір</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>Автопідбір</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>Якщо увімкнено, мінімуми та максимуми індикаторів і графіків автоматично коригуються на основі минулих значень.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>Якщо увімкнено, мінімуми та максимуми індикаторів і графіків автоматично коригуються на основі минулих значень.</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>Скинути всі значення діапазону до нуля</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>Скинути всі значення діапазону до нуля</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>Скинути значення діапазону</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>Скинути значення діапазону</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>Ви впевнені, що хочете обнулити всі значення?</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>Ви впевнені, що хочете обнулити всі значення?</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>Макс. струм: вхід AC 1 підключений</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>Макс. струм: вхід AC 1 підключений</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>Макс. струм: вхід AC 2 підключений</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>Макс. струм: вхід AC 2 підключений</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>Макс. струм: немає входів AC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>Макс. струм: немає входів AC</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>Вихід DC</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>Вихід DC</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>Сонячна</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>Сонячна</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>Оберти двигуна</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>Оберти двигуна</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>Температура двигуна</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>Температура двигуна</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>Температура Контролера</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>Температура Контролера</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>Активний цикл</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>Активний цикл</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>Цикл %1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>Цикл %1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>Відключення постійного струму</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>Відключення постійного струму</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>Вимкнено</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>Вимкнено</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>Зміна функції</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>Зміна функції</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>Оновлення прошивки</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>Оновлення прошивки</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>Перезавантаження програмного забезпечення</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>Перезавантаження програмного забезпечення</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>Неповний</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>Неповний</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>Час, що минув</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>Час, що минув</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>Заряджати / підтримувати (А-год)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>Заряджати / підтримувати (А-год)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Батарея (V&lt;sub&gt;початок&lt;/sub&gt;/V&lt;sub&gt;кінець&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>Батарея (V&lt;sub&gt;початок&lt;/sub&gt;/V&lt;sub&gt;кінець&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>Низька напруга виходу AC</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>Низька напруга виходу AC</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>Висока напруга виходу AC</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>Висока напруга виходу AC</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>Загальний вихід</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>Загальний вихід</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>Вихід системи</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>Вихід системи</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>Щоденна історія</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>Щоденна історія</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>Немає тривог для налаштування</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>Немає тривог для налаштування</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>Максимальна напруга фотоелектричної панелі</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>Максимальна напруга фотоелектричної панелі</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>Максимальна напруга батареї</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>Максимальна напруга батареї</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>Мінімальна напруга батареї</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>Мінімальна напруга батареї</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>Помилка батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>Помилка батареї</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>Напруга батареї не підтримується</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>Напруга батареї не підтримується</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>Неправильна кількість батарейок</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>Неправильна кількість батарейок</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>Неправильна конфігурація батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>Неправильна конфігурація батареї</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>Статус балансувальника</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>Статус балансувальника</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>Збалансовано</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>Збалансовано</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>Незбалансовано</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>Незбалансовано</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>Використовуйте цю опцію в пристроях, які не підтримують пікове гоління.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>Використовуйте цю опцію в пристроях, які не підтримують пікове гоління.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>Використовуйте цю опцію для пікового гоління.</translation>
+        <translation>Використовуйте цю опцію для пікового гоління.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Обмеження піків встановлюється за допомогою параметра обмеження вхідного струму AC. Для отримання додаткової інформації див. документацію.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>Обмеження піків встановлюється за допомогою параметра обмеження вхідного струму AC. Для отримання додаткової інформації див. документацію.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>На цьому екрані можна змінити пікові пороги гоління для імпорту та експорту. Докладнішу інформацію див. у документації.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>На цьому екрані можна змінити пікові пороги гоління для імпорту та експорту. Докладнішу інформацію див. у документації.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>Обмеження системного струму імпорту AC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>Обмеження системного струму імпорту AC</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Щоб скористатися цією функцією, для параметра "Мережевий облік" має бути встановлено значення "Зовнішній лічильник", а також має бути встановлено актуальну версію ESS-асистента.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>Щоб скористатися цією функцією, для параметра &quot;Мережевий облік&quot; має бути встановлено значення &quot;Зовнішній лічильник&quot;, а також має бути встановлено актуальну версію ESS-асистента.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>Максимальний струм імпорту системи (на фазу)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>Максимальний струм імпорту системи (на фазу)</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Щоб скористатися цією функцією, для параметра Мережевий лічильник має бути встановлено значення Зовнішній лічильник.</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>Щоб скористатися цією функцією, для параметра Мережевий лічильник має бути встановлено значення Зовнішній лічильник.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>Максимальний струм експорту системи (на фазу)</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>Максимальний струм експорту системи (на фазу)</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>Дротяна.</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>Дротяна.</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">Коротко</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>Високе навантаження на систему, закриття бічної панелі для зменшення навантаження на процесор</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>Високе навантаження на систему, закриття бічної панелі для зменшення навантаження на процесор</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>Обмеження вхідного струму</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>Обмеження вхідного струму</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>Коротке замикання</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>Коротке замикання</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>Купівля</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>Купівля</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>Продаж</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>Продаж</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>Цільовий SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>Цільовий SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>AC вихід %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>AC вихід %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>Трекер</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>Трекер</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>Пристрої RS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>Пристрої RS</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>Призупинити анімацію електронів</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>Призупинити анімацію електронів</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>Загальна потужність</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>Загальна потужність</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>Кількість СМБ</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>Кількість СМБ</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN-шина BMS LV (500 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN-шина BMS LV (500 кбіт/с)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN-шина BMS HV (500 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN-шина BMS HV (500 кбіт/с)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>Обмеження системного струму експорту AC</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>Обмеження системного струму експорту AC</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Пристрої Modbus TCP/UDP</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Пристрої Modbus TCP/UDP</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>Додати пристрій</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>Додати пристрій</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>Сканування на наявність пристроїв</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>Сканування на наявність пристроїв</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>Збережені пристрої</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>Збережені пристрої</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>Виявлені пристрої</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>Виявлені пристрої</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>Додати пристрій Modbus TCP/UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>Додати пристрій Modbus TCP/UDP</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>Протокол</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>Протокол</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>Порт</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>Порт</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>Пристрій</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>Пристрій</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>Не збережено жодного пристрою Modbus</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>Не збережено жодного пристрою Modbus</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>Пристрій %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>Пристрій %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>Видалити пристрій Modbus?</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>Видалити пристрій Modbus?</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>Пристроїв Modbus не виявлено</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>Пристроїв Modbus не виявлено</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>Батарея %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>Батарея %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>AC струм</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>AC струм</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>Вимкнено старт/стоп генератора</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>Вимкнено старт/стоп генератора</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>Віддалений старт вимкнено на генератора. GX не зможу запустити або зупинити генератор. Увімкніть функцію на панелі генератора.</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>Віддалений старт вимкнено на генератора. GX не зможу запустити або зупинити генератор. Увімкніть функцію на панелі генератора.</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>Функція автоматичного запуску</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>Функція автоматичного запуску</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">Поточний час виконання</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>Стан керування</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>Стан керування</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>Стан генератора</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>Стан генератора</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>Режим дистанційного запуску</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>Режим дистанційного запуску</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>Тиск оливи</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>Тиск оливи</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>Заплановані рівні заряду</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>Заплановані рівні заряду</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>Активна (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>Активна (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>Ручна зупинка</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>Ручна зупинка</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>Відкритий ланцюг</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>Відкритий ланцюг</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (недоступно)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (недоступно)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>Сенсорне введення ввімкнено</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>Сенсорне введення ввімкнено</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>Сенсорне введення вимкнено</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>Сенсорне введення вимкнено</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>Сенсорне введення відключено</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>Сенсорне введення відключено</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>Підтвердження сповіщення</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>Підтвердження сповіщення</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>Код помилки керування</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>Код помилки керування</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>Використовуйте це меню, щоб визначити дані батареї, які відображаються при натисканні на піктограму "Батарея" на сторінці "Огляд". Той самий вибір також відображається на Порталі VRM.</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>Використовуйте це меню, щоб визначити дані батареї, які відображаються при натисканні на піктограму &quot;Батарея&quot; на сторінці &quot;Огляд&quot;. Той самий вибір також відображається на Порталі VRM.</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>Напруга системи [В]</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>Напруга системи [В]</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>Інформація про зʼєднання</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>Інформація про зʼєднання</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>Будь ласка, оберіть...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>Будь ласка, оберіть...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>Захищено</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>Захищено</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>Захищено паролем, а мережеве з'єднання зашифровано</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>Захищено паролем, а мережеве з&apos;єднання зашифровано</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>Слабкий.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>Слабкий.</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>Захищено паролем, але мережеве з'єднання не шифрується</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>Захищено паролем, але мережеве з&apos;єднання не шифрується</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>Незахищено</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>Незахищено</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>Немає пароля і мережеве з'єднання не шифрується</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>Немає пароля і мережеве з&apos;єднання не шифрується</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">Пароль повинен мати довжину не менше 8 символів</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">Введіть пароль</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>Пароль повинен мати довжину не менше 8 символів</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>Пароль повинен мати довжину не менше 8 символів</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>Обрали профіль "Захищений"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>Обрали профіль &quot;Захищений&quot;?</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>Обрали профіль "Слабкий"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>Обрали профіль &quot;Слабкий&quot;?</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>Обрали профіль "Незахищений"?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>Обрали профіль &quot;Незахищений&quot;?</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Служби локальної мережі захищені паролем
-- Мережевий зв'язок зашифровано
-- Увімкнено безпечне з'єднання з VRM
+        <translation>- Служби локальної мережі захищені паролем
+- Мережевий зв&apos;язок зашифровано
+- Увімкнено безпечне з&apos;єднання з VRM
 - Неможливо ввімкнути небезпечні налаштування</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Служби локальної мережі захищені паролем
+        <translation>- Служби локальної мережі захищені паролем
 - Також дозволено незашифрований доступ до локальних веб-сайтів (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Служби локальної мережі не потребують пароля
+        <translation>- Служби локальної мережі не потребують пароля
 - Доступ до локальних веб-сайтів у незашифрованому вигляді (HTTP/HTTPS)</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>Рут-пароль</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>Рут-пароль</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>Вихід</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>Вихід</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>Вийдіть з системи</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>Вийдіть з системи</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>Вийти з системи?</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>Вийти з системи?</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>Це призведе до відключення всіх підключень до локальної мережі.</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>Це призведе до відключення всіх підключень до локальної мережі.</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>Вихід</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>Вихід</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>Тільки для читання</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>Тільки для читання</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>Повний</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>Повний</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>Впевнені?</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>Впевнені?</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>Зміна цього параметра на "Тільки для читання" або "Вимкнено" заблокує вас.</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>Зміна цього параметра на &quot;Тільки для читання&quot; або &quot;Вимкнено&quot; заблокує вас.</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>Доступ до MQTT</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>Доступ до MQTT</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>'%1' не є числом.</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>&apos;%1&apos; не є числом.</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>Підтвердження</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>Підтвердження</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>Використовуйте число з %1 цифр або менше.</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>Використовуйте число з %1 цифр або менше.</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>'%1' є недійсною IP-адресою.</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>&apos;%1&apos; є недійсною IP-адресою.</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>'%1' не є правильним номером порту. Використовуйте номер у діапазоні 0-65535.</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>&apos;%1&apos; не є правильним номером порту. Використовуйте номер у діапазоні 0-65535.</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 не є допустимим номером одиниці виміру. Використовуйте номер в діапазоні 1-247.</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 не є допустимим номером одиниці виміру. Використовуйте номер в діапазоні 1-247.</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>Поточний час виконання</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>Поточний час виконання</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>Коди помилок генераторної установки</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>Коди помилок генераторної установки</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>Температура радіатора</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>Температура радіатора</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">Напруга заряджання</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>Напруга заряду наразі контролюється системою BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>Напруга заряду наразі контролюється системою BMS.</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>Обмеження зарядного струму</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>Обмеження зарядного струму</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>Під керуванням BMS</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>Під керуванням BMS</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Керування BMS вмикається автоматично за наявності BMS. Скиньте, якщо змінилася конфігурація системи або якщо відсутня BMS.</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>Керування BMS вмикається автоматично за наявності BMS. Скиньте, якщо змінилася конфігурація системи або якщо відсутня BMS.</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>Сервісний таймер вимкнено.</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>Сервісний таймер вимкнено.</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>Портал VRM</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>Портал VRM</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale (віддалений VPN-доступ)</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale (віддалений VPN-доступ)</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>Перш ніж увімкнути мережеві служби, необхідно налаштувати профіль безпеки, див. розділ Налаштування - Загальні</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>Перш ніж увімкнути мережеві служби, необхідно налаштувати профіль безпеки, див. розділ Налаштування - Загальні</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>'%1' було замінено на '%2', оскільки він містив неприпустимі символи.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>&apos;%1&apos; було замінено на &apos;%2&apos;, оскільки він містив неприпустимі символи.</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>Ініціалізація...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>Ініціалізація...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>Запуск бекенда...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>Запуск бекенда...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>Бекенд зупинився.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>Бекенд зупинився.</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>З'єднання не вдалося.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>З&apos;єднання не вдалося.</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>Цей пристрій GX вийшов з Tailscale.
+        <translation>Цей пристрій GX вийшов з Tailscale.
 
 Зачекайте або перевірте підключення до Інтернету.</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>Чекаємо на відповідь від Tailscale...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>Чекаємо на відповідь від Tailscale...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>Підключіть цей пристрій GX до свого облікового запису Tailscale, перейшовши за цим посиланням:</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>Підключіть цей пристрій GX до свого облікового запису Tailscale, перейшовши за цим посиланням:</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>Будь ласка, зачекайте або перевірте підключення до Інтернету.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>Будь ласка, зачекайте або перевірте підключення до Інтернету.</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>Невідомий стан: #%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>Невідомий стан: #%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>Помилка: %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>Помилка: %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>Вимкніть Tailscale, щоб змінити ці налаштування.</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>Вимкніть Tailscale, щоб змінити ці налаштування.</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>Увімкнути хвостову шкалу</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>Увімкнути хвостову шкалу</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>Назва машини</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>Назва машини</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>Вихід з облікового запису Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>Вихід з облікового запису Tailscale</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>Доступ до локальної мережі</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>Доступ до локальної мережі</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>Доступ до локальної мережі Ethernet</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>Доступ до локальної мережі Ethernet</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>Доступ до локальної мережі WiFi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>Доступ до локальної мережі WiFi</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>Користувацька мережа (мережі)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>Користувацька мережа (мережі)</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>Приклад: 192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>Приклад: 192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>Пояснення:
+        <translation>Пояснення:
 
 Ця функція, яку у Tailscale називають маршрутами підмереж, дозволяє віддалений доступ до інших пристроїв у локальній мережі.
 
@@ -7397,2993 +8028,3058 @@ After adding/enabling a new network, you need to approve it in the Tailscale adm
 Після додавання/увімкнення нової мережі вам потрібно один раз підтвердити її в консолі адміністратора Tailscale.</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>Користувацькі аргументи "хвостового масштабування"</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>Користувацькі аргументи &quot;хвостового масштабування&quot;</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>Користувацька URL-адреса сервера (Headscale)</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>Користувацька URL-адреса сервера (Headscale)</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Для керування цим контролером генераторної установки потрібне допоміжне реле, але допоміжне реле не налаштоване. Будь ласка, налаштуйте реле 1 у розділі Налаштування → Реле на "Підключене допоміжне реле генераторної установки".</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>Для керування цим контролером генераторної установки потрібне допоміжне реле, але допоміжне реле не налаштоване. Будь ласка, налаштуйте реле 1 у розділі Налаштування → Реле на &quot;Підключене допоміжне реле генераторної установки&quot;.</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>Сигналізація про високу напругу стартерної батареї</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>Сигналізація про високу напругу стартерної батареї</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>Пропустити прогрів генератора</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>Пропустити прогрів генератора</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>Вгору, але без послуг (500 кбіт/с)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>Вгору, але без послуг (500 кбіт/с)</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>Рут-пароль змінено на %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>Рут-пароль змінено на %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>Підключено допоміжне реле генераторної установки</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>Підключено допоміжне реле генераторної установки</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>Позиція віджетів AC споживачів</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>Позиція віджетів AC споживачів</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>Вхід і вихід змінного струму</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>Вхід і вихід змінного струму</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>Використовуйте цю опцію, якщо на вході інвертора/зарядного пристрою є навантаження AC. Використовуйте цю опцію, якщо ви не впевнені.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>Використовуйте цю опцію, якщо на вході інвертора/зарядного пристрою є навантаження AC. Використовуйте цю опцію, якщо ви не впевнені.</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>Тільки вихід змінного струму</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>Тільки вихід змінного струму</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>Використовуйте цю опцію, коли система використовує мережевий лічильник, але всі навантаження AC на виході інвертора/зарядного пристрою.</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>Використовуйте цю опцію, коли система використовує мережевий лічильник, але всі навантаження AC на виході інвертора/зарядного пристрою.</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>Щомісяця</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>Щомісяця</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>Зарядка EV</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>Зарядка EV</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>Тепловий насос</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>Тепловий насос</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>Важливі Спож.</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>Важливі Спож.</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>Запуск і зупинка генератора на основі налаштованих умов автозапуску.</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>Запуск і зупинка генератора на основі налаштованих умов автозапуску.</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>Налаштування генераторної установки постійного струму</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>Налаштування генераторної установки постійного струму</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>Температура генератора</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>Температура генератора</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>Температура двигуна</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>Температура двигуна</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>Загальний час роботи</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>Загальний час роботи</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>Профіль мережевої безпеки</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>Профіль мережевої безпеки</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>Останні %1 днів</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>Останні %1 днів</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>Генератор зупиниться через %1, якщо не увімкнено умови автозапуску, які підтримують його роботу.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>Генератор зупиниться через %1, якщо не увімкнено умови автозапуску, які підтримують його роботу.</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>Генератор працюватиме до тих пір, поки не буде зупинений вручну, якщо не будуть увімкнені умови автоматичного запуску, які підтримують його роботу.</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>Генератор працюватиме до тих пір, поки не буде зупинений вручну, якщо не будуть увімкнені умови автоматичного запуску, які підтримують його роботу.</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>Класичний інтерфейс</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>Класичний інтерфейс</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>Новий інтерфейс</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>Новий інтерфейс</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>Успішно змінили мову!</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>Обмеження потужності</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>Успішно змінили мову!</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>Для пристроїв Multi-RS і HS19 налаштування ESS доступні на сторінці продукту RS System.</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>Для пристроїв Multi-RS і HS19 налаштування ESS доступні на сторінці продукту RS System.</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>Запуск/зупинка генераторної установки</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>Запуск/зупинка генераторної установки</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Перемикання версії прошивки неможливе, якщо не вибрано "Профіль мережевої безпеки" у розділі "Налаштування/Загальні".</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>Перемикання версії прошивки неможливе, якщо не вибрано &quot;Профіль мережевої безпеки&quot; у розділі &quot;Налаштування/Загальні&quot;.</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>Тривалість</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>Тривалість</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>Системні тривоги</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>Системні тривоги</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>Відсутність системних тривог</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>Відсутність системних тривог</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>Назад</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>Назад</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>Новинки</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>Новинки</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>пропустити</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>пропустити</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>Ласкаво просимо!</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>Ласкаво просимо!</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>Ми раді представити вам повністю оновлений інтерфейс, який покращує як зручність використання, так і естетику вашого GX.
+        <translation>Ми раді представити вам повністю оновлений інтерфейс, який покращує як зручність використання, так і естетику вашого GX.
 
 Завдяки спрощеній навігації та свіжому вигляду, все, що ви любите, стало ще доступнішим та привабливішим.</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>Темний - світлий режим</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>Темний - світлий режим</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Різні середовища вимагають різних налаштувань дисплея. Темний і світлий режими забезпечують найкращі враження від перегляду незалежно від того, де ви знаходитесь.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>Різні середовища вимагають різних налаштувань дисплея. Темний і світлий режими забезпечують найкращі враження від перегляду незалежно від того, де ви знаходитесь.</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Вся ключова інформація, яка вам потрібна, представлена в чистому і простому макеті. Центральним елементом є настроюваний віджет з кільцями, що надає швидкий доступ до інформації про вашу систему з першого погляду.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>Вся ключова інформація, яка вам потрібна, представлена в чистому і простому макеті. Центральним елементом є настроюваний віджет з кільцями, що надає швидкий доступ до інформації про вашу систему з першого погляду.</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Отримайте більше контролю з нашою оновленою панеллю огляду, яка відображає системні дані в реальному часі - все в одному місці для зручного моніторингу.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>Отримайте більше контролю з нашою оновленою панеллю огляду, яка відображає системні дані в реальному часі - все в одному місці для зручного моніторингу.</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>Управління:</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>Управління:</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>Всі щоденні елементи керування тепер об'єднані в новій панелі "Елементи керування". </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">Всі щоденні елементи керування тепер об&apos;єднані в новій панелі &quot;Елементи керування&quot;. </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>Вати та Ампери</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>Вати та Ампери</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>Тепер ви можете перемикатися між Ватами та Амперами. Виберіть одиницю виміру, яка найкраще відповідає вашим уподобанням.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>Тепер ви можете перемикатися між Ватами та Амперами. Виберіть одиницю виміру, яка найкраще відповідає вашим уподобанням.</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>Вивчайте більше</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>Вивчайте більше</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>Перейдіть за посиланням нижче, щоб дізнатися більше про оновлений інтерфейс.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>Перейдіть за посиланням нижче, щоб дізнатися більше про оновлений інтерфейс.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>Відскануйте QR-код, щоб дізнатися більше про оновлений інтерфейс.</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>Відскануйте QR-код, щоб дізнатися більше про оновлений інтерфейс.</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>Готово</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>Готово</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>Далі</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>Далі</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>Помилка: #%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>Помилка: #%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>Активна помилка</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>Активна помилка</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>Загальний час роботи генератора (годин)</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>Загальний час роботи генератора (годин)</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>Початкова сторінка</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>Початкова сторінка</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>Інтерфейс користувача</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>Інтерфейс користувача</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>Інтерфейс користувача (віддалена консоль)</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>Інтерфейс користувача (віддалена консоль)</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 оновлено</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 оновлено</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>Інтерфейс користувача зміниться на %1.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>Інтерфейс користувача зміниться на %1.</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 встановлено на %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Цей фотоелектричний інвертор має підтримку обмеження потужності. Вимкніть це налаштування, якщо воно заважає нормальній роботі.</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 встановлено на %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>Натисніть "OK", щоб перезавантажитися</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>Натисніть &quot;OK&quot;, щоб перезавантажитися</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Скидання до заводських налаштувань Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Скидання до заводських налаштувань Node-RED</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>Ви впевнені, що хочете скинути Node-RED до заводських налаштувань? Це видалить всі ваші потоки.</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>Ви впевнені, що хочете скинути Node-RED до заводських налаштувань? Це видалить всі ваші потоки.</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>Стан з'єднання</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>Стан з&apos;єднання</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>Стан з'єднання (канал HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>Стан з&apos;єднання (канал HTTPS)</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>Стан з'єднання (HTTP-канал)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>Стан з&apos;єднання (HTTP-канал)</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>Стан з'єднання (канал реального часу MQTT)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>Стан з&apos;єднання (канал реального часу MQTT)</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>Стан з'єднання (канал MQTT RPC)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>Стан з&apos;єднання (канал MQTT RPC)</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>Автозапуск - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>Автозапуск - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>Значення деактивації</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>Значення деактивації</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>Не біжу.</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>Не біжу.</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>Втрата зв'язку</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>Втрата зв&apos;язку</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>Стан SOC</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>Стан SOC</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>Стан навантаження змінного струму</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>Стан навантаження змінного струму</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>Поточний стан акумулятора</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>Поточний стан акумулятора</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>Стан напруги акумулятора</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>Стан напруги акумулятора</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>Стан перевантаження інвертора</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>Стан перевантаження інвертора</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Заряд/розряд вимкнено</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 Заряд/розряд вимкнено</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 Заряд вимкнено</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 Заряд вимкнено</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 Розряд вимкнено</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 Розряд вимкнено</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">Коротко</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>Коротко (бічна панель відкрита)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>Коротко (бічна панель відкрита)</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">Огляд</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>Рівні (Танки)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>Рівні (Танки)</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>Рівні (навколишнє середовище)</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>Рівні (навколишнє середовище)</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>Список батарейок</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>Список батарейок</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>Пристрій GX оновлено</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>Пристрій GX оновлено</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>Через %n хвилин(и)</numerusform>
-        <numerusform>Через %n хвилин(и)</numerusform>
-        <numerusform>Через %n хвилин(и)</numerusform>
-        <numerusform>Через %n хвилин(и)</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>Через %n хвилин(и)</numerusform>
+            <numerusform>Через %n хвилин(и)</numerusform>
+            <numerusform>Через %n хвилин(и)</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>Перейдіть на цю сторінку після запуску програми.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>Перейдіть на цю сторінку після запуску програми.</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>Тайм-аут.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>Тайм-аут.</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>Повернутися до стартової сторінки, коли програма неактивна.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>Повернутися до стартової сторінки, коли програма неактивна.</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Після однієї хвилини бездіяльності виберіть поточну сторінку як стартову, якщо вона є в цьому списку.</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>Після однієї хвилини бездіяльності виберіть поточну сторінку як стартову, якщо вона є в цьому списку.</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Ця межа струму зафіксована в конфігурації системи. Він не може бути змінений.</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Ця межа струму зафіксована в конфігурації системи. Він не може бути змінений.</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>Режим зафіксовано в конфігурації системи. Він не може бути змінений.</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>Режим зафіксовано в конфігурації системи. Він не може бути змінений.</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>Функція запуску/зупинки генератора не ввімкнена, перейдіть до налаштувань реле та встановіть функцію на "Запуск/зупинка генератора"</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Стандартний час Марокко</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Західно- і центральноафриканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Південноафриканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Стандартний час Намібії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Стандартний час Єгипту</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Східноафриканський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Аргентинський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Східно- і Південноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Стандартний час Гренландії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Стандартний час Монтевідео</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Ньюфаундлендський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Південноамериканський східний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Атлантичний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Центральний бразильський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Тихоокеанський південноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Парагвайський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>Південноамериканський західний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Стандартний час Венесуели</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>Східний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Південноамериканський тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Східний стандартний час США</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Канадський центральний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>Центральноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Центральний стандартний час (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>Центральний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Гірський стандартний час (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>Гірський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Гірський стандартний час США</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Тихоокеанський стандартний час (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>Тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Аляскинський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Гавайсько-алеутський</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новозеландський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Західний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Західноавстралійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Стандартний час Південно-Східної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Стандартний час Центральної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Стандартний час Західної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Східноафриканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Тихоокеанський південноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Південноамериканський західний стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Західноєвропейський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Камчатський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Магаданський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Владивостоцький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Якутський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Токійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Корейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Сингапурський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Стандартний час в Улан-Баторі</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Стандартний час в Тайбеї</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Східний стандартний час Північної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Китайський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Стандартний час Південно-Східної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Стандартний час Північної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Стандартний час М’янми</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Стандартний час Північно-Центральної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Стандартний час Центральної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Стандартний час Бангладеш</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Непальський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Стандартний час Шрі-Ланки</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Індійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Стандартний час Західної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Пакистанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Єкатеринбурзький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Грузинський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Кавказький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Азербайджанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Арабський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Стандартний час в Афганістані</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Іранський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Аравійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Аравійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Сирійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Близькосхідний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Стандартний час Йорданії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Ізраїльський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Гринвіцький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Стандартний час на Азорських островах</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Стандартний час Кабо-Верде</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Стандартний час Тасманії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Східноавстралійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Австралійський східний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Центр. Австралійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Австралійський центральний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Західноавстралійський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Середньоатлантичний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>Стандартний час від лінії змін дат (DST)</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Стандартний час GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Стандартний час Центральної Європи</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Центральноєвропейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Романський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Західноєвропейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Східноєвропейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Стандартний час FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Стандартний час GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Білоруський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Російський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Стандартний час Туреччини</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Маврикійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Стандартний час острова Різдва</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Стандартний час Тонга</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Стандартний час Фіджі</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новозеландський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Західний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Стандартний час Самоа</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Гавайський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Стандартний час острова Пасхи</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>Функція запуску/зупинки генератора не ввімкнена, перейдіть до налаштувань реле та встановіть функцію на &quot;Запуск/зупинка генератора&quot;</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Невідоме</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">PV генерація</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">Вхід DC</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">AC Спож.</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">DC спож.</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">Огляд</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">Стан</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">Загальний вихід</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">Вихід системи</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">Тільки тривоги</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">Тривоги та попередження</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">Попередження</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Помилки немає</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>Помилки немає</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Невідома помилка: %1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>Невідома помилка: %1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Помилки немає</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>Помилки немає</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Помилка ініціалізації батареї</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>Помилка ініціалізації батареї</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Аккумулятор не підключено</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>Аккумулятор не підключено</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Невідома батарея</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>Невідома батарея</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Різні типи батарей</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>Різні типи батарей</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Кількість. батарей неправильна</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>Кількість. батарей неправильна</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Шунт не знайдено</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Шунт не знайдено</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Помилка вимірювання батареї</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>Помилка вимірювання батареї</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Внутрішня помилка обчислень</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>Внутрішня помилка обчислень</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Кількість. батарей у серії неправильна</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>Кількість. батарей у серії неправильна</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Апаратна помилка</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>Апаратна помилка</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Помилка датчика стеження</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>Помилка датчика стеження</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Перевищення напруги</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>Перевищення напруги</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Під напругою</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>Під напругою</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Перевищена температура</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>Перевищена температура</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Під температурою</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>Під температурою</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Режим очікування при недостатньому заряді</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>Режим очікування при недостатньому заряді</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Помилка ADC</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>Помилка ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Помилка. зв'язку з батареєю</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>Помилка. зв&apos;язку з батареєю</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Помилка попереднього заряду</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>Помилка попереднього заряду</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Помилка захисного контактора</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>Помилка захисного контактора</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Помилка оновлення батареї</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>Помилка оновлення батареї</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Помилка кабелю BMS</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>Помилка кабелю BMS</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Збій опорної напруги</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>Збій опорної напруги</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Неправильна напруга системи</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>Неправильна напруга системи</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Закінчився очікування попереднього заряджання</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>Закінчився очікування попереднього заряджання</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Збій ATC/ATD</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>Збій ATC/ATD</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Дані калібрування втрачено</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>Дані калібрування втрачено</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Налаштування недійсні</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>Налаштування недійсні</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Блокування</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>Блокування</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Аварійна зупинка</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>Аварійна зупинка</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Тайм-аут зв'язку</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>Тайм-аут зв&apos;язку</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Запобіжник</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>Запобіжник</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Перегрів терміналу</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>Перегрів терміналу</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Помилки немає</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Висока температура батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Висока напруга батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Неправильне підключення датчика температури батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Відсутній датчик температури батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Неправильне підключення датчика напруги батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Відсутній датчик напруги батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Високі втрати у проводах батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Низька напруга батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Висока напруга пульсації батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Низький рівень заряду батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Проблема із напругою в середній точці батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Надто низька температура батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Висока температура зарядного пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Надмірний струм зарядного пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Отрицательный ток зарядного устройства</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Час роботи зарядного пристрою закінчився</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Проблема з датчиком струму зарядного пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Внутрішній датчик температури підключено неправильно</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Відсутній внутрішній датчик температури</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Вентилятор зарядного пристрою не виявлено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Перевищення струму вентилятора зарядного пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Перегрів клеми зарядного пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Коротке замикання зарядного пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Проблема зі ступенем живлення зарядного пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Захист від перезаряду</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Вхідна висока напруга</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Надмірний вхідний струм</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Надмірна вхідна потужність</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Проблема з полярністю входу</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Вхідна напруга відсутня</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Вимкнення входу (без повторних спроб)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Вимкнення входу (повторна спроба)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Внутрішня несправність входу</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Збій ізоляції PV</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Виявлено замикання на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Перевантаження інвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Надто висока температура інвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Піковий струм інвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Внутрішній рівень постійного струму інвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Неправильний вихідний рівень AC інвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Несправність інвертора(powerstage)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Інвертор підключений до мережі AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Не вдалося перевірити реле входу AC 1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Не вдалося перевірити реле входу AC 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Пристрій зник</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Несумісний пристрій</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Втрачено з’єднання BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Мережа неправильно налаштована</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Чергування фаз</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Кілька входів AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Перевантаження по фазі</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Помилка запису в пам'ять</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Занадто висока температура ЦП</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Втрачено зв'язок</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Дані калібрування втрачено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Несумісна прошивка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Несумісне обладнання</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Налаштування недійсні</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Збій контрольної напруги</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Помилка тестера</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Історія недійсна</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>лічильники кВт-год недійсні</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Помилка напруги DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Помилка датчика GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Помилка живлення 3.3В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Помилка живлення 5В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Помилка живлення 12В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Помилка живлення 15В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Вимкнення PV входу</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Щоб змінити налаштування, встановіть перемикач у розблоковане положення.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Використовувати джерело даних D-Bus: підключитися до вказаної адреси D-Bus.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>адреса</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Використовувати джерело даних D-Bus: підключитися до адреси D-Bus за умовчанням</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Використовувати джерело даних MQTT: підключитися до вказаної адреси брокера MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>адреса</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>Ідентифікатор порталу джерела даних MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <extracomment>seems like machine name, should not be translatable</extracomment>
-      <translation>ідентифікатор порталу ( portalId )</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Шард веб-хосту MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>shard</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>Ім’я користувача джерела даних MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>користувач</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>Пароль джерела даних MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>пароль</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>Токен джерела даних MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>токен</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>Увімкнути лічильник FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>Пропустити заставку</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Використовуйте макет джерела даних для тестування.</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>Пристрій вимкнено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>Змішаний старий/новий MK2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>Очікувана помилка пристроїв</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>Інші пристрої не виявлено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>Перенапруга на виході AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>Помилка програми DDC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>VE.Bus BMS без асистента</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>Не вдалося перевірити реле захисту від замикання на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>Помилка синхронізації системного часу</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>Не вдалося перевірити реле мережі</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>Невідповідність конфігурації другому мікроконтролеру</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>Помилка передачі пристрою</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>Очікується налаштування або відсутній адаптер</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>Відсутній Головний фази</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>Виникла перенапруга</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>Керований пристрій не має входу AC!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>Пристрій не може бути Керованим</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>Ініційовано захист системи</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>Несумісність мікропрограми</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>Внутрішня помилка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>Тест поламаного реле блокує звʼязок</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>Помилка VE.Bus</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>Невідома помилка:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>Внутрішня помилка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>Помилки немає</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>Висока температура батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>Висока напруга батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>Низька напруга батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>Напруга батареї перевищує налаштований максимум</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>Висока температура генератора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>Високі оберти генератора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>Висока температура польового транзистора FET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>Відсутній потрібний датчик</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>Низька напруга генератора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>Зміщення високої напруги генератора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>Напруга генератора перевищує налаштований максимум</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>Висока напруга генератора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>Батарею від’єднано</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>Від’єднання за високої напруги батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>Екземпляр батареї поза зоною</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>Надто багато BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>Батарея скоро від’єднається</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>Занадто багато пристроїв для відстеження</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>Від’єднання за низької напруги батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>Від’єднання за високого струму батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>Від’єднання за високої температури батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>Від’єднання за низької температури батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>Втрачено з’єднання BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC вимкнено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>Перетворювач пост. ст./пост. ст. не готовий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>Висока первинна напруга пост. ст./пост. ст.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>Низька первинна напруга пост. ст./пост. ст.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>Висока вторинна напруга пост. ст./пост. ст.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>Низька вторинна напруга пост. ст./пост. ст.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>Висока температура пост. ст./пост. ст.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>Неправильна конфігурація пост. ст./пост. ст.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>Несправний датчик температури батареї</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Невідома помилка:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>Невідома помилка:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>Помилки немає</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>Висока температура батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>Висока напруга батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>Неправильне підключення датчика температури батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>Відсутній датчик температури батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>Неправильне підключення датчика напруги батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>Відсутній датчик напруги батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>Високі втрати у проводах батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>Низька напруга батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>Висока напруга пульсації батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>Низький рівень заряду батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>Проблема із напругою в середній точці батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>Надто низька температура батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>Висока температура зарядного пристрою</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>Надмірний струм зарядного пристрою</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>Отрицательный ток зарядного устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>Час роботи зарядного пристрою закінчився</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>Проблема з датчиком струму зарядного пристрою</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>Внутрішній датчик температури підключено неправильно</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>Відсутній внутрішній датчик температури</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>Вентилятор зарядного пристрою не виявлено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>Перевищення струму вентилятора зарядного пристрою</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>Перегрів клеми зарядного пристрою</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>Коротке замикання зарядного пристрою</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>Проблема зі ступенем живлення зарядного пристрою</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>Захист від перезаряду</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>Вхідна висока напруга</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>Надмірний вхідний струм</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>Надмірна вхідна потужність</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>Проблема з полярністю входу</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>Вхідна напруга відсутня</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>Вимкнення входу (без повторних спроб)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>Вимкнення входу (повторна спроба)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>Внутрішня несправність входу</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>Збій ізоляції PV</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>Виявлено замикання на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>Перевантаження інвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>Надто висока температура інвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>Піковий струм інвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>Внутрішній рівень постійного струму інвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>Неправильний вихідний рівень AC інвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>Несправність інвертора(powerstage)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>Інвертор підключений до мережі AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>Не вдалося перевірити реле входу AC 1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>Не вдалося перевірити реле входу AC 2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>Пристрій зник</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>Несумісний пристрій</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>Втрачено з’єднання BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>Мережа неправильно налаштована</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>Чергування фаз</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>Кілька входів AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>Перевантаження по фазі</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>Помилка запису в пам&apos;ять</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>Занадто висока температура ЦП</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>Втрачено зв&apos;язок</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>Дані калібрування втрачено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>Несумісна прошивка</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>Несумісне обладнання</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>Налаштування недійсні</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>Збій контрольної напруги</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>Помилка тестера</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>Історія недійсна</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>лічильники кВт-год недійсні</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>Помилка напруги DC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>Помилка датчика GFCI</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>Помилка живлення 3.3В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>Помилка живлення 5В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>Помилка живлення 12В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>Помилка живлення 15В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>Вимкнення PV входу</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Невідома помилка:</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>Невідома помилка:</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Невідома помилка:</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Невідома помилка:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Помилки немає</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>Напруга AC L1 занадто низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>Надто низька напруга AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Напруга AC L1 надто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Напруга AC занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Частота AC L1 надто низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Занизька частота AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Частота AC L1 надто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Частота AC занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>AC L1 струм занадто високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>Занадто високий AC струм</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Потужність AC L1 надто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>Потужність AC занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Аварійна зупинка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Надто високий струм сервоприводу</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Надто низький тиск масла</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Надто високий тиск масла</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Занизька температура двигуна</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Надто висока температура двигуна</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Занизька температура обмотки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Надто висока температура обмотки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Занизька температура вихлопу</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Надто висока температура вихлопу</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Електронна температура низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Висока електронна температура</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Занадто низька напруга стартера</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Надто високий струм стартера</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Занадто низька напруга розжарення</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Занадто високий струм розжарювання</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Занадто висока напруга системи допомоги при холодному запуску</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Занадто високий струм системи допомоги при холодному запуску</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Занадто низька напруга магніту утримування палива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Надто високий струм магніту, що утримує паливо</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Занадто низька напруга на котушці електромагніту стоп-сигналу</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Високий струм утримування електромагнітної котушки зупинки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Занадто низька напруга на котушці електромагніту зупинки </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Занадто високий струм тягової котушки електромагнітної зупинки</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Занадто низька напруга вентилятора/водяного насоса</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Занадто високий струм вентилятора/водяного насоса</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Напруга датчика струму низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Високий струм датчика струму</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Занадто низька вихідна напруга підсилювача</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Надто високий вихідний струм підвищення</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Занадто низька напруга живлення шини</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Занадто високий струм живлення шини</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Занадто низька напруга батареї стартера</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Занадто висока напруга батареї стартера</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Обертання надто низьке</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Обертання занадто високе</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Несподівана зупинка/проблема з подачею палива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Занадто низька напруга силового контактора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Занадто високий струм силового контактора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>Напруга AC L2 занадто низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Напруга AC L2 занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>Частота AC L2 занадто низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Частота AC L2 занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>AC струм L2 занадто високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>Потужність AC L2 занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Напруга AC L3 занадто низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>Напруга AC L3 занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Частота AC L3 занадто низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Частота AC L3 занадто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>AC струм L3 занадто високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>Потужність AC L3 надто висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Вихідна напруга інвертора занадто низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Вихідний струм інвертора занадто високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Занадто низька напруга на універсальному виході (1А)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Занадто високий струм універсального виходу (1А)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Занадто низька напруга на універсальному виході (5А)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Занадто високий струм універсального виходу (5А)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Напруга постійного струму AGT 1 низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Напруга постійного струму AGT 1 висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT постійний струм 1 низький</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT постійний струм 1 високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Напруга постійного струму AGT 2 низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Напруга постійного струму AGT 2 висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT постійний струм 2 низький</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT постійний струм 2 високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 кулер низький</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 кулер високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 рейка (-) низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 рейка (-) висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 рейка (+) низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 рейка (+) висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Занизька температура палива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Надто висока температура палива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Занадто низький рівень палива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Втрачений блок управління</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Втрачена панель</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Потрібен сервіс</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Пропав 3-фазний модуль</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Втрачений модуль AGT</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Помилка синхронізації</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Загублений зовнішній блок управління</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Впускний повітряний фільтр</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Діагностичне повідомлення (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Втрачено модуль синхронізації</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Помилка балансування навантаження</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Режим синхронізації вимкнено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Червоний стоп-сигнал (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Янтарна сигнальна лампа (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Індикаторна лампа несправності (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Захисна лампа (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Поле обертання неправильне</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Збитий датчик рівня палива</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Запуск без інвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Шина №1 мертва.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Запит на запуск відхилено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Віддалений запуск заборонено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Реле примусового вимкнення навантаження</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Модуль синхронізації не працює</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Втрачено BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Перетворювач напруги ланки постійного струму Низька/Реверс</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Перетворювач постійного струму Низький струм ланки постійного струму</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Перетворювач постійного струму Напруга попереднього заряду низька</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Перетворювач постійного струму Напруга попереднього заряду Висока</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Помилка драйвера IGBT/MOSFET перетворювача Помилка драйвера IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Контур регулювання потужності помилки перетворювача</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Виявлення частоти AC перетворювача</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Помилка значення керування перетворювача</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Змінено заводські налаштування</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Параметр змінено в режимі адміністратора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Ручне втручання (додаткова система)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Помилка ініціалізації</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Сторожовий таймер</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Висока температура інвертора L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Висока температура інвертора L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Висока температура інвертора L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Висока температура інвертора в ланці постійного струму</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Перевантаження інвертора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Зв'язок інвертора втрачено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Перенавантаження постійним струмом</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Перенапруга постійного струму</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Немає зв'язку</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Помилки немає</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Невідома помилка: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Невідома помилка:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Тиск мастила</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Перегрів головки циліндра</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Контроль заряду</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Швидкість вища, ніж очікувалося</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Перевищення швидкості</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <extracomment>Oiltemperature seems like multiple errors in different strings</extracomment>
-      <translation type="unfinished">Температура оливи вища, ніж очікувалося</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation type="unfinished">Обрив ланцюга на температурі оливи / коротке замикання на живлення</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation type="unfinished">Температура оливи коротке замикання на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Аналогова точка потужності високе / коротке замикання на живлення</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Аналогова точка потужності низька / замикання на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Тайм-аут прийому повідомлення TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Тайм-аут прийому повідомлення CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Висока напруга батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Низька напруга батареї</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Сигнал швидкості спотворено</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Внутрішнє живлення датчика 5В високе</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Низький рівень живлення внутрішнього датчика 5В</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Барометричний тиск високий</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Барометричний тиск низький</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Вихідний паливний насос закорочений на живлення</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Вихідний паливний насос закорочений на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Вихідна свічка розжарювання закорочена на живлення</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Вихідна свічка розжарювання замкнена на землю</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Обрив інжектора / замикання на землю з нижньої сторони</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Внутрішнє коротке замикання котушки інжектора</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Нижня сторона інжектора замкнута на живлення</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Час обслуговування закінчився</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Несправність процесора</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>Невідома помилка:</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Батарея</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>Батарея</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Холодильник</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>Холодильник</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Загальне</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>Загальне</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Кімната</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>Кімната</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>На відкритому повітрі</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>На відкритому повітрі</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Водонагрівач</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>Водонагрівач</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Морозильна камера</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>Морозильна камера</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>Невідома помилка:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>Помилки немає</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>Напруга AC L1 занадто низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>Надто низька напруга AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>Напруга AC L1 надто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>Напруга AC занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>Частота AC L1 надто низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>Занизька частота AC</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>Частота AC L1 надто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>Частота AC занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>AC L1 струм занадто високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>Занадто високий AC струм</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>Потужність AC L1 надто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>Потужність AC занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>Аварійна зупинка</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>Надто високий струм сервоприводу</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>Надто низький тиск масла</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>Надто високий тиск масла</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>Занизька температура двигуна</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>Надто висока температура двигуна</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>Занизька температура обмотки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>Надто висока температура обмотки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>Занизька температура вихлопу</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>Надто висока температура вихлопу</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>Електронна температура низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>Висока електронна температура</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>Занадто низька напруга стартера</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>Надто високий струм стартера</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>Занадто низька напруга розжарення</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>Занадто високий струм розжарювання</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>Занадто висока напруга системи допомоги при холодному запуску</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>Занадто високий струм системи допомоги при холодному запуску</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>Занадто низька напруга магніту утримування палива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>Надто високий струм магніту, що утримує паливо</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>Занадто низька напруга на котушці електромагніту стоп-сигналу</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>Високий струм утримування електромагнітної котушки зупинки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>Занадто низька напруга на котушці електромагніту зупинки </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>Занадто високий струм тягової котушки електромагнітної зупинки</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>Занадто низька напруга вентилятора/водяного насоса</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>Занадто високий струм вентилятора/водяного насоса</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>Напруга датчика струму низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>Високий струм датчика струму</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>Занадто низька вихідна напруга підсилювача</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>Надто високий вихідний струм підвищення</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>Занадто низька напруга живлення шини</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>Занадто високий струм живлення шини</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>Занадто низька напруга батареї стартера</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>Занадто висока напруга батареї стартера</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>Обертання надто низьке</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>Обертання занадто високе</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>Несподівана зупинка/проблема з подачею палива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>Занадто низька напруга силового контактора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>Занадто високий струм силового контактора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>Напруга AC L2 занадто низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>Напруга AC L2 занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>Частота AC L2 занадто низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>Частота AC L2 занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>AC струм L2 занадто високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>Потужність AC L2 занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>Напруга AC L3 занадто низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>Напруга AC L3 занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>Частота AC L3 занадто низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>Частота AC L3 занадто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>AC струм L3 занадто високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>Потужність AC L3 надто висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>Вихідна напруга інвертора занадто низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>Вихідний струм інвертора занадто високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>Занадто низька напруга на універсальному виході (1А)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>Занадто високий струм універсального виходу (1А)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>Занадто низька напруга на універсальному виході (5А)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>Занадто високий струм універсального виходу (5А)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>Напруга постійного струму AGT 1 низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>Напруга постійного струму AGT 1 висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT постійний струм 1 низький</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT постійний струм 1 високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>Напруга постійного струму AGT 2 низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>Напруга постійного струму AGT 2 висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT постійний струм 2 низький</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT постійний струм 2 високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 кулер низький</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 кулер високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 рейка (-) низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 рейка (-) висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 рейка (+) низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 рейка (+) висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>Занизька температура палива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>Надто висока температура палива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>Занадто низький рівень палива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>Втрачений блок управління</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>Втрачена панель</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>Потрібен сервіс</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>Пропав 3-фазний модуль</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>Втрачений модуль AGT</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>Помилка синхронізації</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>Загублений зовнішній блок управління</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>Впускний повітряний фільтр</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>Діагностичне повідомлення (ECU)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>Втрачено модуль синхронізації</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>Помилка балансування навантаження</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>Режим синхронізації вимкнено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>Червоний стоп-сигнал (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>Янтарна сигнальна лампа (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>Індикаторна лампа несправності (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>Захисна лампа (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>Поле обертання неправильне</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>Збитий датчик рівня палива</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>Запуск без інвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>Шина №1 мертва.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>Запит на запуск відхилено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>Віддалений запуск заборонено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>Реле примусового вимкнення навантаження</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>Модуль синхронізації не працює</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>Втрачено BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>Перетворювач напруги ланки постійного струму Низька/Реверс</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>Перетворювач постійного струму Низький струм ланки постійного струму</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>Перетворювач постійного струму Напруга попереднього заряду низька</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>Перетворювач постійного струму Напруга попереднього заряду Висока</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>Помилка драйвера IGBT/MOSFET перетворювача Помилка драйвера IGBT/MOSFET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>Контур регулювання потужності помилки перетворювача</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>Виявлення частоти AC перетворювача</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>Помилка значення керування перетворювача</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>Змінено заводські налаштування</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>Параметр змінено в режимі адміністратора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>Ручне втручання (додаткова система)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>Помилка ініціалізації</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>Сторожовий таймер</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>Висока температура інвертора L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>Висока температура інвертора L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>Висока температура інвертора L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>Висока температура інвертора в ланці постійного струму</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>Перевантаження інвертора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>Зв&apos;язок інвертора втрачено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>Перенавантаження постійним струмом</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>Перенапруга постійного струму</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>Немає зв&apos;язку</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>Помилки немає</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>Невідома помилка: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>Невідома помилка:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>Тиск мастила</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>Перегрів головки циліндра</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>Контроль заряду</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>Швидкість вища, ніж очікувалося</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>Перевищення швидкості</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation type="unfinished">Температура оливи вища, ніж очікувалося</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation type="unfinished">Обрив ланцюга на температурі оливи / коротке замикання на живлення</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation type="unfinished">Температура оливи коротке замикання на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>Аналогова точка потужності високе / коротке замикання на живлення</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>Аналогова точка потужності низька / замикання на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>Тайм-аут прийому повідомлення TSC1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>Тайм-аут прийому повідомлення CM1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>Висока напруга батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>Низька напруга батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>Сигнал швидкості спотворено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>Внутрішнє живлення датчика 5В високе</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>Низький рівень живлення внутрішнього датчика 5В</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>Барометричний тиск високий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>Барометричний тиск низький</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>Вихідний паливний насос закорочений на живлення</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>Вихідний паливний насос закорочений на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>Вихідна свічка розжарювання закорочена на живлення</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>Вихідна свічка розжарювання замкнена на землю</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>Обрив інжектора / замикання на землю з нижньої сторони</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>Внутрішнє коротке замикання котушки інжектора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>Нижня сторона інжектора замкнута на живлення</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>Час обслуговування закінчився</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>Несправність процесора</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>Щоб змінити налаштування, встановіть перемикач у розблоковане положення.</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>Використовувати джерело даних D-Bus: підключитися до вказаної адреси D-Bus.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>адреса</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>Використовувати джерело даних D-Bus: підключитися до адреси D-Bus за умовчанням</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>Використовувати джерело даних MQTT: підключитися до вказаної адреси брокера MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>адреса</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>Ідентифікатор порталу джерела даних MQTT.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>ідентифікатор порталу ( portalId )</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>Шард веб-хосту MQTT VRM</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>shard</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>Ім’я користувача джерела даних MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>користувач</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>Пароль джерела даних MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>пароль</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>Токен джерела даних MQTT</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>токен</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>Увімкнути лічильник FPS</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>Пропустити заставку</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>Використовуйте макет джерела даних для тестування.</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>Стандартний час Марокко</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>Західно- і центральноафриканський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>Південноафриканський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>Стандартний час Намібії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>Стандартний час Єгипту</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Східноафриканський стандартний час</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>Аргентинський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>Східно- і Південноамериканський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>Стандартний час Гренландії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>Стандартний час Монтевідео</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>Ньюфаундлендський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>Південноамериканський східний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>Атлантичний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>Центральний бразильський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Тихоокеанський південноамериканський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>Парагвайський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>Південноамериканський західний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>Стандартний час Венесуели</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>Східний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>Південноамериканський тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>Східний стандартний час США</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>Канадський центральний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>Центральноамериканський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>Центральний стандартний час (Мексика)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>Центральний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>Гірський стандартний час (Мексика)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>Гірський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>Гірський стандартний час США</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>Тихоокеанський стандартний час (Мексика)</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>Тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>Аляскинський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>Гавайсько-алеутський</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Новозеландський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Центральний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Західний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Західноавстралійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Стандартний час Південно-Східної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Стандартний час Центральної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>Стандартний час Західної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>Східноафриканський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>Тихоокеанський південноамериканський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>Південноамериканський західний стандартний час</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Західноєвропейський стандартний час</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>Камчатський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>Магаданський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>Владивостоцький стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>Якутський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>Токійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>Корейський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>Сингапурський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>Стандартний час в Улан-Баторі</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>Стандартний час в Тайбеї</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>Східний стандартний час Північної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>Китайський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>Стандартний час Південно-Східної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>Стандартний час Північної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>Стандартний час М’янми</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>Стандартний час Північно-Центральної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>Стандартний час Центральної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>Стандартний час Бангладеш</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>Непальський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>Стандартний час Шрі-Ланки</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>Індійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>Стандартний час Західної Азії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>Пакистанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>Єкатеринбурзький стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>Грузинський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>Кавказький стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>Азербайджанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>Арабський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>Стандартний час в Афганістані</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>Іранський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>Аравійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>Аравійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>Сирійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>Близькосхідний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>Стандартний час Йорданії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>Ізраїльський стандартний час</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>Гринвіцький стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>Стандартний час на Азорських островах</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>Стандартний час Кабо-Верде</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>Стандартний час Тасманії</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>Східноавстралійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>Австралійський східний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>Центр. Австралійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>Австралійський центральний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>Західноавстралійський стандартний час</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>Середньоатлантичний стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>Стандартний час від лінії змін дат (DST)</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>Стандартний час GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>Стандартний час Центральної Європи</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>Центральноєвропейський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>Романський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>Західноєвропейський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>Східноєвропейський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>Стандартний час FLE</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>Стандартний час GTB</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>Білоруський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>Російський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>Стандартний час Туреччини</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>Маврикійський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>Стандартний час острова Різдва</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>Стандартний час Тонга</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>Стандартний час Фіджі</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>Новозеландський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>Центральний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>Західний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>Стандартний час Самоа</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>Гавайський стандартний час</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>Стандартний час острова Пасхи</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">Внутрішня помилка</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>Невідома помилка:</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>Внутрішня помилка</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>Помилки немає</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>Висока температура батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>Висока напруга батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>Низька напруга батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>Напруга батареї перевищує налаштований максимум</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>Висока температура генератора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>Високі оберти генератора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>Висока температура польового транзистора FET</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>Відсутній потрібний датчик</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>Низька напруга генератора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>Зміщення високої напруги генератора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>Напруга генератора перевищує налаштований максимум</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>Висока напруга генератора</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>Батарею від’єднано</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>Від’єднання за високої напруги батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>Екземпляр батареї поза зоною</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>Надто багато BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>Батарея скоро від’єднається</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>Занадто багато пристроїв для відстеження</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>Від’єднання за низької напруги батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>Від’єднання за високого струму батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>Від’єднання за високої температури батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>Від’єднання за низької температури батареї</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>Втрачено з’єднання BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC вимкнено</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>Перетворювач пост. ст./пост. ст. не готовий</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>Висока первинна напруга пост. ст./пост. ст.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>Низька первинна напруга пост. ст./пост. ст.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>Висока вторинна напруга пост. ст./пост. ст.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>Низька вторинна напруга пост. ст./пост. ст.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>Висока температура пост. ст./пост. ст.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>Неправильна конфігурація пост. ст./пост. ст.</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>Несправний датчик температури батареї</translation>
+    </message>
+</context>
 </TS>

--- a/i18n/venus-gui-v2_zh_CN.ts
+++ b/i18n/venus-gui-v2_zh_CN.ts
@@ -1,7381 +1,8023 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
-  <context>
+<context>
     <name></name>
     <message id="settings_tailscale_disabled">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
-      <source>Disabled</source>
-      <translation>已禁用</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="118"/>
+        <source>Disabled</source>
+        <translation>已禁用</translation>
     </message>
     <message id="common_words_inverter_overload">
-      <location filename="../../components/CommonWords.qml" line="225"/>
-      <source>Inverter overload</source>
-      <translation>逆变器过载</translation>
+        <location filename="../components/CommonWords.qml" line="225"/>
+        <source>Inverter overload</source>
+        <translation>逆变器过载</translation>
     </message>
     <message id="common_words_power_watts">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <source>Power</source>
-      <extracomment>Electric power, as measured in Watts</extracomment>
-      <translation>功率</translation>
+        <location filename="../components/CommonWords.qml" line="352"/>
+        <source>Power</source>
+        <extracomment>Electric power, as measured in Watts</extracomment>
+        <translation>功率</translation>
     </message>
     <message id="solarchargers_state_off">
-      <location filename="../../data/SolarChargers.qml" line="51"/>
-      <source>Off</source>
-      <translation>关</translation>
+        <location filename="../data/SolarChargers.qml" line="51"/>
+        <source>Off</source>
+        <translation>关</translation>
     </message>
     <message id="common_words_auto">
-      <location filename="../../components/CommonWords.qml" line="74"/>
-      <source>Auto</source>
-      <translation>自动</translation>
+        <location filename="../components/CommonWords.qml" line="74"/>
+        <source>Auto</source>
+        <translation>自动</translation>
+    </message>
+    <message id="common_words_battery">
+        <location filename="../components/CommonWords.qml" line="83"/>
+        <source>Battery</source>
+        <translation type="unfinished">电池</translation>
+    </message>
+    <message id="common_words_connected">
+        <location filename="../components/CommonWords.qml" line="113"/>
+        <source>Connected</source>
+        <translation type="unfinished">已连接</translation>
+    </message>
+    <message id="common_words_disconnected">
+        <location filename="../components/CommonWords.qml" line="146"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">已断开连接</translation>
+    </message>
+    <message id="common_words_generator">
+        <location filename="../components/CommonWords.qml" line="177"/>
+        <source>Generator</source>
+        <translation type="unfinished">发电机</translation>
     </message>
     <message id="common_words_high_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="186"/>
-      <source>High battery voltage</source>
-      <translation>电池电压高</translation>
+        <location filename="../components/CommonWords.qml" line="186"/>
+        <source>High battery voltage</source>
+        <translation>电池电压高</translation>
     </message>
     <message id="overview_widget_inverter_title">
-      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
-      <source>Inverter / Charger</source>
-      <translation>逆变器/充电器</translation>
+        <location filename="../components/widgets/InverterChargerWidget.qml" line="34"/>
+        <source>Inverter / Charger</source>
+        <translation>逆变器/充电器</translation>
     </message>
     <message id="common_words_low_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="234"/>
-      <source>Low battery voltage</source>
-      <translation>电池电压低</translation>
+        <location filename="../components/CommonWords.qml" line="234"/>
+        <source>Low battery voltage</source>
+        <translation>电池电压低</translation>
     </message>
     <message id="common_words_manual">
-      <location filename="../../components/CommonWords.qml" line="253"/>
-      <source>Manual</source>
-      <translation>手动</translation>
+        <location filename="../components/CommonWords.qml" line="253"/>
+        <source>Manual</source>
+        <translation>手动</translation>
     </message>
     <message id="settings_startpage_none">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation>无</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+        <source>None</source>
+        <translation>无</translation>
     </message>
     <message id="common_words_position_ac">
-      <location filename="../../components/CommonWords.qml" line="359"/>
-      <source>Position</source>
-      <extracomment>EVCS AC input/output position</extracomment>
-      <translation>位置</translation>
+        <location filename="../components/CommonWords.qml" line="359"/>
+        <source>Position</source>
+        <extracomment>AC input or output position</extracomment>
+        <translation>位置</translation>
     </message>
     <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="421"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation>速度</translation>
+        <location filename="../components/CommonWords.qml" line="421"/>
+        <source>Speed</source>
+        <extracomment>A speed measurement value</extracomment>
+        <translation>速度</translation>
     </message>
     <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="439"/>
-      <source>State</source>
-      <translation>状态</translation>
+        <location filename="../components/CommonWords.qml" line="439"/>
+        <source>State</source>
+        <translation>状态</translation>
     </message>
     <message id="settings_firmware_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>正在安装 %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="67"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>正在安装 %1...</translation>
     </message>
     <message id="splash_view_unknown_error">
-      <location filename="../../components/SplashView.qml" line="271"/>
-      <source>Unknown error</source>
-      <translation>未知错误</translation>
+        <location filename="../components/SplashView.qml" line="271"/>
+        <source>Unknown error</source>
+        <translation>未知错误</translation>
     </message>
     <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="50"/>
-      <source>Minimum SOC</source>
-      <translation>最小SOC</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="23"/>
+        <location filename="../pages/controlcards/ESSCard.qml" line="50"/>
+        <source>Minimum SOC</source>
+        <translation>最小SOC</translation>
+    </message>
+    <message id="settings_radio_button_group_unknown">
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="46"/>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
     </message>
     <message id="settings_radio_button_enter_password">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="175"/>
-      <source>Enter password</source>
-      <translation>输入密码</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="175"/>
+        <source>Enter password</source>
+        <translation>输入密码</translation>
     </message>
     <message id="settings_firmware_press_to_check">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="18"/>
-      <source>Press to check</source>
-      <translation>按下查看</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="18"/>
+        <source>Press to check</source>
+        <translation>按下查看</translation>
     </message>
     <message id="common_words_grid">
-      <location filename="../../components/CommonWords.qml" line="180"/>
-      <source>Grid</source>
-      <translation>电网</translation>
+        <location filename="../components/CommonWords.qml" line="180"/>
+        <source>Grid</source>
+        <translation>电网</translation>
     </message>
     <message id="overview_widget_solaryield_title">
-      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
-      <source>Solar yield</source>
-      <translation>太阳能发电量</translation>
+        <location filename="../components/widgets/SolarYieldWidget.qml" line="26"/>
+        <source>Solar yield</source>
+        <translation>太阳能发电量</translation>
     </message>
     <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="181"/>
-      <source>External control</source>
-      <translation>外部控制</translation>
+        <location filename="../data/System.qml" line="181"/>
+        <source>External control</source>
+        <translation>外部控制</translation>
     </message>
     <message id="levels_page_tanks">
-      <location filename="../../pages/LevelsPage.qml" line="53"/>
-      <source>Tanks</source>
-      <translation>水箱</translation>
+        <location filename="../pages/LevelsPage.qml" line="53"/>
+        <source>Tanks</source>
+        <translation>水箱</translation>
     </message>
     <message id="levels_page_environment">
-      <location filename="../../pages/LevelsPage.qml" line="55"/>
-      <source>Environment</source>
-      <translation>环境</translation>
+        <location filename="../pages/LevelsPage.qml" line="55"/>
+        <source>Environment</source>
+        <translation>环境</translation>
     </message>
     <message id="notifications_no_current_alerts">
-      <location filename="../../pages/NotificationsPage.qml" line="145"/>
-      <source>No current alerts</source>
-      <translation>无当前警报</translation>
+        <location filename="../pages/NotificationsPage.qml" line="145"/>
+        <source>No current alerts</source>
+        <translation>无当前警报</translation>
     </message>
     <message id="settings_bluetooth">
-      <location filename="../../pages/SettingsPage.qml" line="108"/>
-      <source>Bluetooth</source>
-      <translation>蓝牙</translation>
+        <location filename="../pages/SettingsPage.qml" line="108"/>
+        <source>Bluetooth</source>
+        <translation>蓝牙</translation>
     </message>
     <message id="settings_general">
-      <location filename="../../pages/SettingsPage.qml" line="34"/>
-      <source>General</source>
-      <translation>通用</translation>
+        <location filename="../pages/SettingsPage.qml" line="34"/>
+        <source>General</source>
+        <translation>通用</translation>
     </message>
     <message id="settings_firmware">
-      <location filename="../../pages/SettingsPage.qml" line="39"/>
-      <source>Firmware</source>
-      <translation>固件</translation>
+        <location filename="../pages/SettingsPage.qml" line="39"/>
+        <source>Firmware</source>
+        <translation>固件</translation>
     </message>
     <message id="settings_date_and_time">
-      <location filename="../../pages/SettingsPage.qml" line="44"/>
-      <source>Date &amp; Time</source>
-      <translation>日期 &amp;时间</translation>
+        <location filename="../pages/SettingsPage.qml" line="44"/>
+        <source>Date &amp; Time</source>
+        <translation>日期 &amp;时间</translation>
     </message>
     <message id="settings_system_setup">
-      <location filename="../../pages/SettingsPage.qml" line="49"/>
-      <source>System setup</source>
-      <translation>系统设置</translation>
+        <location filename="../pages/SettingsPage.qml" line="49"/>
+        <source>System setup</source>
+        <translation>系统设置</translation>
     </message>
     <message id="settings_system_dvcc">
-      <location filename="../../pages/SettingsPage.qml" line="54"/>
-      <source>DVCC</source>
-      <translation>DVCC</translation>
+        <location filename="../pages/SettingsPage.qml" line="54"/>
+        <source>DVCC</source>
+        <translation>DVCC</translation>
     </message>
     <message id="settings_display_and_language">
-      <location filename="../../pages/SettingsPage.qml" line="59"/>
-      <source>Display &amp; Language</source>
-      <translation>显示&amp;语言</translation>
+        <location filename="../pages/SettingsPage.qml" line="59"/>
+        <source>Display &amp; Language</source>
+        <translation>显示&amp;语言</translation>
     </message>
     <message id="settings_vrm_online_portal">
-      <location filename="../../pages/SettingsPage.qml" line="64"/>
-      <source>VRM online portal</source>
-      <translation>VRM在线门户</translation>
+        <location filename="../pages/SettingsPage.qml" line="64"/>
+        <source>VRM online portal</source>
+        <translation>VRM在线门户</translation>
     </message>
     <message id="common_words_ess">
-      <location filename="../../components/CommonWords.qml" line="171"/>
-      <source>ESS</source>
-      <translation>ESS储能系统</translation>
+        <location filename="../components/CommonWords.qml" line="171"/>
+        <source>ESS</source>
+        <translation>ESS储能系统</translation>
     </message>
     <message id="settings_energy_meters">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
-      <source>Energy meters</source>
-      <translation>电表</translation>
+        <location filename="../pages/SettingsPage.qml" line="73"/>
+        <source>Energy meters</source>
+        <translation>电表</translation>
     </message>
     <message id="settings_pv_inverters">
-      <location filename="../../pages/SettingsPage.qml" line="78"/>
-      <source>PV inverters</source>
-      <translation>光伏逆变器</translation>
+        <location filename="../pages/SettingsPage.qml" line="78"/>
+        <source>PV inverters</source>
+        <translation>光伏逆变器</translation>
     </message>
     <message id="settings_tailscale_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
-      <source>Ethernet</source>
-      <translation>以太网</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="103"/>
+        <source>Ethernet</source>
+        <translation>以太网</translation>
     </message>
     <message id="settings_wifi">
-      <location filename="../../pages/SettingsPage.qml" line="93"/>
-      <source>Wi-Fi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/SettingsPage.qml" line="93"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_gsm_modem">
-      <location filename="../../pages/SettingsPage.qml" line="98"/>
-      <source>GSM modem</source>
-      <translation>GSM调制解调器</translation>
+        <location filename="../pages/SettingsPage.qml" line="98"/>
+        <source>GSM modem</source>
+        <translation>GSM调制解调器</translation>
     </message>
     <message id="settings_gps">
-      <location filename="../../pages/SettingsPage.qml" line="103"/>
-      <source>GPS</source>
-      <translation>GPS</translation>
+        <location filename="../pages/SettingsPage.qml" line="103"/>
+        <source>GPS</source>
+        <translation>GPS</translation>
     </message>
     <message id="settings_generator_start_stop">
-      <location filename="../../pages/SettingsPage.qml" line="114"/>
-      <source>Generator start/stop</source>
-      <translation>发电机启/停</translation>
+        <location filename="../pages/SettingsPage.qml" line="114"/>
+        <source>Generator start/stop</source>
+        <translation>发电机启/停</translation>
     </message>
     <message id="settings_tank_pump">
-      <location filename="../../pages/SettingsPage.qml" line="120"/>
-      <source>Tank pump</source>
-      <translation>水箱泵</translation>
+        <location filename="../pages/SettingsPage.qml" line="120"/>
+        <source>Tank pump</source>
+        <translation>水箱泵</translation>
     </message>
     <message id="settings_services">
-      <location filename="../../pages/SettingsPage.qml" line="130"/>
-      <source>Services</source>
-      <translation>服务</translation>
+        <location filename="../pages/SettingsPage.qml" line="130"/>
+        <source>Services</source>
+        <translation>服务</translation>
     </message>
     <message id="settings_io">
-      <location filename="../../pages/SettingsPage.qml" line="135"/>
-      <source>I/O</source>
-      <translation>I/O</translation>
+        <location filename="../pages/SettingsPage.qml" line="135"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
     </message>
     <message id="settings_venus_os_large_features">
-      <location filename="../../pages/SettingsPage.qml" line="140"/>
-      <source>Venus OS Large features</source>
-      <translation>Venus OS 大版本功能</translation>
+        <location filename="../pages/SettingsPage.qml" line="140"/>
+        <source>Venus OS Large features</source>
+        <translation>Venus OS 大版本功能</translation>
     </message>
     <message id="ess_battery_life_limit">
-      <location filename="../../pages/controlcards/ESSCard.qml" line="69"/>
-      <source>Battery life limit: %1%</source>
-      <translation>电池寿命限制：%1%</translation>
+        <location filename="../pages/controlcards/ESSCard.qml" line="69"/>
+        <source>Battery life limit: %1%</source>
+        <translation>电池寿命限制：%1%</translation>
+    </message>
+    <message id="controlcard_generator_label_autostart">
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="60"/>
+        <source>Autostart</source>
+        <translation type="unfinished">自动启动</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_description">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
-      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
-      <translation>自动启动将被禁用，发电机不会根据配置的条件自动启动。</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="94"/>
+        <source>Autostart will be disabled and the generator won&apos;t automatically start based on the configured conditions.</source>
+        <translation>自动启动将被禁用，发电机不会根据配置的条件自动启动。</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_stop">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
-      <source>Manual Stop</source>
-      <translation>手动停止</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="34"/>
+        <source>Manual Stop</source>
+        <translation>手动停止</translation>
     </message>
     <message id="controlcard_generator_subcard_button_manual_start">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
-      <source>Manual Start</source>
-      <translation>手动启动</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="37"/>
+        <source>Manual Start</source>
+        <translation>手动启动</translation>
+    </message>
+    <message id="evcs_ac_position">
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="20"/>
+        <source>Position</source>
+        <extracomment>EVCS AC input/output position</extracomment>
+        <translation type="unfinished">位置</translation>
     </message>
     <message id="evcs_autostart">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="36"/>
-      <source>Autostart</source>
-      <translation>自动启动</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="36"/>
+        <source>Autostart</source>
+        <translation>自动启动</translation>
     </message>
     <message id="controlcard_switches">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
-      <source>Switches</source>
-      <translation>开关</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="16"/>
+        <source>Switches</source>
+        <translation>开关</translation>
     </message>
     <message id="settings_access_level">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
-      <source>Access level</source>
-      <translation>访问级别</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="75"/>
+        <source>Access level</source>
+        <translation>访问级别</translation>
     </message>
     <message id="settings_access_user">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
-      <source>User</source>
-      <translation>用户</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="80"/>
+        <source>User</source>
+        <translation>用户</translation>
     </message>
     <message id="settings_access_user_installer">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
-      <source>User &amp; Installer</source>
-      <translation>用户&amp;安装商</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="82"/>
+        <source>User &amp; Installer</source>
+        <translation>用户&amp;安装商</translation>
     </message>
     <message id="settings_access_superuser">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
-      <source>Superuser</source>
-      <translation>超级用户</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="84"/>
+        <source>Superuser</source>
+        <translation>超级用户</translation>
     </message>
     <message id="settings_access_service">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
-      <source>Service</source>
-      <translation>服务</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="86"/>
+        <source>Service</source>
+        <translation>服务</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="17"/>
+        <source>DVCC</source>
+        <translation type="unfinished">DVCC</translation>
     </message>
     <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
-      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
-      <translation>禁用 DVCC 后，确保重置 VE.Bus 系统</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="23"/>
+        <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+        <translation>禁用 DVCC 后，确保重置 VE.Bus 系统</translation>
     </message>
     <message id="settings_dvcc_limit_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
-      <source>Limit charge current</source>
-      <translation>限制充电电流</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="32"/>
+        <source>Limit charge current</source>
+        <translation>限制充电电流</translation>
     </message>
     <message id="settings_dvcc_max_charge_current">
-      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
-      <source>Maximum charge current</source>
-      <translation>最大充电电流</translation>
+        <location filename="../pages/settings/DvccCommonSettings.qml" line="44"/>
+        <source>Maximum charge current</source>
+        <translation>最大充电电流</translation>
     </message>
     <message id="generator_condition_use_value_to_start_stop">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
-      <source>Use %1 value to start/stop</source>
-      <translation>用%1数值启动/停止</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="21"/>
+        <source>Use %1 value to start/stop</source>
+        <translation>用%1数值启动/停止</translation>
     </message>
     <message id="generator_condition_start_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
-      <source>Start when %1 is higher than</source>
-      <translation>当 %1 高于时启动</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="24"/>
+        <source>Start when %1 is higher than</source>
+        <translation>当 %1 高于时启动</translation>
     </message>
     <message id="generator_condition_start_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
-      <source>Start when %1 is lower than</source>
-      <translation>当 %1 小于时启动</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="27"/>
+        <source>Start when %1 is lower than</source>
+        <translation>当 %1 小于时启动</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_higher_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
-      <source>Stop when %1 is higher than</source>
-      <translation>当 %1 大于时停止</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="32"/>
+        <source>Stop when %1 is higher than</source>
+        <translation>当 %1 大于时停止</translation>
     </message>
     <message id="generator_condition_stop_when_property_is_lower_than">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
-      <source>Stop when %1 is lower than</source>
-      <translation>当 %1 低于时停止</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="35"/>
+        <source>Stop when %1 is lower than</source>
+        <translation>当 %1 低于时停止</translation>
     </message>
     <message id="settings_fronius_remove_ip_address">
-      <location filename="../../pages/settings/IpAddressListView.qml" line="51"/>
-      <source>Remove IP address?</source>
-      <translation>删除 IP 地址？</translation>
+        <location filename="../pages/settings/IpAddressListView.qml" line="53"/>
+        <source>Remove IP address?</source>
+        <translation>删除 IP 地址？</translation>
     </message>
     <message id="settings_dvcc_max">
-      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
-      <source>Max: %1</source>
-      <translation>最大值：%1</translation>
+        <location filename="../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+        <source>Max: %1</source>
+        <translation>最大值：%1</translation>
     </message>
     <message id="settings_deviceinfo_connection">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
-      <source>Connection</source>
-      <translation>连接</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="22"/>
+        <source>Connection</source>
+        <translation>连接</translation>
     </message>
     <message id="settings_deviceinfo_product">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
-      <source>Product</source>
-      <translation>产品</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="49"/>
+        <source>Product</source>
+        <translation>产品</translation>
     </message>
     <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
-      <source>Name</source>
-      <translation>名字</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+        <source>Name</source>
+        <translation>名字</translation>
+    </message>
+    <message id="settings_deviceinfo_name">
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="56"/>
+        <source>Name</source>
+        <translation type="unfinished">名字</translation>
     </message>
     <message id="settings_deviceinfo_product_id">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="66"/>
-      <source>Product ID</source>
-      <translation>产品ID</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="66"/>
+        <source>Product ID</source>
+        <translation>产品ID</translation>
     </message>
     <message id="settings_deviceinfo_hardware_version">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="79"/>
-      <source>Hardware version</source>
-      <translation>硬件版本</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="79"/>
+        <source>Hardware version</source>
+        <translation>硬件版本</translation>
     </message>
     <message id="settings_deviceinfo_device_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="100"/>
-      <source>Device name</source>
-      <translation>设备名</translation>
+        <location filename="../pages/settings/PageDeviceInfo.qml" line="100"/>
+        <source>Device name</source>
+        <translation>设备名</translation>
     </message>
     <message id="settings_remote_switch_control_disabled">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="17"/>
-      <source>Remote switch control disabled</source>
-      <translation>遥控开关控制已禁用</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="17"/>
+        <source>Remote switch control disabled</source>
+        <translation>遥控开关控制已禁用</translation>
     </message>
     <message id="settings_generator_in_fault_condition">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="19"/>
-      <source>Generator in fault condition</source>
-      <translation>发电机处于错误状态</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="19"/>
+        <source>Generator in fault condition</source>
+        <translation>发电机处于错误状态</translation>
     </message>
     <message id="settings_generator_not_detected">
-      <location filename="../../components/settings/ListGeneratorError.qml" line="21"/>
-      <source>Generator not detected at AC input</source>
-      <translation>交流输入未检测到发电机</translation>
+        <location filename="../components/settings/ListGeneratorError.qml" line="21"/>
+        <source>Generator not detected at AC input</source>
+        <translation>交流输入未检测到发电机</translation>
     </message>
     <message id="settings_page_run_time_and_service_accumulated_running_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
-      <source>Accumulated running time since last test run</source>
-      <translation>上次试运行后的累计运行时间</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+        <source>Accumulated running time since last test run</source>
+        <translation>上次试运行后的累计运行时间</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_next_test_run">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
-      <source>Time to next test run</source>
-      <translation>下次试运行时间</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+        <source>Time to next test run</source>
+        <translation>下次试运行时间</translation>
     </message>
     <message id="settings_page_run_time_and_service_running_now">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
-      <source>Running now</source>
-      <translation>现在运行</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+        <source>Running now</source>
+        <translation>现在运行</translation>
     </message>
     <message id="common_words_manual_start">
-      <location filename="../../components/CommonWords.qml" line="259"/>
-      <source>Manual start</source>
-      <translation>手动启动</translation>
+        <location filename="../components/CommonWords.qml" line="259"/>
+        <source>Manual start</source>
+        <translation>手动启动</translation>
     </message>
     <message id="page_generator_conditions_start_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="64"/>
-      <source>Start generator</source>
-      <translation>启动发电机</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="64"/>
+        <source>Start generator</source>
+        <translation>启动发电机</translation>
     </message>
     <message id="settings_page_run_time_and_service_daily_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
-      <source>Daily run time</source>
-      <translation>每日运行时间</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+        <source>Daily run time</source>
+        <translation>每日运行时间</translation>
     </message>
     <message id="value_must_be_greater_than_stop_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
-      <source>Value must be greater than stop value</source>
-      <translation>数值必须大于停止值</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+        <source>Value must be greater than stop value</source>
+        <translation>数值必须大于停止值</translation>
     </message>
     <message id="value_must_be_lower_than_start_value">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
-      <source>Value must be lower than start value</source>
-      <translation>数值必须低于启动值</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+        <source>Value must be lower than start value</source>
+        <translation>数值必须低于启动值</translation>
     </message>
     <message id="settings_minmax_acout_max_power">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
-      <source>AC output</source>
-      <translation>交流输出</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+        <source>AC output</source>
+        <translation>交流输出</translation>
+    </message>
+    <message id="ac_output">
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="29"/>
+        <source>AC output</source>
+        <translation type="unfinished">交流输出</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
-      <source>Use AC Load to start/stop</source>
-      <translation>用交流负载启停</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+        <source>Use AC Load to start/stop</source>
+        <translation>用交流负载启停</translation>
     </message>
     <message id="page_generator_ac_load_measurement">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
-      <source>Measurement</source>
-      <translation>测量</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+        <source>Measurement</source>
+        <translation>测量</translation>
     </message>
     <message id="total_consumption">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
-      <source>Total consumption</source>
-      <translation>合计消耗</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+        <source>Total consumption</source>
+        <translation>合计消耗</translation>
     </message>
     <message id="total_ac_out">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
-      <source>Inverter total AC out</source>
-      <translation>逆变器总交流输出</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+        <source>Inverter total AC out</source>
+        <translation>逆变器总交流输出</translation>
     </message>
     <message id="ac_out_highest_phase">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
-      <source>Inverter AC out highest phase</source>
-      <translation>逆变器交流输出最高相位</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+        <source>Inverter AC out highest phase</source>
+        <translation>逆变器交流输出最高相位</translation>
     </message>
     <message id="start_when_power_is_higher_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
-      <source>Start when power is higher than</source>
-      <translation>当功率高于时启动</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+        <source>Start when power is higher than</source>
+        <translation>当功率高于时启动</translation>
     </message>
     <message id="stop_when_power_is_lower_than">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
-      <source>Stop when power is lower than</source>
-      <translation>当功率低于时停止</translation>
+        <location filename="../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+        <source>Stop when power is lower than</source>
+        <translation>当功率低于时停止</translation>
     </message>
     <message id="settings_system_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="126"/>
-      <source>Battery monitor</source>
-      <translation>电池监测器</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="126"/>
+        <source>Battery monitor</source>
+        <translation>电池监测器</translation>
     </message>
     <message id="settings_system_unavailable_monitor">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="129"/>
-      <source>Unavailable monitor, set another</source>
-      <translation>监测仪不可用，设置另一监测仪</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="129"/>
+        <source>Unavailable monitor, set another</source>
+        <translation>监测仪不可用，设置另一监测仪</translation>
+    </message>
+    <message id="page_generator_conditions_battery_monitor">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="49"/>
+        <source>Battery monitor</source>
+        <translation type="unfinished">电池监测器</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_monitor_set_another">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="51"/>
+        <source>Unavailable monitor, set another</source>
+        <translation type="unfinished">监测仪不可用，设置另一监测仪</translation>
     </message>
     <message id="page_generator_conditions_on_loss_of_communication">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="58"/>
-      <source>On loss of communication</source>
-      <translation>一旦通讯丢失</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="58"/>
+        <source>On loss of communication</source>
+        <translation>一旦通讯丢失</translation>
     </message>
     <message id="page_generator_conditions_stop_generator">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="62"/>
-      <source>Stop generator</source>
-      <translation>停止发电机</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="62"/>
+        <source>Stop generator</source>
+        <translation>停止发电机</translation>
     </message>
     <message id="page_generator_conditions_keep_generator_running">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="66"/>
-      <source>Keep generator running</source>
-      <translation>发电机保持运行</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="66"/>
+        <source>Keep generator running</source>
+        <translation>发电机保持运行</translation>
     </message>
     <message id="page_generator_conditions_stop_generator_when_ac_input_available">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
-      <source>Stop generator when AC-input is available</source>
-      <translation>交流输入可用时停止发电机</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="72"/>
+        <source>Stop generator when AC-input is available</source>
+        <translation>交流输入可用时停止发电机</translation>
     </message>
     <message id="page_generator_conditions_battery_soc">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="95"/>
-      <source>Battery SOC</source>
-      <translation>电池SOC</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="95"/>
+        <source>Battery SOC</source>
+        <translation>电池SOC</translation>
+    </message>
+    <message id="page_generator_conditions_inverter_high_temperature">
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="129"/>
+        <source>Inverter high temperature</source>
+        <translation type="unfinished">逆变器高温</translation>
     </message>
     <message id="settings_inverter_high_temperature">
-      <location filename="../../data/Generators.qml" line="91"/>
-      <source>Inverter high temperature</source>
-      <translation>逆变器高温</translation>
+        <location filename="../data/Generators.qml" line="91"/>
+        <source>Inverter high temperature</source>
+        <translation>逆变器高温</translation>
     </message>
     <message id="page_generator_conditions_start_on_high_temperature_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="131"/>
-      <source>Start on high temperature warning</source>
-      <translation>在高温警报下启动</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="131"/>
+        <source>Start on high temperature warning</source>
+        <translation>在高温警报下启动</translation>
     </message>
     <message id="page_generator_conditions_start_on_overload_warning">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="140"/>
-      <source>Start on overload warning</source>
-      <translation>在过载警报下启动</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="140"/>
+        <source>Start on overload warning</source>
+        <translation>在过载警报下启动</translation>
     </message>
     <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="149"/>
-      <source>Periodic run</source>
-      <translation>定期运行</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="149"/>
+        <source>Periodic run</source>
+        <translation>定期运行</translation>
     </message>
     <message id="run_interval">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
-      <source>Run interval</source>
-      <translation>运行间隔</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+        <source>Run interval</source>
+        <translation>运行间隔</translation>
     </message>
     <message id="page_generator_test_run_days">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
-      <source>%1 day(s)</source>
-      <translation>%1天</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+        <source>%1 day(s)</source>
+        <translation>%1天</translation>
     </message>
     <message id="page_generator_test_run_skip_run">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
-      <source>Skip run if has been running for</source>
-      <translation>如果已经运行，跳过运行</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+        <source>Skip run if has been running for</source>
+        <translation>如果已经运行，跳过运行</translation>
     </message>
     <message id="page_generator_test_run_start_always">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
-      <source>Start always</source>
-      <translation>始终启动</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+        <source>Start always</source>
+        <translation>始终启动</translation>
     </message>
     <message id="page_generator_test_run_run_interval_start_date">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
-      <source>Run interval start date</source>
-      <translation>运行间隔开始日期</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+        <source>Run interval start date</source>
+        <translation>运行间隔开始日期</translation>
     </message>
     <message id="page_generator_test_run_run_duration">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
-      <source>Run duration (hh:mm)</source>
-      <translation>运行时间（小时:分钟）</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+        <source>Run duration (hh:mm)</source>
+        <translation>运行时间（小时:分钟）</translation>
     </message>
     <message id="page_generator_test_run_run_until_fully_charged">
-      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
-      <source>Run until battery is fully charged</source>
-      <translation>运行直到电池充满电</translation>
+        <location filename="../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+        <source>Run until battery is fully charged</source>
+        <translation>运行直到电池充满电</translation>
     </message>
     <message id="settings_gps_ok_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="45"/>
-      <source>GPS OK (fix)</source>
-      <translation>GPS正常（定位)</translation>
+        <location filename="../pages/settings/PageGps.qml" line="45"/>
+        <source>GPS OK (fix)</source>
+        <translation>GPS正常（定位)</translation>
     </message>
     <message id="settings_gps_ok_no_fix">
-      <location filename="../../pages/settings/PageGps.qml" line="48"/>
-      <source>GPS connected, but no GPS fix</source>
-      <translation>GPS已连接，但无定位</translation>
+        <location filename="../pages/settings/PageGps.qml" line="48"/>
+        <source>GPS connected, but no GPS fix</source>
+        <translation>GPS已连接，但无定位</translation>
     </message>
     <message id="settings_gps_not_connected">
-      <location filename="../../pages/settings/PageGps.qml" line="51"/>
-      <source>No GPS connected</source>
-      <translation>未连接GPS</translation>
+        <location filename="../pages/settings/PageGps.qml" line="51"/>
+        <source>No GPS connected</source>
+        <translation>未连接GPS</translation>
     </message>
     <message id="settings_gps_latitude">
-      <location filename="../../pages/settings/PageGps.qml" line="57"/>
-      <source>Latitude</source>
-      <translation>纬度</translation>
+        <location filename="../pages/settings/PageGps.qml" line="57"/>
+        <source>Latitude</source>
+        <translation>纬度</translation>
     </message>
     <message id="settings_gps_longitude">
-      <location filename="../../pages/settings/PageGps.qml" line="64"/>
-      <source>Longitude</source>
-      <translation>经度</translation>
+        <location filename="../pages/settings/PageGps.qml" line="64"/>
+        <source>Longitude</source>
+        <translation>经度</translation>
     </message>
     <message id="settings_gps_speed_kmh">
-      <location filename="../../pages/settings/PageGps.qml" line="79"/>
-      <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometers per hour</extracomment>
-      <translation>%1 公里/小时</translation>
+        <location filename="../pages/settings/PageGps.qml" line="79"/>
+        <source>%1 km/h</source>
+        <extracomment>GPS speed data, in kilometers per hour</extracomment>
+        <translation>%1 公里/小时</translation>
     </message>
     <message id="settings_gps_speed_mph">
-      <location filename="../../pages/settings/PageGps.qml" line="83"/>
-      <source>%1 mph</source>
-      <extracomment>GPS speed data, in miles per hour</extracomment>
-      <translation>%1 英里/小时</translation>
+        <location filename="../pages/settings/PageGps.qml" line="83"/>
+        <source>%1 mph</source>
+        <extracomment>GPS speed data, in miles per hour</extracomment>
+        <translation>%1 英里/小时</translation>
     </message>
     <message id="settings_gps_speed_kt">
-      <location filename="../../pages/settings/PageGps.qml" line="87"/>
-      <source>%1 kt</source>
-      <extracomment>GPS speed data, in knots</extracomment>
-      <translation>%1 kt</translation>
+        <location filename="../pages/settings/PageGps.qml" line="87"/>
+        <source>%1 kt</source>
+        <extracomment>GPS speed data, in knots</extracomment>
+        <translation>%1 kt</translation>
     </message>
     <message id="settings_gps_speed_ms">
-      <location filename="../../pages/settings/PageGps.qml" line="91"/>
-      <source>%1 m/s</source>
-      <extracomment>GPS speed data, in meters per second</extracomment>
-      <translation>%1 米/秒</translation>
+        <location filename="../pages/settings/PageGps.qml" line="91"/>
+        <source>%1 m/s</source>
+        <extracomment>GPS speed data, in meters per second</extracomment>
+        <translation>%1 米/秒</translation>
     </message>
     <message id="settings_gps_course">
-      <location filename="../../pages/settings/PageGps.qml" line="98"/>
-      <source>Course</source>
-      <translation>航向</translation>
+        <location filename="../pages/settings/PageGps.qml" line="98"/>
+        <source>Course</source>
+        <translation>航向</translation>
     </message>
     <message id="settings_gps_altitude">
-      <location filename="../../pages/settings/PageGps.qml" line="105"/>
-      <source>Altitude</source>
-      <translation>海拔</translation>
+        <location filename="../pages/settings/PageGps.qml" line="105"/>
+        <source>Altitude</source>
+        <translation>海拔</translation>
     </message>
     <message id="settings_gps_num_satellites">
-      <location filename="../../pages/settings/PageGps.qml" line="111"/>
-      <source>Number of satellites</source>
-      <translation>卫星数量</translation>
+        <location filename="../pages/settings/PageGps.qml" line="111"/>
+        <source>Number of satellites</source>
+        <translation>卫星数量</translation>
     </message>
     <message id="settings_ess_debug_grid_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
-      <source>Grid Setpoint</source>
-      <translation>电网设定点</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="15"/>
+        <source>Grid Setpoint</source>
+        <translation>电网设定点</translation>
     </message>
     <message id="settings_ess_debug_ac_in_setpoint">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="44"/>
-      <source>AC-In setpoint</source>
-      <translation>交流输入设定点</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="44"/>
+        <source>AC-In setpoint</source>
+        <translation>交流输入设定点</translation>
     </message>
     <message id="settings_ess_debug_battery_current">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="53"/>
-      <source>Current: %1</source>
-      <extracomment>Battery current, in amps</extracomment>
-      <translation>电流：%1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="53"/>
+        <source>Current: %1</source>
+        <extracomment>Battery current, in amps</extracomment>
+        <translation>电流：%1</translation>
     </message>
     <message id="settings_ess_debug_battery_voltage">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="56"/>
-      <source>Voltage: %1</source>
-      <extracomment>Battery voltage, in volts</extracomment>
-      <translation>电压： %1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="56"/>
+        <source>Voltage: %1</source>
+        <extracomment>Battery voltage, in volts</extracomment>
+        <translation>电压： %1</translation>
     </message>
     <message id="settings_ess_debug_limits_i">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="72"/>
-      <source>Limits (I)</source>
-      <translation>限值 (I)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="72"/>
+        <source>Limits (I)</source>
+        <translation>限值 (I)</translation>
     </message>
     <message id="settings_ess_debug_battery_charge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="75"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="96"/>
-      <source>Charge: %1</source>
-      <translation>充电：%1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="75"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="96"/>
+        <source>Charge: %1</source>
+        <translation>充电：%1</translation>
     </message>
     <message id="settings_ess_debug_battery_discharge">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
-      <source>Discharge: %1</source>
-      <translation>放电：%1</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="77"/>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="98"/>
+        <source>Discharge: %1</source>
+        <translation>放电：%1</translation>
     </message>
     <message id="settings_ess_debug_limits_p">
-      <location filename="../../pages/settings/PageHub4Debug.qml" line="93"/>
-      <source>Limits (P)</source>
-      <translation>限值 (P)</translation>
+        <location filename="../pages/settings/PageHub4Debug.qml" line="93"/>
+        <source>Limits (P)</source>
+        <translation>限值 (P)</translation>
     </message>
     <message id="settings_batteries_battery_visible">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
-      <source>Visible</source>
-      <translation>可见</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="15"/>
+        <source>Visible</source>
+        <translation>可见</translation>
     </message>
     <message id="settings_batteries_battery_hidden">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
-      <source>Hidden</source>
-      <translation>隐藏</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="17"/>
+        <source>Hidden</source>
+        <translation>隐藏</translation>
     </message>
     <message id="settings_batteries_battery_auxiliary_measurement">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
-      <source>%1 (Auxiliary measurement)</source>
-      <translation>%1（辅助测量）</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="62"/>
+        <source>%1 (Auxiliary measurement)</source>
+        <translation>%1（辅助测量）</translation>
     </message>
     <message id="settings_batteries_battery_output">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
-      <source>%1 (Output %2)</source>
-      <translation>%1（输出%2）</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="64"/>
+        <source>%1 (Output %2)</source>
+        <translation>%1（输出%2）</translation>
     </message>
     <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation>主动式电池监测器</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="88"/>
+        <source>Active battery monitor</source>
+        <translation>主动式电池监测器</translation>
+    </message>
+    <message id="settings_batteries_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="100"/>
+        <source>Name</source>
+        <translation type="unfinished">名字</translation>
+    </message>
+    <message id="settings_batteries_enter_name">
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="102"/>
+        <source>Enter name</source>
+        <translation type="unfinished">输入名称</translation>
     </message>
     <message id="settings_system_enter_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
-      <source>Enter name</source>
-      <translation>输入名称</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="62"/>
+        <source>Enter name</source>
+        <translation>输入名称</translation>
     </message>
     <message id="settings_continuous_scan">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
-      <source>Continuous scanning</source>
-      <translation>连续扫描</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+        <source>Continuous scanning</source>
+        <translation>连续扫描</translation>
     </message>
     <message id="settings_io_bluetooth_adapters">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
-      <source>Bluetooth adapters</source>
-      <translation>蓝牙适配器</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+        <source>Bluetooth adapters</source>
+        <translation>蓝牙适配器</translation>
     </message>
     <message id="settings_pincode">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
-      <source>Pincode</source>
-      <translation>PIN码</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+        <source>Pincode</source>
+        <translation>PIN码</translation>
     </message>
     <message id="settings_bluetooth_remove_existing_pairing_info">
-      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
-      <source>It might be necessary to remove existing pairing information before connecting.</source>
-      <translation>连接之前，可能需要删除现有配对信息。</translation>
+        <location filename="../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+        <source>It might be necessary to remove existing pairing information before connecting.</source>
+        <translation>连接之前，可能需要删除现有配对信息。</translation>
     </message>
     <message id="settings_cgwacs_phase_type">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
-      <source>Phase type</source>
-      <translation>相位类型</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+        <source>Phase type</source>
+        <translation>相位类型</translation>
     </message>
     <message id="settings_single_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
-      <source>Single phase</source>
-      <translation>单相</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+        <source>Single phase</source>
+        <translation>单相</translation>
     </message>
     <message id="settings_multi_phase">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
-      <source>Multi phase</source>
-      <translation>多相</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+        <source>Multi phase</source>
+        <translation>多相</translation>
     </message>
     <message id="settings_pv_inverter_on_phase_2">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
-      <source>PV inverter on phase 2</source>
-      <translation>第2相光伏逆变器</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+        <source>PV inverter on phase 2</source>
+        <translation>第2相光伏逆变器</translation>
     </message>
     <message id="settings_cgwacs_pv_inverter_l2_position">
-      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
-      <source>PV inverter on phase 2 Position</source>
-      <translation>第2相光伏逆变器位置</translation>
+        <location filename="../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+        <source>PV inverter on phase 2 Position</source>
+        <translation>第2相光伏逆变器位置</translation>
     </message>
     <message id="settings_canbus_profile">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
-      <source>CAN-bus profile</source>
-      <translation>CAN总线配置文件</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="60"/>
+        <source>CAN-bus profile</source>
+        <translation>CAN总线配置文件</translation>
+    </message>
+    <message id="settings_disabled">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished">已禁用</translation>
     </message>
     <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS(250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="70"/>
+        <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; Lynx Ion BMS(250 kbit/s)</translation>
     </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
-      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; CAN-bus BMS(250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="76"/>
+        <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+        <translation>VE.Can &amp; CAN-bus BMS(250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
-      <source>Oceanvolt (250 kbit/s)</source>
-      <translation>Oceanvolt (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="94"/>
+        <source>Oceanvolt (250 kbit/s)</source>
+        <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
-      <source>RV-C (250 kbit/s)</source>
-      <translation>RV-C (250 kbit/s)</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="100"/>
+        <source>RV-C (250 kbit/s)</source>
+        <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
-      <source>Up, but no services (250 kbit/s)</source>
-      <translation>正常运行，但无服务（250 kbit/s）</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="106"/>
+        <source>Up, but no services (250 kbit/s)</source>
+        <translation>正常运行，但无服务（250 kbit/s）</translation>
     </message>
     <message id="settings_devices">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
-      <source>Devices</source>
-      <translation>设备</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="121"/>
+        <source>Devices</source>
+        <translation>设备</translation>
     </message>
     <message id="settings_canbus_nmea2000out">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
-      <source>NMEA2000-out</source>
-      <translation>NMEA2000输出</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="136"/>
+        <source>NMEA2000-out</source>
+        <translation>NMEA2000输出</translation>
     </message>
     <message id="settings_canbus_unique_id_select">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
-      <source>Unique identity number selector</source>
-      <translation>唯一ID编号选择器</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="143"/>
+        <source>Unique identity number selector</source>
+        <translation>唯一ID编号选择器</translation>
     </message>
     <message id="settings_canbus_unique_id_wait">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
-      <source>Please wait, changing and checking the unique number takes a while</source>
-      <translation>请稍候，更改和检查唯一编号需要时间</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="161"/>
+        <source>Please wait, changing and checking the unique number takes a while</source>
+        <translation>请稍候，更改和检查唯一编号需要时间</translation>
     </message>
     <message id="settings_canbus_unique_id_vecan_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
-      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
-      <translation>以上选择器设置 PGN 60928 NAME 字段中 NAME 唯一标识号使用的唯一标识号块。只有在一个 VE.Can 网络中使用多个 GX 设备时才可更改。</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="152"/>
+        <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+        <translation>以上选择器设置 PGN 60928 NAME 字段中 NAME 唯一标识号使用的唯一标识号块。只有在一个 VE.Can 网络中使用多个 GX 设备时才可更改。</translation>
     </message>
     <message id="settings_canbus_unique_id_rvc_description">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
-      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
-      <translation>以上选择器设置 DGN 60928 ADDRESS_CLAIM 字段中的序列号要使用哪个唯一标识号块。仅在一个 RV-C 网络中使用多个 GX 设备时更改。</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="155"/>
+        <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+        <translation>以上选择器设置 DGN 60928 ADDRESS_CLAIM 字段中的序列号要使用哪个唯一标识号块。仅在一个 RV-C 网络中使用多个 GX 设备时更改。</translation>
     </message>
     <message id="settings_canbus_unique_id_choose">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
-      <source>Check Unique id numbers</source>
-      <translation>检查唯一ID编号</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="178"/>
+        <source>Check Unique id numbers</source>
+        <translation>检查唯一ID编号</translation>
+    </message>
+    <message id="settings_canbus_unique_id_press_to_check">
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="183"/>
+        <source>Press to check</source>
+        <translation type="unfinished">按下查看</translation>
     </message>
     <message id="settings_canbus_unique_id_conflict">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
-      <source>There is another device connected with this unique number, please select a new number.</source>
-      <translation>此唯一号码已连接了其他设备，请选择新号码。</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="196"/>
+        <source>There is another device connected with this unique number, please select a new number.</source>
+        <translation>此唯一号码已连接了其他设备，请选择新号码。</translation>
     </message>
     <message id="settings_canbus_unique_id_ok">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
-      <source>OK: No other device is connected with this unique number.</source>
-      <translation>可以：没有其他设备与此唯一编号连接。</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="204"/>
+        <source>OK: No other device is connected with this unique number.</source>
+        <translation>可以：没有其他设备与此唯一编号连接。</translation>
     </message>
     <message id="common_words_network_status">
-      <location filename="../../components/CommonWords.qml" line="295"/>
-      <source>Network status</source>
-      <translation>网络状态</translation>
+        <location filename="../components/CommonWords.qml" line="295"/>
+        <source>Network status</source>
+        <translation>网络状态</translation>
     </message>
     <message id="settings_adaptive_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
-      <source>Adaptive brightness</source>
-      <translation>自适应亮度</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="20"/>
+        <source>Adaptive brightness</source>
+        <translation>自适应亮度</translation>
     </message>
     <message id="settings_brightness">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
-      <source>Brightness</source>
-      <translation>亮度</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="27"/>
+        <source>Brightness</source>
+        <translation>亮度</translation>
     </message>
     <message id="settings_display_off_time">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
-      <source>Display off time</source>
-      <translation>关闭显示时间</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="35"/>
+        <source>Display off time</source>
+        <translation>关闭显示时间</translation>
     </message>
     <message id="settings_displayoff_10sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
-      <source>10 sec</source>
-      <translation>10秒</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="41"/>
+        <source>10 sec</source>
+        <translation>10秒</translation>
     </message>
     <message id="settings_displayoff_30sec">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
-      <source>30 sec</source>
-      <translation>30秒</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="43"/>
+        <source>30 sec</source>
+        <translation>30秒</translation>
     </message>
     <message id="settings_1_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="94"/>
-      <source>1 min</source>
-      <translation>1分钟</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="95"/>
+        <source>1 min</source>
+        <translation>1分钟</translation>
     </message>
     <message id="settings_10_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="98"/>
-      <source>10 min</source>
-      <translation>10分钟</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="99"/>
+        <source>10 min</source>
+        <translation>10分钟</translation>
     </message>
     <message id="settings_30_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="102"/>
-      <source>30 min</source>
-      <translation>30分钟</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="103"/>
+        <source>30 min</source>
+        <translation>30分钟</translation>
     </message>
     <message id="settings_startpage_timeout_never">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
-      <source>Never</source>
-      <translation>从不</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+        <source>Never</source>
+        <translation>从不</translation>
     </message>
     <message id="settings_display_color_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
-      <source>Display mode</source>
-      <translation>显示模式</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="58"/>
+        <source>Display mode</source>
+        <translation>显示模式</translation>
     </message>
     <message id="settings_display_dark_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
-      <source>Dark</source>
-      <extracomment>Dark colors mode</extracomment>
-      <translation>深色</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="62"/>
+        <source>Dark</source>
+        <extracomment>Dark colors mode</extracomment>
+        <translation>深色</translation>
     </message>
     <message id="settings_display_light_mode">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
-      <source>Light</source>
-      <extracomment>Light colors mode</extracomment>
-      <translation>浅色</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="65"/>
+        <source>Light</source>
+        <extracomment>Light colors mode</extracomment>
+        <translation>浅色</translation>
     </message>
     <message id="settings_brief_view_levels">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
-      <source>Brief view levels</source>
-      <translation>概要视图水平</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="76"/>
+        <source>Brief view levels</source>
+        <translation>概要视图水平</translation>
     </message>
     <message id="settings_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
-      <source>Language</source>
-      <translation>语言</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="84"/>
+        <source>Language</source>
+        <translation>语言</translation>
     </message>
     <message id="settings_language_changing_language">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
-      <source>Changing language</source>
-      <translation>更改语言</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="136"/>
+        <source>Changing language</source>
+        <translation>更改语言</translation>
     </message>
     <message id="settings_units_energy">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
-      <source>Electrical power display</source>
-      <translation>电能显示</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+        <source>Electrical power display</source>
+        <translation>电能显示</translation>
     </message>
     <message id="settings_units_watts">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
-      <source>Power (Watts)</source>
-      <translation>功率（瓦）</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+        <source>Power (Watts)</source>
+        <translation>功率（瓦）</translation>
     </message>
     <message id="settings_units_amps">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
-      <source>Current (Amps)</source>
-      <translation>电流（安培）</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+        <source>Current (Amps)</source>
+        <translation>电流（安培）</translation>
     </message>
     <message id="settings_units">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
-      <source>Units</source>
-      <translation>单位</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="156"/>
+        <source>Units</source>
+        <translation>单位</translation>
     </message>
     <message id="settings_briefview_level">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
-      <source>Level %1</source>
-      <extracomment>Level number</extracomment>
-      <translation>水平 %1</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+        <source>Level %1</source>
+        <extracomment>Level number</extracomment>
+        <translation>水平 %1</translation>
     </message>
     <message id="settings_units_celsius">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
-      <source>Celsius</source>
-      <translation>摄氏 (°C)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+        <source>Celsius</source>
+        <translation>摄氏 (°C)</translation>
     </message>
     <message id="settings_units_fahrenheit">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
-      <source>Fahrenheit</source>
-      <translation>华氏度</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+        <source>Fahrenheit</source>
+        <translation>华氏度</translation>
     </message>
     <message id="settings_dvcc_instructions">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
-      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
-      <translation>&lt;b&gt;注意：&lt;/b&gt;调整前请阅读手册。</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="19"/>
+        <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+        <translation>&lt;b&gt;注意：&lt;/b&gt;调整前请阅读手册。</translation>
     </message>
     <message id="settings_dvcc_limit_managed_battery_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
-      <source>Limit managed battery charge voltage</source>
-      <translation>限制电池充电电压</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="40"/>
+        <source>Limit managed battery charge voltage</source>
+        <translation>限制电池充电电压</translation>
     </message>
     <message id="settings_dvcc_max_charge_voltage">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
-      <source>Maximum charge voltage</source>
-      <translation>最大充电电压</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="52"/>
+        <source>Maximum charge voltage</source>
+        <translation>最大充电电压</translation>
     </message>
     <message id="settings_dvcc_shared_voltage_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
-      <source>SVS - Shared voltage sense</source>
-      <translation>SVS - 共享电压感测</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="62"/>
+        <source>SVS - Shared voltage sense</source>
+        <translation>SVS - 共享电压感测</translation>
     </message>
     <message id="settings_dvcc_shared_temp_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
-      <source>STS - Shared temperature sense</source>
-      <translation>STS -共享温度感测</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="71"/>
+        <source>STS - Shared temperature sense</source>
+        <translation>STS -共享温度感测</translation>
     </message>
     <message id="settings_tank_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
-      <source>Unavailable sensor, set another</source>
-      <translation>传感器不可用，请另设置一个</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="70"/>
+        <source>Unavailable sensor, set another</source>
+        <translation>传感器不可用，请另设置一个</translation>
+    </message>
+    <message id="settings_system_unavailable_sensor">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="82"/>
+        <source>Unavailable sensor, set another</source>
+        <translation type="unfinished">传感器不可用，请另设置一个</translation>
     </message>
     <message id="settings_dvcc_used_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
-      <source>Used sensor</source>
-      <translation>使用过的传感器</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="103"/>
+        <source>Used sensor</source>
+        <translation>使用过的传感器</translation>
     </message>
     <message id="settings_dvcc_shared_current_sense">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
-      <source>SCS - Shared current sense</source>
-      <translation>SCS 共用电流感应</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="115"/>
+        <source>SCS - Shared current sense</source>
+        <translation>SCS 共用电流感应</translation>
     </message>
     <message id="settings_dvcc_scs_status">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
-      <source>SCS status</source>
-      <translation>SCS状态</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="122"/>
+        <source>SCS status</source>
+        <translation>SCS状态</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_external_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
-      <source>Disabled (external control)</source>
-      <translation>已禁用（外部控制）</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="130"/>
+        <source>Disabled (external control)</source>
+        <translation>已禁用（外部控制）</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_chargers">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
-      <source>Disabled (no chargers)</source>
-      <translation>已禁用（无充电器）</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="132"/>
+        <source>Disabled (no chargers)</source>
+        <translation>已禁用（无充电器）</translation>
     </message>
     <message id="settings_dvcc_scs_disabled_no_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
-      <source>Disabled (no battery monitor)</source>
-      <translation>已禁用（无电池监测器）</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="134"/>
+        <source>Disabled (no battery monitor)</source>
+        <translation>已禁用（无电池监测器）</translation>
     </message>
     <message id="settings_dvcc_auto_selection">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
-      <source>Automatic selection</source>
-      <translation>自动选择</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="144"/>
+        <source>Automatic selection</source>
+        <translation>自动选择</translation>
     </message>
     <message id="settings_dvcc_no_bms_control">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
-      <source>No BMS control</source>
-      <translation>无 BMS 控制</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="146"/>
+        <source>No BMS control</source>
+        <translation>无 BMS 控制</translation>
     </message>
     <message id="settings_dvcc_controlling_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
-      <source>Controlling BMS</source>
-      <translation>控制BMS</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="150"/>
+        <source>Controlling BMS</source>
+        <translation>控制BMS</translation>
     </message>
     <message id="settings_dvcc_unavailable_bms">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
-      <source>Unavailable, set another</source>
-      <extracomment>Shown when BMS instance is invalid</extracomment>
-      <translation>不可用，设置另一个</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="156"/>
+        <source>Unavailable, set another</source>
+        <extracomment>Shown when BMS instance is invalid</extracomment>
+        <translation>不可用，设置另一个</translation>
     </message>
     <message id="settings_dvcc_auto_selected">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
-      <source>Auto selected</source>
-      <translation>自动选择</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="186"/>
+        <source>Auto selected</source>
+        <translation>自动选择</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected_none">
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="192"/>
+        <source>None</source>
+        <extracomment>Indicates no option is selected</extracomment>
+        <translation type="unfinished">无</translation>
     </message>
     <message id="settings_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
-      <source>Build date/time</source>
-      <translation>构建日期/时间</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="27"/>
+        <source>Build date/time</source>
+        <translation>构建日期/时间</translation>
     </message>
     <message id="settings_online_updates">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
-      <source>Online updates</source>
-      <translation>在线更新</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="33"/>
+        <source>Online updates</source>
+        <translation>在线更新</translation>
     </message>
     <message id="settings_install_firmware_from_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
-      <source>Install firmware from SD/USB</source>
-      <translation>从SD/USB安装固件</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="41"/>
+        <source>Install firmware from SD/USB</source>
+        <translation>从SD/USB安装固件</translation>
     </message>
     <message id="settings_stored_backup_firmware">
-      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
-      <source>Stored backup firmware</source>
-      <translation>已保存备份固件</translation>
+        <location filename="../pages/settings/PageSettingsFirmware.qml" line="49"/>
+        <source>Stored backup firmware</source>
+        <translation>已保存备份固件</translation>
     </message>
     <message id="settings_firmware_check_for_updates_on_sd_usb">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
-      <source>Check for updates on SD/USB</source>
-      <translation>检查 SD/USB 上的更新</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+        <source>Check for updates on SD/USB</source>
+        <translation>检查 SD/USB 上的更新</translation>
     </message>
     <message id="settings_firmware_found">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
-      <source>Firmware found</source>
-      <translation>固件已找到</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+        <source>Firmware found</source>
+        <translation>固件已找到</translation>
     </message>
     <message id="settings_firmware_offline_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
-      <source>Installing %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>正在安装 %1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+        <source>Installing %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>正在安装 %1</translation>
+    </message>
+    <message id="settings_firmware_offline_press_to_install">
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">按下更新到%1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>按下更新到%1</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+        <source>Press to update to %1</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>按下更新到%1</translation>
     </message>
     <message id="settings_firmware_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
-      <source>Firmware build date/time</source>
-      <translation>更新构建日期/时间</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+        <source>Firmware build date/time</source>
+        <translation>更新构建日期/时间</translation>
     </message>
     <message id="settings_auto_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
-      <source>Auto update</source>
-      <translation>自动更新</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+        <source>Auto update</source>
+        <translation>自动更新</translation>
     </message>
     <message id="settings_firmware_check_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
-      <source>Check only</source>
-      <translation>只查看</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+        <source>Check only</source>
+        <translation>只查看</translation>
     </message>
     <message id="settings_firmware_check_and_download_only">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
-      <source>Check and download only</source>
-      <translation>只查看和下载</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+        <source>Check and download only</source>
+        <translation>只查看和下载</translation>
     </message>
     <message id="settings_firmware_check_and_update">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
-      <source>Check and update</source>
-      <translation>查看和更新</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+        <source>Check and update</source>
+        <translation>查看和更新</translation>
     </message>
     <message id="settings_update_feed">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
-      <source>Update feed</source>
-      <translation>更新feed信息源</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+        <source>Update feed</source>
+        <translation>更新feed信息源</translation>
     </message>
     <message id="settings_firmware_image_type">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
-      <source>Image type</source>
-      <translation>固件类型</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+        <source>Image type</source>
+        <translation>固件类型</translation>
     </message>
     <message id="settings_firmware_normal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
-      <source>Normal</source>
-      <translation>正常</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+        <source>Normal</source>
+        <translation>正常</translation>
     </message>
     <message id="settings_firmware_large">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
-      <source>Large</source>
-      <translation>大版本</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+        <source>Large</source>
+        <translation>大版本</translation>
     </message>
     <message id="settings_firmware_check_for_updates">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
-      <source>Check for updates</source>
-      <translation>查看更新</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+        <source>Check for updates</source>
+        <translation>查看更新</translation>
     </message>
     <message id="settings_firmware_update_available">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
-      <source>Update available</source>
-      <translation>可用更新</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+        <source>Update available</source>
+        <translation>可用更新</translation>
     </message>
     <message id="settings_firmware_online_installing_progress">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
-      <source>Installing %1 %2%</source>
-      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>正在安装 %1 %2%</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+        <source>Installing %1 %2%</source>
+        <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+        <translation>正在安装 %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_online_installing">
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="89"/>
+        <source>Installing %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation type="unfinished">正在安装 %1...</translation>
     </message>
     <message id="settings_firmware_update_build_date_time">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
-      <source>Update build date/time</source>
-      <translation>更新构建日期/时间</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+        <source>Update build date/time</source>
+        <translation>更新构建日期/时间</translation>
     </message>
     <message id="page_settings_fronius_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
-      <source>Inverters</source>
-      <translation>逆变器</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="30"/>
+        <source>Inverters</source>
+        <translation>逆变器</translation>
     </message>
     <message id="page_settings_fronius_find_pv_inverters">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
-      <source>Find PV inverters</source>
-      <translation>找到光伏逆变器</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="36"/>
+        <source>Find PV inverters</source>
+        <translation>找到光伏逆变器</translation>
     </message>
     <message id="page_settings_fronius_detected_ip_addresses">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
-      <source>Detected IP addresses</source>
-      <translation>检测到的IP地址</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="43"/>
+        <source>Detected IP addresses</source>
+        <translation>检测到的IP地址</translation>
     </message>
     <message id="page_settings_fronius_add_ip_address_manually">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
-      <source>Add IP address manually</source>
-      <translation>手动添加IP地址</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="49"/>
+        <source>Add IP address manually</source>
+        <translation>手动添加IP地址</translation>
     </message>
     <message id="page_settings_fronius_tcp_port">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
-      <source>TCP port</source>
-      <translation>TCP端口</translation>
+        <location filename="../pages/settings/PageSettingsFronius.qml" line="55"/>
+        <source>TCP port</source>
+        <translation>TCP端口</translation>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
-      <source>Multiphase</source>
-      <translation>多相</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="30"/>
+        <source>Multiphase</source>
+        <translation>多相</translation>
     </message>
     <message id="page_settings_fronius_inverter_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
-      <source>L1</source>
-      <translation>L1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="40"/>
+        <source>L1</source>
+        <translation>L1</translation>
     </message>
     <message id="page_settings_fronius_inverter_l2">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
-      <source>L2</source>
-      <translation>L2</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="42"/>
+        <source>L2</source>
+        <translation>L2</translation>
     </message>
     <message id="page_settings_fronius_inverter_l3">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
-      <source>L3</source>
-      <translation>L3</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="44"/>
+        <source>L3</source>
+        <translation>L3</translation>
     </message>
     <message id="page_settings_fronius_inverter_split_phase">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
-      <source>Split-phase (L1+L2)</source>
-      <translation>分相(L1+L2)</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+        <source>Split-phase (L1+L2)</source>
+        <translation>分相(L1+L2)</translation>
     </message>
     <message id="page_settings_fronius_inverter_show">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
-      <source>Show</source>
-      <translation>显示</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverter.qml" line="53"/>
+        <source>Show</source>
+        <translation>显示</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
-      <source>AC-In1 MP</source>
-      <translation>AC-In1 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="43"/>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="99"/>
+        <source>AC-In1 MP</source>
+        <translation>AC-In1 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
-      <source>AC-In1 L%1</source>
-      <translation>AC-In1 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+        <source>AC-In1 L%1</source>
+        <translation>AC-In1 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in1_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
-      <source>AC-In1 --</source>
-      <translation>AC-In1 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="109"/>
+        <source>AC-In1 --</source>
+        <translation>AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
-      <source>AC-Out MP</source>
-      <translation>交流输出 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="61"/>
+        <source>AC-Out MP</source>
+        <translation>交流输出 MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="49"/>
+        <source>AC-In1 L%1</source>
+        <translation type="unfinished">AC-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="53"/>
+        <source>AC-In1 --</source>
+        <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
-      <source>AC-Out L%1</source>
-      <translation>交流输出 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+        <source>AC-Out L%1</source>
+        <translation>交流输出 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
-      <source>AC-Out --</source>
-      <translation>交流输出 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="71"/>
+        <source>AC-Out --</source>
+        <translation>交流输出 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_mp">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
-      <source>AC-In2 MP</source>
-      <translation>AC-In2 MP</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="80"/>
+        <source>AC-In2 MP</source>
+        <translation>AC-In2 MP</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_l1">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
-      <source>AC-In2 L%1</source>
-      <translation>AC-In2 L%1</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+        <source>AC-In2 L%1</source>
+        <translation>AC-In2 L%1</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
-      <source>AC-In2 --</source>
-      <translation>AC-In2 --</translation>
+        <location filename="../pages/settings/PageSettingsFroniusInverters.qml" line="90"/>
+        <source>AC-In2 --</source>
+        <translation>AC-In2 --</translation>
     </message>
     <message id="settings_fronius_rescan_title">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
-      <source>Rescan for IP addresses?</source>
-      <translation>重新扫描 IP 地址？</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+        <source>Rescan for IP addresses?</source>
+        <translation>重新扫描 IP 地址？</translation>
     </message>
     <message id="settings_fronius_rescan">
-      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
-      <source>Rescan</source>
-      <translation>重新扫描</translation>
+        <location filename="../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+        <source>Rescan</source>
+        <translation>重新扫描</translation>
     </message>
     <message id="settings_ssh_on_lan">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
-      <source>SSH on LAN</source>
-      <translation>LAN上的SSH</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="240"/>
+        <source>SSH on LAN</source>
+        <translation>LAN上的SSH</translation>
     </message>
     <message id="settings_remote_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
-      <source>Remote support</source>
-      <translation>远程支持</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="249"/>
+        <source>Remote support</source>
+        <translation>远程支持</translation>
     </message>
     <message id="settings_remote_support_tunnel">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
-      <source>Remote support tunnel</source>
-      <translation>远程支持通道</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="255"/>
+        <source>Remote support tunnel</source>
+        <translation>远程支持通道</translation>
     </message>
     <message id="settings_remote_ip_and_support">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
-      <source>Remote support IP and port</source>
-      <translation>远程支持IP和端口</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="264"/>
+        <source>Remote support IP and port</source>
+        <translation>远程支持IP和端口</translation>
+    </message>
+    <message id="settings_logout_now">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="273"/>
+        <source>Log out now</source>
+        <translation type="unfinished">立即退出</translation>
     </message>
     <message id="settings_reboot_now">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
-      <source>Reboot now</source>
-      <translation>立即重启</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="300"/>
+        <source>Reboot now</source>
+        <translation>立即重启</translation>
+    </message>
+    <message id="dialoglayer_rebooted">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="328"/>
+        <source>Device has been rebooted.</source>
+        <translation type="unfinished">设备已重启。</translation>
     </message>
     <message id="settings_audible_alarm">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
-      <source>Audible alarm</source>
-      <translation>声音报警</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="340"/>
+        <source>Audible alarm</source>
+        <translation>声音报警</translation>
     </message>
     <message id="settings_demo_mode">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
-      <source>Demo mode</source>
-      <translation>演示模式</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="359"/>
+        <source>Demo mode</source>
+        <translation>演示模式</translation>
     </message>
     <message id="page_settings_demo_ess">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
-      <source>ESS demo</source>
-      <translation>ESS演示</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="368"/>
+        <source>ESS demo</source>
+        <translation>ESS演示</translation>
     </message>
     <message id="page_settings_demo_1">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
-      <source>Boat/Motorhome demo 1</source>
-      <translation>船/房车演示1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="370"/>
+        <source>Boat/Motorhome demo 1</source>
+        <translation>船/房车演示1</translation>
     </message>
     <message id="page_settings_demo_2">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
-      <source>Boat/Motorhome demo 2</source>
-      <translation>船/房车演示2</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="372"/>
+        <source>Boat/Motorhome demo 2</source>
+        <translation>船/房车演示2</translation>
     </message>
     <message id="settings_demo_mode_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
-      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
-      <translation>开始演示模式会更改某些设置，用户界面短时间没有反应。</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="382"/>
+        <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+        <translation>开始演示模式会更改某些设置，用户界面短时间没有反应。</translation>
     </message>
     <message id="page_settings_generator_conditions">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
-      <source>Conditions</source>
-      <translation>条件</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="29"/>
+        <source>Conditions</source>
+        <translation>条件</translation>
     </message>
     <message id="page_settings_generator_minimum_run_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
-      <source>Minimum run time</source>
-      <translation>最小运行时间</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="35"/>
+        <source>Minimum run time</source>
+        <translation>最小运行时间</translation>
     </message>
     <message id="page_settings_generator_warm_up_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
-      <source>Warm-up time</source>
-      <translation>预热时间</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="56"/>
+        <source>Warm-up time</source>
+        <translation>预热时间</translation>
     </message>
     <message id="page_settings_generator_cool_down_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
-      <source>Cool-down time</source>
-      <translation>冷却时间</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="65"/>
+        <source>Cool-down time</source>
+        <translation>冷却时间</translation>
     </message>
     <message id="page_settings_generator_detect_generator_at_ac_input">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
-      <source>Detect generator at AC input</source>
-      <translation>交流输入检测发电机</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="89"/>
+        <source>Detect generator at AC input</source>
+        <translation>交流输入检测发电机</translation>
     </message>
     <message id="page_settings_generator_detect_generator_not_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
-      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
-      <translation>没有在任何交流输入上设置发电机。前往系统设置页，设置正确的发电机交流输入，以便启用该功能。</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="96"/>
+        <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+        <translation>没有在任何交流输入上设置发电机。前往系统设置页，设置正确的发电机交流输入，以便启用该功能。</translation>
     </message>
     <message id="page_settings_generator_detect_generator_set">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
-      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
-      <translation>如果在逆变器交流输入，检测不到发电机功率，就会触发警报。确保在系统设置页面设置正确的发电机交流输入。</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="100"/>
+        <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+        <translation>如果在逆变器交流输入，检测不到发电机功率，就会触发警报。确保在系统设置页面设置正确的发电机交流输入。</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_start_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
-      <source>Quiet hours start time</source>
-      <translation>安静时间之起始时间</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="142"/>
+        <source>Quiet hours start time</source>
+        <translation>安静时间之起始时间</translation>
     </message>
     <message id="page_settings_generator_quiet_hours_end_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
-      <source>Quiet hours end time</source>
-      <translation>安静时间之终止时间</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="150"/>
+        <source>Quiet hours end time</source>
+        <translation>安静时间之终止时间</translation>
     </message>
     <message id="page_settings_generator_run_time_and_service">
-      <location filename="../../components/PageGensetModel.qml" line="290"/>
-      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
-      <source>Run time and service</source>
-      <translation>运行时和服务</translation>
+        <location filename="../components/PageGensetModel.qml" line="290"/>
+        <location filename="../pages/settings/PageGenerator.qml" line="110"/>
+        <source>Run time and service</source>
+        <translation>运行时和服务</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
-      <source>Reset daily run time counters</source>
-      <translation>复位每日运行时间计数器</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+        <source>Reset daily run time counters</source>
+        <translation>复位每日运行时间计数器</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
-      <source>The daily runtime counter has been reset</source>
-      <translation>每日运行时间计数器已复位</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+        <source>The daily runtime counter has been reset</source>
+        <translation>每日运行时间计数器已复位</translation>
     </message>
     <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
-      <source>It is not possible to modify the counters while the generator is running</source>
-      <translation>发电机运行时不可修改计数器</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+        <source>It is not possible to modify the counters while the generator is running</source>
+        <translation>发电机运行时不可修改计数器</translation>
     </message>
     <message id="page_settings_generator_service_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
-      <source>Generator service interval (hours)</source>
-      <translation>发电机维修间隔（小时）</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+        <source>Generator service interval (hours)</source>
+        <translation>发电机维修间隔（小时）</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_interval">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
-      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
-      <translation>服务时间间隔设置为 %1h。使用 "重置服务计时器 "按钮重置服务计时器。</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+        <source>Service time interval set to %1h. Use the &apos;Reset service timer&apos; button to reset the service timer.</source>
+        <translation>服务时间间隔设置为 %1h。使用 &quot;重置服务计时器 &quot;按钮重置服务计时器。</translation>
     </message>
     <message id="page_settings_run_time_and_service_reset_service_timer">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
-      <source>Reset service timer</source>
-      <translation>重置服务计时器</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+        <source>Reset service timer</source>
+        <translation>重置服务计时器</translation>
     </message>
     <message id="settings_gps_settings">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
-      <source>GPS Settings</source>
-      <translation>GPS设置</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="67"/>
+        <source>GPS Settings</source>
+        <translation>GPS设置</translation>
     </message>
     <message id="settings_gps_format">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
-      <source>Format</source>
-      <extracomment>Format of reported GPS data</extracomment>
-      <translation>格式</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="81"/>
+        <source>Format</source>
+        <extracomment>Format of reported GPS data</extracomment>
+        <translation>格式</translation>
     </message>
     <message id="settings_gps_format_dms_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
-      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
-      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
-      <translation>北纬52° 20' 41.6"，东经5° 13' 12.3"</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="86"/>
+        <source>52° 20&apos; 41.6&quot; N, 5° 13&apos; 12.3&quot; E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees, Minutes, Seconds&apos; format</extracomment>
+        <translation>北纬52° 20&apos; 41.6&quot;，东经5° 13&apos; 12.3&quot;</translation>
     </message>
     <message id="settings_gps_format_dd_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
-      <source>52.34489, 5.22008</source>
-      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
-      <translation>52.34489, 5.22008</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="89"/>
+        <source>52.34489, 5.22008</source>
+        <extracomment>Example of GPS data in the &apos;Decimal Degrees&apos; format</extracomment>
+        <translation>52.34489, 5.22008</translation>
     </message>
     <message id="settings_gps_format_dm_example">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
-      <source>52° 20.693 N, 5° 13.205 E</source>
-      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
-      <translation>北纬52° 20.693，东经5° 13.205</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="92"/>
+        <source>52° 20.693 N, 5° 13.205 E</source>
+        <extracomment>Example of GPS data in the &apos;Degrees Minutes&apos; format</extracomment>
+        <translation>北纬52° 20.693，东经5° 13.205</translation>
     </message>
     <message id="settings_gps_speed_unit">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
-      <source>Speed Unit</source>
-      <extracomment>Speed unit for reported GPS data</extracomment>
-      <translation>速度单位</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="99"/>
+        <source>Speed Unit</source>
+        <extracomment>Speed unit for reported GPS data</extracomment>
+        <translation>速度单位</translation>
     </message>
     <message id="settings_gps_format_kmh">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
-      <source>Kilometers per hour</source>
-      <translation>公里/小时</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="103"/>
+        <source>Kilometers per hour</source>
+        <translation>公里/小时</translation>
     </message>
     <message id="settings_gps_format_ms">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
-      <source>Meters per second</source>
-      <translation>米/秒</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="105"/>
+        <source>Meters per second</source>
+        <translation>米/秒</translation>
     </message>
     <message id="settings_gps_format_mph">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
-      <source>Miles per hour</source>
-      <translation>英里每小时</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="107"/>
+        <source>Miles per hour</source>
+        <translation>英里每小时</translation>
     </message>
     <message id="settings_gps_format_kt">
-      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
-      <source>Knots</source>
-      <translation>节</translation>
+        <location filename="../pages/settings/PageSettingsGpsList.qml" line="109"/>
+        <source>Knots</source>
+        <translation>节</translation>
     </message>
     <message id="page_settings_no_gsm_modem_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
-      <source>No GSM modem connected</source>
-      <translation>未连接GSM调制解调器</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="40"/>
+        <source>No GSM modem connected</source>
+        <translation>未连接GSM调制解调器</translation>
     </message>
     <message id="page_settings_gsm_internet">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
-      <source>Internet</source>
-      <translation>互联网</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="51"/>
+        <source>Internet</source>
+        <translation>互联网</translation>
     </message>
     <message id="page_settings_gsm_carrier">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
-      <source>Carrier</source>
-      <translation>手机运营商</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="60"/>
+        <source>Carrier</source>
+        <translation>手机运营商</translation>
     </message>
     <message id="page_settings_gsm_error_message">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
-      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
-If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
-      <translation>可能需要配置本页下面的APN设置，详情请联系运营商。
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="86"/>
+        <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn&apos;t work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+        <translation>可能需要配置本页下面的APN设置，详情请联系运营商。
 如果不行的话，请检查手机中的SIM卡，确保有话费和/或已注册，可用于数据业务。</translation>
     </message>
     <message id="page_settings_gsm_allow_roaming">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
-      <source>Allow roaming</source>
-      <translation>允许漫游</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="92"/>
+        <source>Allow roaming</source>
+        <translation>允许漫游</translation>
     </message>
     <message id="page_settings_gsm_sim_status">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
-      <source>Sim status</source>
-      <translation>SIM卡状态</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="99"/>
+        <source>Sim status</source>
+        <translation>SIM卡状态</translation>
     </message>
     <message id="page_settings_gsm_sim_not_inserted">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
-      <source>SIM not inserted</source>
-      <translation>未插入SIM卡</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="104"/>
+        <source>SIM not inserted</source>
+        <translation>未插入SIM卡</translation>
     </message>
     <message id="page_settings_gsm_pin_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
-      <source>PIN required</source>
-      <translation>需要PIN码</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="107"/>
+        <source>PIN required</source>
+        <translation>需要PIN码</translation>
     </message>
     <message id="page_settings_gsm_puk_required">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
-      <source>PUK required</source>
-      <translation>需要PUK码</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="110"/>
+        <source>PUK required</source>
+        <translation>需要PUK码</translation>
     </message>
     <message id="page_settings_gsm_sim_failure">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
-      <source>SIM failure</source>
-      <translation>SIM卡故障</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="113"/>
+        <source>SIM failure</source>
+        <translation>SIM卡故障</translation>
     </message>
     <message id="page_settings_gsm_sim_busy">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
-      <source>SIM busy</source>
-      <translation>SIM忙</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="116"/>
+        <source>SIM busy</source>
+        <translation>SIM忙</translation>
     </message>
     <message id="page_settings_gsm_wrong_sim">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
-      <source>Wrong SIM</source>
-      <translation>错误的SIM卡</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="119"/>
+        <source>Wrong SIM</source>
+        <translation>错误的SIM卡</translation>
     </message>
     <message id="page_settings_gsm_wrong_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
-      <source>Wrong PIN</source>
-      <translation>密码错误</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="122"/>
+        <source>Wrong PIN</source>
+        <translation>密码错误</translation>
     </message>
     <message id="page_settings_gsm_ready">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>Ready</source>
-      <translation>准备就绪</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="125"/>
+        <source>Ready</source>
+        <translation>准备就绪</translation>
+    </message>
+    <message id="page_settings_gsm_unknown_error">
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="128"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">未知错误</translation>
     </message>
     <message id="page_settings_gsm_pin">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
-      <source>PIN</source>
-      <translation>PIN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="136"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
     </message>
     <message id="page_settings_gsm_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
-      <source>APN</source>
-      <translation>APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="152"/>
+        <source>APN</source>
+        <translation>APN</translation>
     </message>
     <message id="page_settings_gsm_default">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
-      <source>Default</source>
-      <translation>默认</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="154"/>
+        <source>Default</source>
+        <translation>默认</translation>
     </message>
     <message id="page_settings_gsm_use_default_apn">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
-      <source>Use default APN</source>
-      <translation>使用默认APN</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="168"/>
+        <source>Use default APN</source>
+        <translation>使用默认APN</translation>
     </message>
     <message id="page_settings_gsm_apn_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
-      <source>APN name</source>
-      <translation>APN名称</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="180"/>
+        <source>APN name</source>
+        <translation>APN名称</translation>
     </message>
     <message id="page_settings_gsm_use_authentication">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
-      <source>Use authentication</source>
-      <translation>使用身份验证</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="194"/>
+        <source>Use authentication</source>
+        <translation>使用身份验证</translation>
     </message>
     <message id="page_settings_gsm_user_name">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
-      <source>User name</source>
-      <translation>用户名</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="209"/>
+        <source>User name</source>
+        <translation>用户名</translation>
     </message>
     <message id="page_settings_gsm_imei">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
-      <source>IMEI</source>
-      <translation>IMEI</translation>
+        <location filename="../pages/settings/PageSettingsGsm.qml" line="224"/>
+        <source>IMEI</source>
+        <translation>IMEI</translation>
     </message>
     <message id="settings_ess_battery_life_self_consumption">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
-      <source>Self-consumption</source>
-      <translation>自消耗</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="15"/>
+        <source>Self-consumption</source>
+        <translation>自消耗</translation>
     </message>
     <message id="settings_ess_no_ess_assistant">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
-      <source>No ESS Assistant found</source>
-      <translation>未找到ESS助手</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="22"/>
+        <source>No ESS Assistant found</source>
+        <translation>未找到ESS助手</translation>
     </message>
     <message id="settings_ess_grid_metering">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
-      <source>Grid metering</source>
-      <translation>电网供电量统计</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="58"/>
+        <source>Grid metering</source>
+        <translation>电网供电量统计</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
-      <source>External meter</source>
-      <translation>外部计量表</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="63"/>
+        <source>External meter</source>
+        <translation>外部计量表</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
-      <source>Inverter/Charger</source>
-      <translation>逆变器/充电器</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="65"/>
+        <source>Inverter/Charger</source>
+        <translation>逆变器/充电器</translation>
     </message>
     <message id="settings_ess_inverter_ac_output_in_use">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="72"/>
-      <source>Inverter AC output in use</source>
-      <translation>使用的逆变器交流输出</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="72"/>
+        <source>Inverter AC output in use</source>
+        <translation>使用的逆变器交流输出</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
-      <source>Multiphase regulation</source>
-      <translation>多相调节</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="92"/>
+        <source>Multiphase regulation</source>
+        <translation>多相调节</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
-      <source>Total of all phases</source>
-      <translation>所有相位总计</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="100"/>
+        <source>Total of all phases</source>
+        <translation>所有相位总计</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
-      <source>Individual phase</source>
-      <translation>每个相位</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="102"/>
+        <source>Individual phase</source>
+        <translation>每个相位</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="108"/>
-      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="108"/>
+        <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
-      <translation>调节每个相位以单独达到电网设定点（系统效率降低）。
+        <translation>调节每个相位以单独达到电网设定点（系统效率降低）。
 
 注意：仅在电力公司要求时使用。</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="111"/>
+        <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
-      <translation>智能调节所有相位的总和，以达到电网设定点（优化系统效率）。
+        <translation>智能调节所有相位的总和，以达到电网设定点（优化系统效率）。
 
 除非电力公司禁止，否则请使用。</translation>
     </message>
+    <message id="settings_ess_inactive">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="268"/>
+        <source>Inactive</source>
+        <translation type="unfinished">不激活</translation>
+    </message>
+    <message id="settings_ess_dynamic">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="298"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">动态ESS</translation>
+    </message>
     <message id="settings_rs_ess_min_soc">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation>最低放电量（除非电网故障）</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="31"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation>最低放电量（除非电网故障）</translation>
     </message>
     <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="136"/>
-      <source>Active SOC limit</source>
-      <translation>实际充电状态限制</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="136"/>
+        <source>Active SOC limit</source>
+        <translation>实际充电状态限制</translation>
+    </message>
+    <message id="settings_ess_battery_life_sustain">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="164"/>
+        <source>Sustain</source>
+        <translation type="unfinished">维持</translation>
+    </message>
+    <message id="settings_ess_battery_life_recharge">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="166"/>
+        <source>Recharge</source>
+        <translation type="unfinished">重新充电</translation>
     </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
-      <source>Peak shaving</source>
-      <translation>削峰</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="254"/>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+        <source>Peak shaving</source>
+        <translation>削峰</translation>
     </message>
     <message id="settings_ess_above_minimum_soc_only">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
-      <source>Above minimum SOC only</source>
-      <translation>只在最小SOC以上</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+        <source>Above minimum SOC only</source>
+        <translation>只在最小SOC以上</translation>
     </message>
     <message id="settings_ess_always">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
-      <source>Always</source>
-      <translation>总是</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+        <source>Always</source>
+        <translation>总是</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="160"/>
-      <source>Discharge disabled</source>
-      <translation>放电已禁用</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="160"/>
+        <source>Discharge disabled</source>
+        <translation>放电已禁用</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
-      <source>Slow charge</source>
-      <translation>慢冲</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="162"/>
+        <source>Slow charge</source>
+        <translation>慢冲</translation>
     </message>
     <message id="inverters_state_system_sustain">
-      <location filename="../../data/System.qml" line="187"/>
-      <source>Sustain</source>
-      <translation>维持</translation>
+        <location filename="../data/System.qml" line="187"/>
+        <source>Sustain</source>
+        <translation>维持</translation>
     </message>
     <message id="inverters_state_recharge">
-      <location filename="../../data/System.qml" line="190"/>
-      <source>Recharge</source>
-      <translation>重新充电</translation>
+        <location filename="../data/System.qml" line="190"/>
+        <source>Recharge</source>
+        <translation>重新充电</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="174"/>
-      <source>Limit charge power</source>
-      <translation>限制充电功率</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="174"/>
+        <source>Limit charge power</source>
+        <translation>限制充电功率</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="193"/>
-      <source>Maximum charge power</source>
-      <translation>最大充电功率</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="193"/>
+        <source>Maximum charge power</source>
+        <translation>最大充电功率</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
-      <source>Limit inverter power</source>
-      <translation>限制逆变器功率</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="205"/>
+        <source>Limit inverter power</source>
+        <translation>限制逆变器功率</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="224"/>
-      <source>Maximum inverter power</source>
-      <translation>最大逆变器功率</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="224"/>
+        <source>Maximum inverter power</source>
+        <translation>最大逆变器功率</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
-      <source>Grid setpoint</source>
-      <translation>电网设定点</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="234"/>
+        <source>Grid setpoint</source>
+        <translation>电网设定点</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="243"/>
-      <source>Grid feed-in</source>
-      <translation>上网</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="243"/>
+        <source>Grid feed-in</source>
+        <translation>上网</translation>
     </message>
     <message id="settings_ess_ac_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
-      <source>AC-coupled PV - feed in excess</source>
-      <translation>交流耦合光伏 – 供应过量</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+        <source>AC-coupled PV - feed in excess</source>
+        <translation>交流耦合光伏 – 供应过量</translation>
     </message>
     <message id="settings_ess_dc_coupled_pv">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
-      <source>DC-coupled PV - feed in excess</source>
-      <translation>直流耦合光伏 – 供应过量</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+        <source>DC-coupled PV - feed in excess</source>
+        <translation>直流耦合光伏 – 供应过量</translation>
     </message>
     <message id="settings_ess_limit_system_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
-      <source>Limit system feed-in</source>
-      <translation>限制系统上网</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+        <source>Limit system feed-in</source>
+        <translation>限制系统上网</translation>
     </message>
     <message id="settings_ess_max_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
-      <source>Maximum feed-in</source>
-      <translation>最大上网电量</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+        <source>Maximum feed-in</source>
+        <translation>最大上网电量</translation>
     </message>
     <message id="settings_ess_feed_in_limiting_active">
-      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
-      <source>Feed-in limiting active</source>
-      <translation>上网电量限制已激活</translation>
+        <location filename="../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+        <source>Feed-in limiting active</source>
+        <translation>上网电量限制已激活</translation>
     </message>
     <message id="settings_io_analog_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
-      <source>Analog inputs</source>
-      <translation>模拟输入</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="32"/>
+        <source>Analog inputs</source>
+        <translation>模拟输入</translation>
     </message>
     <message id="settings_io_digital_inputs">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
-      <source>Digital inputs</source>
-      <translation>数字输入</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="60"/>
+        <source>Digital inputs</source>
+        <translation>数字输入</translation>
     </message>
     <message id="settings_io_digital_input">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
-      <source>Digital input %1</source>
-      <extracomment>%1 = number of the digital input</extracomment>
-      <translation>数字输入 %1</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="90"/>
+        <source>Digital input %1</source>
+        <extracomment>%1 = number of the digital input</extracomment>
+        <translation>数字输入 %1</translation>
     </message>
     <message id="digitalinputs_type_pulsemeter">
-      <location filename="../../data/DigitalInputs.qml" line="22"/>
-      <source>Pulse meter</source>
-      <translation>脉冲计</translation>
+        <location filename="../data/DigitalInputs.qml" line="22"/>
+        <source>Pulse meter</source>
+        <translation>脉冲计</translation>
     </message>
     <message id="digitalinputs_type_dooralarm">
-      <location filename="../../data/DigitalInputs.qml" line="25"/>
-      <source>Door alarm</source>
-      <translation>门铃</translation>
+        <location filename="../data/DigitalInputs.qml" line="25"/>
+        <source>Door alarm</source>
+        <translation>门铃</translation>
     </message>
     <message id="digitalinputs_type_bilgepump">
-      <location filename="../../data/DigitalInputs.qml" line="28"/>
-      <source>Bilge pump</source>
-      <translation>舱底泵</translation>
+        <location filename="../data/DigitalInputs.qml" line="28"/>
+        <source>Bilge pump</source>
+        <translation>舱底泵</translation>
     </message>
     <message id="digitalinputs_type_bilgealarm">
-      <location filename="../../data/DigitalInputs.qml" line="31"/>
-      <source>Bilge alarm</source>
-      <translation>舱底报警</translation>
+        <location filename="../data/DigitalInputs.qml" line="31"/>
+        <source>Bilge alarm</source>
+        <translation>舱底报警</translation>
     </message>
     <message id="digitalinputs_type_burglaralarm">
-      <location filename="../../data/DigitalInputs.qml" line="34"/>
-      <source>Burglar alarm</source>
-      <translation>防盗报警</translation>
+        <location filename="../data/DigitalInputs.qml" line="34"/>
+        <source>Burglar alarm</source>
+        <translation>防盗报警</translation>
     </message>
     <message id="digitalinputs_type_smokealarm">
-      <location filename="../../data/DigitalInputs.qml" line="37"/>
-      <source>Smoke alarm</source>
-      <translation>烟雾报警</translation>
+        <location filename="../data/DigitalInputs.qml" line="37"/>
+        <source>Smoke alarm</source>
+        <translation>烟雾报警</translation>
     </message>
     <message id="digitalinputs_type_firealarm">
-      <location filename="../../data/DigitalInputs.qml" line="40"/>
-      <source>Fire alarm</source>
-      <translation>火警</translation>
+        <location filename="../data/DigitalInputs.qml" line="40"/>
+        <source>Fire alarm</source>
+        <translation>火警</translation>
     </message>
     <message id="digitalinputs_type_co2alarm">
-      <location filename="../../data/DigitalInputs.qml" line="43"/>
-      <source>CO2 alarm</source>
-      <translation>二氧化碳报警</translation>
+        <location filename="../data/DigitalInputs.qml" line="43"/>
+        <source>CO2 alarm</source>
+        <translation>二氧化碳报警</translation>
     </message>
     <message id="settings_io_bt_sensors">
-      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
-      <source>Bluetooth sensors</source>
-      <translation>蓝牙感应</translation>
+        <location filename="../pages/settings/PageSettingsIo.qml" line="101"/>
+        <source>Bluetooth sensors</source>
+        <translation>蓝牙感应</translation>
     </message>
     <message id="settings_large_features_not_offically_supported">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
-      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="16"/>
+        <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
 
 Documentation at https://ve3.nl/vol</source>
-      <translation>请注意，Victron 不正式对这些功能提供技术支持。 如有问题，请访问 community.victronenergy.com。
+        <translation>请注意，Victron 不正式对这些功能提供技术支持。 如有问题，请访问 community.victronenergy.com。
 
 https://ve3.nl/vol 上的文档</translation>
     </message>
     <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
-      <source>Signal K</source>
-      <translation>Signal K</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="23"/>
+        <source>Signal K</source>
+        <translation>Signal K</translation>
     </message>
     <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation>Node-RED</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="38"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+        <source>Node-RED</source>
+        <translation>Node-RED</translation>
     </message>
     <message id="settings_large_enabled_safe_mode">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
-      <source>Enabled (safe mode)</source>
-      <translation>启用（安全模式）</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+        <source>Enabled (safe mode)</source>
+        <translation>启用（安全模式）</translation>
     </message>
     <message id="settings_logging_time_ago_deferred">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
-      <source>Deferred by %1s</source>
-      <extracomment>%1 = number of seconds</extracomment>
-      <translation>推迟 %1s</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="22"/>
+        <source>Deferred by %1s</source>
+        <extracomment>%1 = number of seconds</extracomment>
+        <translation>推迟 %1s</translation>
     </message>
     <message id="settings_vrm_portal_id">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="85"/>
-      <source>VRM Portal ID</source>
-      <translation>VRM门户ID</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="86"/>
+        <source>VRM Portal ID</source>
+        <translation>VRM门户ID</translation>
     </message>
     <message id="settings_log_interval">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="91"/>
-      <source>Log interval</source>
-      <translation>记录间隔</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="92"/>
+        <source>Log interval</source>
+        <translation>记录间隔</translation>
     </message>
     <message id="settings_5_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="96"/>
-      <source>5 min</source>
-      <translation>5分钟</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="97"/>
+        <source>5 min</source>
+        <translation>5分钟</translation>
     </message>
     <message id="settings_15_min">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="100"/>
-      <source>15 min</source>
-      <translation>15分钟</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="101"/>
+        <source>15 min</source>
+        <translation>15分钟</translation>
     </message>
     <message id="settings_1_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="104"/>
-      <source>1 hour</source>
-      <translation>1小时</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="105"/>
+        <source>1 hour</source>
+        <translation>1小时</translation>
     </message>
     <message id="settings_2_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
-      <source>2 hours</source>
-      <translation>2小时</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="107"/>
+        <source>2 hours</source>
+        <translation>2小时</translation>
     </message>
     <message id="settings_4_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="108"/>
-      <source>4 hours</source>
-      <translation>4小时</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="109"/>
+        <source>4 hours</source>
+        <translation>4小时</translation>
     </message>
     <message id="settings_12_hr">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="110"/>
-      <source>12 hours</source>
-      <translation>12小时</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="111"/>
+        <source>12 hours</source>
+        <translation>12小时</translation>
     </message>
     <message id="settings_1_day">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
-      <source>1 day</source>
-      <translation>1天</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="113"/>
+        <source>1 day</source>
+        <translation>1天</translation>
     </message>
     <message id="settings_https_enabled">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="122"/>
-      <source>Use secure connection (HTTPS)</source>
-      <translation>使用安全连接(HTTPS)</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="123"/>
+        <source>Use secure connection (HTTPS)</source>
+        <translation>使用安全连接(HTTPS)</translation>
     </message>
     <message id="settings_last_contact">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="134"/>
-      <source>Last contact</source>
-      <translation>上次联系</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="135"/>
+        <source>Last contact</source>
+        <translation>上次联系</translation>
     </message>
     <message id="settings_connection_error_150">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="190"/>
-      <source>#150 Unexpected response text</source>
-      <translation>#150 意外响应文本</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="191"/>
+        <source>#150 Unexpected response text</source>
+        <translation>#150 意外响应文本</translation>
     </message>
     <message id="settings_connection_error_151">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="193"/>
-      <source>#151 Unexpected HTTP response</source>
-      <translation>#151 意外的 HTTP 响应</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="194"/>
+        <source>#151 Unexpected HTTP response</source>
+        <translation>#151 意外的 HTTP 响应</translation>
     </message>
     <message id="settings_connection_error_152">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="196"/>
-      <source>#152 Connection timeout</source>
-      <translation>#152 连接超时</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="197"/>
+        <source>#152 Connection timeout</source>
+        <translation>#152 连接超时</translation>
     </message>
     <message id="settings_connection_error_153">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
-      <source>#153 Connection error</source>
-      <translation>#153 连接错误</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="200"/>
+        <source>#153 Connection error</source>
+        <translation>#153 连接错误</translation>
     </message>
     <message id="settings_connection_error_154">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="202"/>
-      <source>#154 DNS failure</source>
-      <translation>#154 DNS 故障</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="203"/>
+        <source>#154 DNS failure</source>
+        <translation>#154 DNS 故障</translation>
     </message>
     <message id="settings_connection_error_155">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="205"/>
-      <source>#155 Routing error</source>
-      <translation>#155 路由错误</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="206"/>
+        <source>#155 Routing error</source>
+        <translation>#155 路由错误</translation>
     </message>
     <message id="settings_connection_error_156">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="208"/>
-      <source>#156 VRM unavailable</source>
-      <translation>#156 VRM 无法使用</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="209"/>
+        <source>#156 VRM unavailable</source>
+        <translation>#156 VRM 无法使用</translation>
     </message>
     <message id="settings_connection_error_157">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
-      <source>#159 Unknown error</source>
-      <translation>#159 未知错误</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="212"/>
+        <source>#159 Unknown error</source>
+        <translation>#159 未知错误</translation>
     </message>
     <message id="settings_vrm_error_message">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="228"/>
-      <source>Error message: 
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="229"/>
+        <source>Error message: 
 %1</source>
-      <translation>错误信息：
+        <translation>错误信息：
 %1</translation>
     </message>
     <message id="settings_no_contact_reboot">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="253"/>
-      <source>Reboot device when no contact</source>
-      <translation>不联网时重启设备</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="254"/>
+        <source>Reboot device when no contact</source>
+        <translation>不联网时重启设备</translation>
     </message>
     <message id="settings_vrm_no_contact_reset_delay">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="263"/>
-      <source>No contact reset delay (hh:mm)</source>
-      <translation>不联网复位延迟（小时：分钟）</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="264"/>
+        <source>No contact reset delay (hh:mm)</source>
+        <translation>不联网复位延迟（小时：分钟）</translation>
     </message>
     <message id="settings_vrm_storage_location">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="269"/>
-      <source>Storage location</source>
-      <translation>存储位置</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="270"/>
+        <source>Storage location</source>
+        <translation>存储位置</translation>
     </message>
     <message id="settings_vrm_no_buffer_active">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="271"/>
-      <source>No buffer active</source>
-      <translation>无有效缓存</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="272"/>
+        <source>No buffer active</source>
+        <translation>无有效缓存</translation>
     </message>
     <message id="settings_vrm_internal_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
-      <source>Internal storage</source>
-      <translation>内部存储</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="275"/>
+        <source>Internal storage</source>
+        <translation>内部存储</translation>
     </message>
     <message id="settings_vrm_transferring">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="276"/>
-      <source>Transferring</source>
-      <translation>正在传输</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="277"/>
+        <source>Transferring</source>
+        <translation>正在传输</translation>
     </message>
     <message id="settings_vrm_external_storage">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="278"/>
-      <source>External storage</source>
-      <translation>外部存储</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="279"/>
+        <source>External storage</source>
+        <translation>外部存储</translation>
+    </message>
+    <message id="settings_vrm_unknown_error">
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="288"/>
+        <source>Unknown error</source>
+        <translation type="unfinished">未知错误</translation>
     </message>
     <message id="settings_vrm_no_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
-      <source>No Error</source>
-      <translation>无错误</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="291"/>
+        <source>No Error</source>
+        <translation>无错误</translation>
     </message>
     <message id="settings_vrm_no_space_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
-      <source>No space left on storage</source>
-      <translation>无剩余存储空间</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="293"/>
+        <source>No space left on storage</source>
+        <translation>无剩余存储空间</translation>
     </message>
     <message id="settings_vrm_io_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="294"/>
-      <source>IO error</source>
-      <translation>IO错误</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="295"/>
+        <source>IO error</source>
+        <translation>IO错误</translation>
     </message>
     <message id="settings_vrm_mount_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="296"/>
-      <source>Mount error</source>
-      <translation>安装错误</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="297"/>
+        <source>Mount error</source>
+        <translation>安装错误</translation>
     </message>
     <message id="settings_vrm_storage_contains_firmware_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="298"/>
-      <source>Contains firmware image. Not using.</source>
-      <translation>含固件文件。未使用。</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="299"/>
+        <source>Contains firmware image. Not using.</source>
+        <translation>含固件文件。未使用。</translation>
     </message>
     <message id="settings_vrm_storage_not_writable_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="300"/>
-      <source>SD card / USB stick not writable</source>
-      <translation>SD卡/USB记忆棒不可写入</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="301"/>
+        <source>SD card / USB stick not writable</source>
+        <translation>SD卡/USB记忆棒不可写入</translation>
     </message>
     <message id="settings_vrm_free_disk_space">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="309"/>
-      <source>Free disk space</source>
-      <translation>可用磁盘空间</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="310"/>
+        <source>Free disk space</source>
+        <translation>可用磁盘空间</translation>
     </message>
     <message id="settings_vrm_byte">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="312"/>
-      <source>byte</source>
-      <translation>子节</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="313"/>
+        <source>byte</source>
+        <translation>子节</translation>
     </message>
     <message id="settings_vrm_bytes">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="314"/>
-      <source>bytes</source>
-      <translation>子节</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="315"/>
+        <source>bytes</source>
+        <translation>子节</translation>
     </message>
     <message id="settings_vrm_stored_records">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="322"/>
-      <source>Stored records</source>
-      <translation>已保存记录</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="323"/>
+        <source>Stored records</source>
+        <translation>已保存记录</translation>
     </message>
     <message id="settings_vrm_records_count">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="325"/>
-      <source>%1 records</source>
-      <translation>%1 记录</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="326"/>
+        <source>%1 records</source>
+        <translation>%1 记录</translation>
     </message>
     <message id="settings_vrm_oldest_record_age">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
-      <source>Oldest record age</source>
-      <translation>最旧的记录存留期</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="334"/>
+        <source>Oldest record age</source>
+        <translation>最旧的记录存留期</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
-      <source>Enable Modbus/TCP</source>
-      <translation>启用Modbus/TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+        <source>Enable Modbus/TCP</source>
+        <translation>启用Modbus/TCP</translation>
     </message>
     <message id="settings_modbus_no_errors">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
-      <source>No errors reported</source>
-      <translation>无报告错误</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+        <source>No errors reported</source>
+        <translation>无报告错误</translation>
     </message>
     <message id="settings_modbus_time_of_last_error">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
-      <source>Time of last error</source>
-      <translation>上次错误时间</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+        <source>Time of last error</source>
+        <translation>上次错误时间</translation>
     </message>
     <message id="settings_modbus_available_services">
-      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
-      <source>Available services</source>
-      <translation>可用服务</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+        <source>Available services</source>
+        <translation>可用服务</translation>
     </message>
     <message id="settings_modbus_unit_id">
-      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
-      <source>Unit ID: %1</source>
-      <translation>单位 ID：%1</translation>
+        <location filename="../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+        <source>Unit ID: %1</source>
+        <translation>单位 ID：%1</translation>
     </message>
     <message id="settings_relay_function_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
-      <source>Function (Relay 1)</source>
-      <translation>功能（继电器1）</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="20"/>
+        <source>Function (Relay 1)</source>
+        <translation>功能（继电器1）</translation>
     </message>
     <message id="settings_relay_function">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
-      <source>Function</source>
-      <translation>功能</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="22"/>
+        <source>Function</source>
+        <translation>功能</translation>
     </message>
     <message id="settings_relay_alarm_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
-      <source>Alarm relay</source>
-      <translation>报警继电器</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="26"/>
+        <source>Alarm relay</source>
+        <translation>报警继电器</translation>
+    </message>
+    <message id="settings_relay_tank_pump">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="32"/>
+        <source>Tank pump</source>
+        <translation type="unfinished">水箱泵</translation>
+    </message>
+    <message id="settings_relay_manual">
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="34"/>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="75"/>
+        <source>Manual</source>
+        <translation type="unfinished">手动</translation>
     </message>
     <message id="settings_relay_alarm_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
-      <source>Alarm relay polarity</source>
-      <translation>报警继电器极性</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="43"/>
+        <source>Alarm relay polarity</source>
+        <translation>报警继电器极性</translation>
     </message>
     <message id="settings_relay_normally_open">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
-      <source>Normally open</source>
-      <translation>常开</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="48"/>
+        <source>Normally open</source>
+        <translation>常开</translation>
     </message>
     <message id="settings_relay_normally_closed">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
-      <source>Normally closed</source>
-      <translation>常闭</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="50"/>
+        <source>Normally closed</source>
+        <translation>常闭</translation>
     </message>
     <message id="settings_relay_relay1on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
-      <source>Relay 1 on</source>
-      <translation>继电器1打开</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="59"/>
+        <source>Relay 1 on</source>
+        <translation>继电器1打开</translation>
     </message>
     <message id="settings_relay_on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
-      <source>Relay on</source>
-      <translation>继电器开</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="61"/>
+        <source>Relay on</source>
+        <translation>继电器开</translation>
     </message>
     <message id="settings_relay_function_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
-      <source>Function (Relay 2)</source>
-      <translation>功能（继电器2）</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="70"/>
+        <source>Function (Relay 2)</source>
+        <translation>功能（继电器2）</translation>
     </message>
     <message id="settings_relay_relay2on">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
-      <source>Relay 2 on</source>
-      <translation>继电器2打开</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="84"/>
+        <source>Relay 2 on</source>
+        <translation>继电器2打开</translation>
     </message>
     <message id="settings_relay_temp_control_rules">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
-      <source>Temperature control rules</source>
-      <translation>温度控制规则</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="92"/>
+        <source>Temperature control rules</source>
+        <translation>温度控制规则</translation>
     </message>
     <message id="settings_relay_activate_on_temp">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
-      <source>Relay activation on temperature</source>
-      <translation>温度继电器激活</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+        <source>Relay activation on temperature</source>
+        <translation>温度继电器激活</translation>
     </message>
     <message id="settings_relay_no_temperature_relay">
-      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
-      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
-      <translation>没有将继电器配置为通过温度激活。进入主设置菜单中的继电器设置页面，将继电器功能设置为 "温度"。</translation>
+        <location filename="../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+        <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to &quot;Temperature&quot;.</source>
+        <translation>没有将继电器配置为通过温度激活。进入主设置菜单中的继电器设置页面，将继电器功能设置为 &quot;温度&quot;。</translation>
     </message>
     <message id="settings_firmware_version_switch_option">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
-      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
-      <translation>此选项允许在新老固件版本间切换。无需互联网或SD卡。</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+        <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+        <translation>此选项允许在新老固件版本间切换。无需互联网或SD卡。</translation>
     </message>
     <message id="settings_firmware_current_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
-      <translation>固件%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+        <translation>固件%1 (%2)</translation>
     </message>
     <message id="settings_firmware_press_to_boot">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
-      <source>Press to boot</source>
-      <translation>按下重启</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+        <source>Press to boot</source>
+        <translation>按下重启</translation>
+    </message>
+    <message id="settings_firmware_backup_version">
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
+        <source>Firmware %1 (%2)</source>
+        <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
+        <translation type="unfinished">固件%1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
-      <source>Rebooting to %1</source>
-      <extracomment>%1 = backup version</extracomment>
-      <translation>重新启动到 %1</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+        <source>Rebooting to %1</source>
+        <extracomment>%1 = backup version</extracomment>
+        <translation>重新启动到 %1</translation>
     </message>
     <message id="settings_firmware_switching_not_possible">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
-      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
-      <translation>当自动更新设置为“检查并更新”时，无法切换固件版本。将自动更新设置为“已禁用”或“仅检查”以启用此选项。</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+        <source>Switching firmware version is not possible when auto update is set to &quot;Check and update&quot;. Set auto update to &quot;Disabled&quot; or &quot;Check only&quot; to enable this option.</source>
+        <translation>当自动更新设置为“检查并更新”时，无法切换固件版本。将自动更新设置为“已禁用”或“仅检查”以启用此选项。</translation>
     </message>
     <message id="settings_firmware_backup_not_available">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
-      <source>Backup firmware not available</source>
-      <translation>备份固件不可用</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+        <source>Backup firmware not available</source>
+        <translation>备份固件不可用</translation>
     </message>
     <message id="settings_services_modbus_tcp">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
-      <source>Modbus TCP</source>
-      <translation>Modbus TCP</translation>
-    </message>
-    <message id="settings_services_console_on_vedirect1">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="54"/>
-      <source>Console on VE.Direct 1</source>
-      <translation>控制端口在VE.Direct 1</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="16"/>
+        <source>Modbus TCP</source>
+        <translation>Modbus TCP</translation>
     </message>
     <message id="settings_services_canbus_over_tcpip_debug">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="87"/>
-      <source>CAN-bus over TCP/IP (Debug)</source>
-      <translation>通过 TCP/IP 连接 CAN 总线（调试）</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="80"/>
+        <source>CAN-bus over TCP/IP (Debug)</source>
+        <translation>通过 TCP/IP 连接 CAN 总线（调试）</translation>
     </message>
     <message id="settings_system_shore_power">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Shore power</source>
-      <translation>岸电</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="21"/>
+        <source>Shore power</source>
+        <translation>岸电</translation>
     </message>
     <message id="settings_system_name_vehicle">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="31"/>
-      <source>Vehicle</source>
-      <translation>车</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="31"/>
+        <source>Vehicle</source>
+        <translation>车</translation>
     </message>
     <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="33"/>
-      <source>Boat</source>
-      <translation>船</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="33"/>
+        <source>Boat</source>
+        <translation>船</translation>
     </message>
     <message id="settings_system_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="38"/>
-      <source>System name</source>
-      <translation>系统名称</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="38"/>
+        <source>System name</source>
+        <translation>系统名称</translation>
     </message>
     <message id="settings_tcpip_auto">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
-      <source>Automatic</source>
-      <translation>自动</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+        <source>Automatic</source>
+        <translation>自动</translation>
+    </message>
+    <message id="settings_system_grid">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="18"/>
+        <source>Grid</source>
+        <translation type="unfinished">电网</translation>
+    </message>
+    <message id="settings_system_name_auto">
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="44"/>
+        <source>Automatic</source>
+        <translation type="unfinished">自动</translation>
     </message>
     <message id="settings_system_name_user_defined">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="53"/>
-      <source>User defined</source>
-      <translation>用户定义</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="53"/>
+        <source>User defined</source>
+        <translation>用户定义</translation>
     </message>
     <message id="settings_system_user_defined_name">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
-      <source>User-defined name</source>
-      <translation>用户自定义名称</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="60"/>
+        <source>User-defined name</source>
+        <translation>用户自定义名称</translation>
     </message>
     <message id="settings_system_ac_input_1">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
-      <source>AC input 1</source>
-      <translation>交流输入1</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="72"/>
+        <source>AC input 1</source>
+        <translation>交流输入1</translation>
     </message>
     <message id="settings_system_ac_input_2">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
-      <source>AC input 2</source>
-      <translation>交流输入2</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="81"/>
+        <source>AC input 2</source>
+        <translation>交流输入2</translation>
     </message>
     <message id="settings_system_monitor_for_grid_failure">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="111"/>
-      <source>Monitor for grid failure</source>
-      <translation>监测电网故障</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="111"/>
+        <source>Monitor for grid failure</source>
+        <translation>监测电网故障</translation>
     </message>
     <message id="settings_system_monitor_for_shore_disconnect">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
-      <source>Monitor for shore disconnect</source>
-      <translation>监测岸电断开</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="113"/>
+        <source>Monitor for shore disconnect</source>
+        <translation>监测岸电断开</translation>
     </message>
     <message id="settings_system_auto_selected">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="151"/>
-      <source>Auto-selected</source>
-      <translation>自动选择</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="151"/>
+        <source>Auto-selected</source>
+        <translation>自动选择</translation>
     </message>
     <message id="settings_system_has_dc_system">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="160"/>
-      <source>Has DC system</source>
-      <translation>有直流系统</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="160"/>
+        <source>Has DC system</source>
+        <translation>有直流系统</translation>
     </message>
     <message id="settings_system_status_sync_vebus_soc_with_battery">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
-      <source>Synchronize VE.Bus SOC with battery</source>
-      <translation>VE.Bus SOC状态与电池同步</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+        <source>Synchronize VE.Bus SOC with battery</source>
+        <translation>VE.Bus SOC状态与电池同步</translation>
     </message>
     <message id="settings_system_status_solar_charger_vebus">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
-      <source>Use solar charger current to improve VE.Bus SOC</source>
-      <translation>用太阳能充电器电流改善VE.Bus SOC状态</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+        <source>Use solar charger current to improve VE.Bus SOC</source>
+        <translation>用太阳能充电器电流改善VE.Bus SOC状态</translation>
     </message>
     <message id="settings_system_status_solar_charger_voltage_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
-      <source>Solar charger voltage control</source>
-      <translation>太阳能充电器电压控制</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+        <source>Solar charger voltage control</source>
+        <translation>太阳能充电器电压控制</translation>
     </message>
     <message id="settings_system_status_solar_charger_current_control">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
-      <source>Solar charger current control</source>
-      <translation>太阳能充电器电流控制</translation>
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+        <source>Solar charger current control</source>
+        <translation>太阳能充电器电流控制</translation>
+    </message>
+    <message id="settings_system_status_bms_params">
+        <location filename="../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS控制</translation>
     </message>
     <message id="charger_network_bms_control">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
-      <source>BMS control</source>
-      <oldsource>BMS Control</oldsource>
-      <translation>BMS控制</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+        <source>BMS control</source>
+        <oldsource>BMS Control</oldsource>
+        <translation>BMS控制</translation>
     </message>
     <message id="settings_pump_function_not_enabled">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
-      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
-      <translation>水箱泵启动/停止功能未启用。转到继电器设置，将功能设置为 "水箱泵"。</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="38"/>
+        <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to &quot;Tank pump&quot;.</source>
+        <translation>水箱泵启动/停止功能未启用。转到继电器设置，将功能设置为 &quot;水箱泵&quot;。</translation>
     </message>
     <message id="settings_pump_state">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
-      <source>Pump state</source>
-      <translation>泵状态</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="47"/>
+        <source>Pump state</source>
+        <translation>泵状态</translation>
+    </message>
+    <message id="settings_pump_auto">
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="56"/>
+        <source>Auto</source>
+        <translation type="unfinished">自动</translation>
     </message>
     <message id="settings_tank_sensor">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
-      <source>Tank sensor</source>
-      <translation>水箱传感器</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="67"/>
+        <source>Tank sensor</source>
+        <translation>水箱传感器</translation>
     </message>
     <message id="settings_tank_start_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
-      <source>Start level</source>
-      <translation>启动液位</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="90"/>
+        <source>Start level</source>
+        <translation>启动液位</translation>
     </message>
     <message id="settings_tank_stop_level">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
-      <source>Stop level</source>
-      <translation>停止液位</translation>
+        <location filename="../pages/settings/PageSettingsTankPump.qml" line="99"/>
+        <source>Stop level</source>
+        <translation>停止液位</translation>
     </message>
     <message id="settings_tcpip_connection_lost">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
-      <source>Connection lost</source>
-      <translation>连接丢失</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+        <source>Connection lost</source>
+        <translation>连接丢失</translation>
     </message>
     <message id="settings_tcpip_connection_unplugged">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
-      <source>Unplugged</source>
-      <translation>未插电</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+        <source>Unplugged</source>
+        <translation>未插电</translation>
     </message>
     <message id="settings_tcpip_hidden">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="160"/>
-      <source>[Hidden]</source>
-      <translation>[隐藏]</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="160"/>
+        <source>[Hidden]</source>
+        <translation>[隐藏]</translation>
     </message>
     <message id="settings_tcpip_connect_to_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
-      <source>Connect to network?</source>
-      <translation>连接到网络?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+        <source>Connect to network?</source>
+        <translation>连接到网络?</translation>
     </message>
     <message id="settings_tcpip_connect">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
-      <source>Connect</source>
-      <translation>连接</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+        <source>Connect</source>
+        <translation>连接</translation>
     </message>
     <message id="settings_tcpip_forget_network">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
-      <source>Forget network?</source>
-      <translation>忘记网络?</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+        <source>Forget network?</source>
+        <translation>忘记网络?</translation>
     </message>
     <message id="settings_tcpip_forget">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
-      <source>Forget</source>
-      <translation>忘记</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+        <source>Forget</source>
+        <translation>忘记</translation>
     </message>
     <message id="settings_tcpip_forget_confirm">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
-      <source>Are you sure that you want to forget this network?</source>
-      <translation>你确定要忘记这个网络吗？</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+        <source>Are you sure that you want to forget this network?</source>
+        <translation>你确定要忘记这个网络吗？</translation>
     </message>
     <message id="settings_tcpip_mac_address">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
-      <source>MAC address</source>
-      <translation>MAC地址</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+        <source>MAC address</source>
+        <translation>MAC地址</translation>
     </message>
     <message id="settings_tcpip_ip_config">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
-      <source>IP configuration</source>
-      <translation>IP配置</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+        <source>IP configuration</source>
+        <translation>IP配置</translation>
+    </message>
+    <message id="settings_tcpip_manual">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="227"/>
+        <source>Manual</source>
+        <translation type="unfinished">手动</translation>
+    </message>
+    <message id="settings_tcpip_off">
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="229"/>
+        <source>Off</source>
+        <translation type="unfinished">关</translation>
     </message>
     <message id="settings_tcpip_fixed">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
-      <source>Fixed</source>
-      <translation>固定</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+        <source>Fixed</source>
+        <translation>固定</translation>
     </message>
     <message id="settings_tcpip_netmask">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
-      <source>Netmask</source>
-      <translation>网络掩码</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+        <source>Netmask</source>
+        <translation>网络掩码</translation>
     </message>
     <message id="settings_tcpip_gateway">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
-      <source>Gateway</source>
-      <translation>网关</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+        <source>Gateway</source>
+        <translation>网关</translation>
     </message>
     <message id="settings_tcpip_dns_server">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
-      <source>DNS server</source>
-      <translation>DNS服务器</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+        <source>DNS server</source>
+        <translation>DNS服务器</translation>
     </message>
     <message id="settings_tcpip_link_local">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
-      <source>Link-local IP address</source>
-      <translation>链路本地IP地址</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+        <source>Link-local IP address</source>
+        <translation>链路本地IP地址</translation>
     </message>
     <message id="settings_vecan_instance_zero_warning">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
-      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
-      <translation>请注意，对于ESS系统以及带有管理电池的系统而言，CAN总线设备实例必须始终配置为0。详见GX手册。</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+        <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+        <translation>请注意，对于ESS系统以及带有管理电池的系统而言，CAN总线设备实例必须始终配置为0。详见GX手册。</translation>
     </message>
     <message id="settings_vecan_device_instance">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
-      <source>Device Instance</source>
-      <translation>设备实例</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+        <source>Device Instance</source>
+        <translation>设备实例</translation>
     </message>
     <message id="settings_vecan_nad">
-      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
-      <source>Network Address</source>
-      <translation>网络地址</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+        <source>Network Address</source>
+        <translation>网络地址</translation>
     </message>
     <message id="settings_vecan_devices">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
-      <source>VE.CAN devices</source>
-      <translation>VE.CAN 设备</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+        <source>VE.CAN devices</source>
+        <translation>VE.CAN 设备</translation>
     </message>
     <message id="settings_vecan_device_number">
-      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
-      <source>Device# %1</source>
-      <translation>设备# %1</translation>
+        <location filename="../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+        <source>Device# %1</source>
+        <translation>设备# %1</translation>
     </message>
     <message id="settings_wifi_no_access_points">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="150"/>
-      <source>No access points</source>
-      <translation>无接入点</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="150"/>
+        <source>No access points</source>
+        <translation>无接入点</translation>
     </message>
     <message id="settings_wifi_no_wifi_adapter_connected">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="152"/>
-      <source>No Wi-Fi adapter connected</source>
-      <translation>无Wi-Fi适配器连接</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="152"/>
+        <source>No Wi-Fi adapter connected</source>
+        <translation>无Wi-Fi适配器连接</translation>
     </message>
     <message id="settings_wifi_create_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="107"/>
-      <source>Create access point</source>
-      <translation>创建接入点</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="107"/>
+        <source>Create access point</source>
+        <translation>创建接入点</translation>
     </message>
     <message id="settings_wifi_networks">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="142"/>
-      <source>Wi-Fi networks</source>
-      <translation>Wi-Fi网络</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="142"/>
+        <source>Wi-Fi networks</source>
+        <translation>Wi-Fi网络</translation>
     </message>
     <message id="settings_wifi_disable_ap_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="131"/>
-      <source>Are you sure that you want to disable the access point?</source>
-      <translation>你确定要取消连接热点吗？</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="131"/>
+        <source>Are you sure that you want to disable the access point?</source>
+        <translation>你确定要取消连接热点吗？</translation>
     </message>
     <message id="settings_tz_date_time_utc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
-      <source>Date/Time UTC</source>
-      <translation>日期/时间 UTC</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="87"/>
+        <source>Date/Time UTC</source>
+        <translation>日期/时间 UTC</translation>
     </message>
     <message id="settings_tz_date_time_local">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
-      <source>Date/Time local</source>
-      <translation>日期/时间 本地</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="98"/>
+        <source>Date/Time local</source>
+        <translation>日期/时间 本地</translation>
     </message>
     <message id="settings_tz_time_zone">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
-      <source>Time zone</source>
-      <translation>时区</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="117"/>
+        <source>Time zone</source>
+        <translation>时区</translation>
     </message>
     <message id="settings_tz_africa">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
-      <source>Africa</source>
-      <translation>非洲</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="206"/>
+        <source>Africa</source>
+        <translation>非洲</translation>
     </message>
     <message id="settings_tz_america">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
-      <source>America</source>
-      <translation>美洲</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="212"/>
+        <source>America</source>
+        <translation>美洲</translation>
     </message>
     <message id="settings_tz_antartica">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
-      <source>Antartica</source>
-      <translation>南极洲</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="218"/>
+        <source>Antartica</source>
+        <translation>南极洲</translation>
     </message>
     <message id="settings_tz_artic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
-      <source>Artic</source>
-      <translation>北极</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="224"/>
+        <source>Artic</source>
+        <translation>北极</translation>
     </message>
     <message id="settings_tz_asia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
-      <source>Asia</source>
-      <translation>亚洲</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="230"/>
+        <source>Asia</source>
+        <translation>亚洲</translation>
     </message>
     <message id="settings_tz_atlantic">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
-      <source>Atlantic</source>
-      <translation>大西洋</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="236"/>
+        <source>Atlantic</source>
+        <translation>大西洋</translation>
     </message>
     <message id="settings_tz_ustralia">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
-      <source>Australia</source>
-      <translation>澳洲</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="242"/>
+        <source>Australia</source>
+        <translation>澳洲</translation>
     </message>
     <message id="settings_tz_europe">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
-      <source>Europe</source>
-      <translation>欧洲</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="248"/>
+        <source>Europe</source>
+        <translation>欧洲</translation>
     </message>
     <message id="settings_tz_indian">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
-      <source>Indian</source>
-      <translation>印度</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="254"/>
+        <source>Indian</source>
+        <translation>印度</translation>
     </message>
     <message id="settings_tz_pacific">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
-      <source>Pacific</source>
-      <translation>太平洋</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="260"/>
+        <source>Pacific</source>
+        <translation>太平洋</translation>
     </message>
     <message id="settings_tz_etc">
-      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
-      <source>Etc</source>
-      <translation>等</translation>
+        <location filename="../pages/settings/PageTzInfo.qml" line="266"/>
+        <source>Etc</source>
+        <translation>等</translation>
     </message>
     <message id="settings_vrm_device_instances_unconnected">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
-      <source>Unconnected %1</source>
-      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
-      <translation>未连接 %1</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+        <source>Unconnected %1</source>
+        <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+        <translation>未连接 %1</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
-      <source>Reboot now?</source>
-      <translation>现在重启？</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+        <source>Reboot now?</source>
+        <translation>现在重启？</translation>
     </message>
     <message id="settings_vrm_device_instances_reboot_now_description">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
-      <source>VRM instance changes will not be applied until the device is rebooted.</source>
-      <translation>VRM 实例更改在设备重启前不会应用。</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+        <source>VRM instance changes will not be applied until the device is rebooted.</source>
+        <translation>VRM 实例更改在设备重启前不会应用。</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooting">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
-      <source>Device is rebooting...</source>
-      <translation>设备正在重启</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+        <source>Device is rebooting...</source>
+        <translation>设备正在重启</translation>
     </message>
     <message id="settings_vrm_device_instances_rebooted">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
-      <source>Device has been rebooted.</source>
-      <translation>设备已重启。</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+        <source>Device has been rebooted.</source>
+        <translation>设备已重启。</translation>
     </message>
     <message id="settings_accharger_low_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
-      <source>Low battery voltage alarm</source>
-      <translation>电池低压报警</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="89"/>
+        <source>Low battery voltage alarm</source>
+        <translation>电池低压报警</translation>
     </message>
     <message id="settings_accharger_high_battery_voltage_alarm">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
-      <source>High battery voltage alarm</source>
-      <translation>高电池电压报警</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="98"/>
+        <source>High battery voltage alarm</source>
+        <translation>高电池电压报警</translation>
     </message>
     <message id="common_words_last_error">
-      <location filename="../../components/CommonWords.qml" line="559"/>
-      <source>Last error</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>上次出错</translation>
+        <location filename="../components/CommonWords.qml" line="559"/>
+        <source>Last error</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>上次出错</translation>
     </message>
     <message id="common_words_2nd_last_error">
-      <location filename="../../components/CommonWords.qml" line="562"/>
-      <source>2nd last error</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>第二次出错</translation>
+        <location filename="../components/CommonWords.qml" line="562"/>
+        <source>2nd last error</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>第二次出错</translation>
     </message>
     <message id="common_words_3rd_last_error">
-      <location filename="../../components/CommonWords.qml" line="565"/>
-      <source>3rd last error</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>第三次出错</translation>
+        <location filename="../components/CommonWords.qml" line="565"/>
+        <source>3rd last error</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>第三次出错</translation>
     </message>
     <message id="common_words_4th_last_error">
-      <location filename="../../components/CommonWords.qml" line="568"/>
-      <source>4th last error</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>第四次出错</translation>
+        <location filename="../components/CommonWords.qml" line="568"/>
+        <source>4th last error</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>第四次出错</translation>
     </message>
     <message id="charger_networked">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
-      <source>Networked</source>
-      <translation>网络</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+        <source>Networked</source>
+        <translation>网络</translation>
     </message>
     <message id="charger_mode_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
-      <source>Mode setting</source>
-      <translation>模式设置</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+        <source>Mode setting</source>
+        <translation>模式设置</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone">
-      <location filename="../../data/SystemSettings.qml" line="101"/>
-      <source>Standalone</source>
-      <extracomment>Network status: Standalone</extracomment>
-      <translation>单机</translation>
+        <location filename="../data/SystemSettings.qml" line="103"/>
+        <source>Standalone</source>
+        <extracomment>Network status: Standalone</extracomment>
+        <translation>单机</translation>
+    </message>
+    <message id="charger_standalone">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="45"/>
+        <source>Standalone</source>
+        <translation type="unfinished">单机</translation>
     </message>
     <message id="charger_charge">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
-      <source>Charge</source>
-      <translation>充电</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+        <source>Charge</source>
+        <translation>充电</translation>
+    </message>
+    <message id="charger_external_control">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="51"/>
+        <source>External control</source>
+        <translation type="unfinished">外部控制</translation>
     </message>
     <message id="charger_charge_hub_1">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
-      <source>Charge &amp; HUB-1</source>
-      <translation>充电&amp;HUB-1</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+        <source>Charge &amp; HUB-1</source>
+        <translation>充电&amp;HUB-1</translation>
     </message>
     <message id="charger_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
-      <source>BMS</source>
-      <translation>BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+        <source>BMS</source>
+        <translation>BMS</translation>
     </message>
     <message id="charger_charge_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
-      <source>Charge &amp; BMS</source>
-      <translation>充电&amp;BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+        <source>Charge &amp; BMS</source>
+        <translation>充电&amp;BMS</translation>
     </message>
     <message id="charger_ext_control_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
-      <source>Ext. Control &amp; BMS</source>
-      <translation>外部控制&amp;BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+        <source>Ext. Control &amp; BMS</source>
+        <translation>外部控制&amp;BMS</translation>
     </message>
     <message id="charger_charge_hub_1_bms">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
-      <source>Charge, Hub-1 &amp; BMS</source>
-      <translation>充电、Hub-1 &amp; BMS</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+        <source>Charge, Hub-1 &amp; BMS</source>
+        <translation>充电、Hub-1 &amp; BMS</translation>
     </message>
     <message id="charger_master_setting">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
-      <source>Master setting</source>
-      <translation>主机设置</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+        <source>Master setting</source>
+        <translation>主机设置</translation>
+    </message>
+    <message id="charger_slave">
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="85"/>
+        <source>Slave</source>
+        <translation type="unfinished">从机</translation>
     </message>
     <message id="systemsettings_networkstatus_slave">
-      <location filename="../../data/SystemSettings.qml" line="85"/>
-      <source>Slave</source>
-      <extracomment>Network status: Slave</extracomment>
-      <translation>从机</translation>
+        <location filename="../data/SystemSettings.qml" line="87"/>
+        <source>Slave</source>
+        <extracomment>Network status: Slave</extracomment>
+        <translation>从机</translation>
     </message>
     <message id="charger_group_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
-      <source>Group master</source>
-      <translation>组主机</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+        <source>Group master</source>
+        <translation>组主机</translation>
     </message>
     <message id="charger_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
-      <source>Charge master</source>
-      <translation>充电主机</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+        <source>Charge master</source>
+        <translation>充电主机</translation>
     </message>
     <message id="charger_group_charge_master">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
-      <source>Group &amp; Charge master</source>
-      <translation>组&amp;充电主机</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+        <source>Group &amp; Charge master</source>
+        <translation>组&amp;充电主机</translation>
     </message>
     <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation>充电电压</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+        <source>Charge voltage</source>
+        <translation>充电电压</translation>
     </message>
     <message id="common_words_reset">
-      <location filename="../../components/CommonWords.qml" line="388"/>
-      <source>Reset</source>
-      <extracomment>Reset the BMS control</extracomment>
-      <translation>重置</translation>
+        <location filename="../components/CommonWords.qml" line="388"/>
+        <source>Reset</source>
+        <translation>重置</translation>
     </message>
     <message id="charger_network_bms_control_info">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
-      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
-      <translation>当BMS存在时，将自动启用 BMS 控制。如果系统配置更改或没有BMS 存在，则重置。</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+        <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+        <translation>当BMS存在时，将自动启用 BMS 控制。如果系统配置更改或没有BMS 存在，则重置。</translation>
+    </message>
+    <message id="charger_total_pv_power">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="50"/>
+        <source>Total PV Power</source>
+        <translation type="unfinished">总的光伏功率</translation>
     </message>
     <message id="charger_load">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="116"/>
-      <source>Load</source>
-      <translation>负载</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="116"/>
+        <source>Load</source>
+        <translation>负载</translation>
     </message>
     <message id="charger_history_found_with_count">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="151"/>
-      <source>%1 found</source>
-      <extracomment>Shows number of items found. %1 = number of items</extracomment>
-      <translation>%1 找到</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="151"/>
+        <source>%1 found</source>
+        <extracomment>Shows number of items found. %1 = number of items</extracomment>
+        <translation>%1 找到</translation>
+    </message>
+    <message id="charger_history_name">
+        <location filename="../pages/solar/SolarChargerPage.qml" line="188"/>
+        <source>%1 History</source>
+        <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+        <translation type="unfinished">%1 历史</translation>
     </message>
     <message id="settings_multirs_history_name">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
-      <source>%1 History</source>
-      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
-      <translation>%1 历史</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="114"/>
+        <source>%1 History</source>
+        <extracomment>Multi RS historic PV data information. %1 = Multi RS name</extracomment>
+        <translation>%1 历史</translation>
     </message>
     <message id="charger_networked_operation">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="196"/>
-      <source>Networked operation</source>
-      <translation>网络操作</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="196"/>
+        <source>Networked operation</source>
+        <translation>网络操作</translation>
     </message>
     <message id="charger_history_table_view">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
-      <source>Table view</source>
-      <translation>表格视图</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="24"/>
+        <source>Table view</source>
+        <translation>表格视图</translation>
     </message>
     <message id="charger_history_chart">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
-      <source>Chart</source>
-      <translation>图表</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="26"/>
+        <source>Chart</source>
+        <translation>图表</translation>
     </message>
     <message id="listitems_alarm_level_warning">
-      <location filename="../../components/listitems/ListAlarm.qml" line="21"/>
-      <source>Warning</source>
-      <extracomment>Voltage alarm is at "Warning" level</extracomment>
-      <translation>警告</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="21"/>
+        <source>Warning</source>
+        <extracomment>Voltage alarm is at &quot;Warning&quot; level</extracomment>
+        <translation>警告</translation>
+    </message>
+    <message id="listitems_alarm_level_alarm">
+        <location filename="../components/listitems/ListAlarm.qml" line="25"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">报警</translation>
     </message>
     <message id="digitalinputs_state_alarm">
-      <location filename="../../data/DigitalInputs.qml" line="80"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation>报警</translation>
+        <location filename="../data/DigitalInputs.qml" line="80"/>
+        <source>Alarm</source>
+        <extracomment>Digital input is in &apos;alarm&apos; state</extracomment>
+        <translation>报警</translation>
     </message>
     <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
-      <source>Volume</source>
-      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
-      <translation>容积</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+        <source>Volume</source>
+        <extracomment>Title for a list of units of volume (e.g. cubic meters, liters, gallons)</extracomment>
+        <translation>容积</translation>
     </message>
     <message id="tank_status_short_circuited">
-      <location filename="../../data/Tanks.qml" line="132"/>
-      <source>Short circuited</source>
-      <translation>短路</translation>
+        <location filename="../data/Tanks.qml" line="132"/>
+        <source>Short circuited</source>
+        <translation>短路</translation>
     </message>
     <message id="tank_status_reverse_polarity">
-      <location filename="../../data/Tanks.qml" line="135"/>
-      <source>Reverse polarity</source>
-      <translation>极性接反</translation>
+        <location filename="../data/Tanks.qml" line="135"/>
+        <source>Reverse polarity</source>
+        <translation>极性接反</translation>
     </message>
     <message id="evcs_charging_stations">
-      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
-      <source>EV Charging Stations</source>
-      <translation>电动汽车充电站</translation>
+        <location filename="../pages/evcs/EvChargerListPage.qml" line="13"/>
+        <source>EV Charging Stations</source>
+        <translation>电动汽车充电站</translation>
     </message>
     <message id="evcs_session">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
-      <source>Session</source>
-      <translation>进程</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="40"/>
+        <source>Session</source>
+        <translation>进程</translation>
     </message>
     <message id="evcs_charging_time">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
-      <source>Time</source>
-      <extracomment>Charging time for the EV charger</extracomment>
-      <translation>时间</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="62"/>
+        <source>Time</source>
+        <extracomment>Charging time for the EV charger</extracomment>
+        <translation>时间</translation>
     </message>
     <message id="evcs_charge_mode">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
-      <source>Charge mode</source>
-      <translation>充电模式</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="109"/>
+        <source>Charge mode</source>
+        <translation>充电模式</translation>
     </message>
     <message id="evcs_manual_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="117"/>
-      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
-      <translation>自行启动和停止进程。可用于快速充电和密切监控。</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="117"/>
+        <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+        <translation>自行启动和停止进程。可用于快速充电和密切监控。</translation>
     </message>
     <message id="evcs_auto_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="123"/>
-      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
-      <translation>根据电池电量启动和停止。最适合隔夜充电和长时间充电，以避免过度充电。</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="123"/>
+        <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+        <translation>根据电池电量启动和停止。最适合隔夜充电和长时间充电，以避免过度充电。</translation>
     </message>
     <message id="evcs_scheduled_caption">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="129"/>
-      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
-      <translation>在非高峰时段或如果您想确保您的电动汽车在特定时间充满电并准备就绪，则可降低电费。</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="129"/>
+        <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+        <translation>在非高峰时段或如果您想确保您的电动汽车在特定时间充满电并准备就绪，则可降低电费。</translation>
     </message>
     <message id="evcs_enable_charging">
-      <location filename="../../pages/evcs/EvChargerPage.qml" line="146"/>
-      <source>Enable charging</source>
-      <translation>激活充电</translation>
+        <location filename="../pages/evcs/EvChargerPage.qml" line="146"/>
+        <source>Enable charging</source>
+        <translation>激活充电</translation>
     </message>
     <message id="evcs_lock_charger_display">
-      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="42"/>
-      <source>Lock charger display</source>
-      <translation>锁定充电器屏幕</translation>
+        <location filename="../pages/evcs/EvChargerSetupPage.qml" line="42"/>
+        <source>Lock charger display</source>
+        <translation>锁定充电器屏幕</translation>
     </message>
     <message id="settings_rvc_source_address">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
-      <source>Source Address</source>
-      <translation>源地址</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+        <source>Source Address</source>
+        <translation>源地址</translation>
     </message>
     <message id="settings_rvc_configuration">
-      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
-      <source>Configuration</source>
-      <translation>设置</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+        <source>Configuration</source>
+        <translation>设置</translation>
     </message>
     <message id="settings_rvc_line_instance_num">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
-      <source>Line instance #%1</source>
-      <extracomment>%1 = number of this line instance</extracomment>
-      <translation>行实例 #%1</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+        <source>Line instance #%1</source>
+        <extracomment>%1 = number of this line instance</extracomment>
+        <translation>行实例 #%1</translation>
     </message>
     <message id="settings_rvc_line_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
-      <source>Line instance</source>
-      <translation>线路实例</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+        <source>Line instance</source>
+        <translation>线路实例</translation>
     </message>
     <message id="settings_rvc_charger_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
-      <source>Charger instance</source>
-      <translation>充电器实例</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+        <source>Charger instance</source>
+        <translation>充电器实例</translation>
     </message>
     <message id="settings_rvc_inverter_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
-      <source>Inverter instance</source>
-      <translation>逆变器实例</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+        <source>Inverter instance</source>
+        <translation>逆变器实例</translation>
     </message>
     <message id="settings_rvc_dc_source_#_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
-      <source>DC source #%1 instance</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>直流源 #%1 实例</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+        <source>DC source #%1 instance</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>直流源 #%1 实例</translation>
     </message>
     <message id="settings_rvc_dc_source_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
-      <source>DC source instance</source>
-      <translation>直流源实例</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+        <source>DC source instance</source>
+        <translation>直流源实例</translation>
     </message>
     <message id="settings_rvc_dc_source_#_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
-      <source>DC source #%1 priority</source>
-      <extracomment>%1 = number of this DC source</extracomment>
-      <translation>直流源 #%1 优先级</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+        <source>DC source #%1 priority</source>
+        <extracomment>%1 = number of this DC source</extracomment>
+        <translation>直流源 #%1 优先级</translation>
     </message>
     <message id="settings_rvc_dc_source_priority">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
-      <source>DC source priority</source>
-      <translation>直流源优先</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+        <source>DC source priority</source>
+        <translation>直流源优先</translation>
     </message>
     <message id="settings_rvc_tank_instance">
-      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
-      <source>Tank instance</source>
-      <translation>液位实例</translation>
+        <location filename="../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+        <source>Tank instance</source>
+        <translation>液位实例</translation>
     </message>
     <message id="settings_rvc_devices">
-      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
-      <source>RV-C devices</source>
-      <translation>RV-C 设备</translation>
+        <location filename="../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+        <source>RV-C devices</source>
+        <translation>RV-C 设备</translation>
     </message>
     <message id="settings_page_debug_enable_fps_visualizer">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
-      <source>Enable frame-rate visualizer</source>
-      <translation>启用帧速率可视化器</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="50"/>
+        <source>Enable frame-rate visualizer</source>
+        <translation>启用帧速率可视化器</translation>
     </message>
     <message id="devicelist_unsupported">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
-      <source>Unsupported</source>
-      <extracomment>Device is not supported</extracomment>
-      <translation>不支持</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="209"/>
+        <source>Unsupported</source>
+        <extracomment>Device is not supported</extracomment>
+        <translation>不支持</translation>
     </message>
     <message id="devicelist_remove_disconnected_devices">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
-      <source>Remove disconnected devices</source>
-      <translation>移除断开连接的设备</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="233"/>
+        <source>Remove disconnected devices</source>
+        <translation>移除断开连接的设备</translation>
     </message>
     <message id="devicelist_unsupporteddevices_found">
-      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
-      <source>Unsupported device found</source>
-      <translation>发现不支持的设备</translation>
+        <location filename="../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+        <source>Unsupported device found</source>
+        <translation>发现不支持的设备</translation>
     </message>
     <message id="batterysettingrelay_relay_function">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
-      <source>Relay function</source>
-      <translation>继电器功能</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+        <source>Relay function</source>
+        <translation>继电器功能</translation>
+    </message>
+    <message id="batterysettingrelay_alarm">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
+        <source>Alarm</source>
+        <extracomment>Relay function is &apos;alarm&apos;</extracomment>
+        <translation type="unfinished">报警</translation>
     </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
-      <source>Charger or generator start/stop</source>
-      <translation>充电器或发动机启/停</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+        <source>Charger or generator start/stop</source>
+        <translation>充电器或发动机启/停</translation>
+    </message>
+    <message id="batterysettingrelay_manual_control">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
+        <source>Manual control</source>
+        <translation type="unfinished">手动控制</translation>
+    </message>
+    <message id="batterysettingrelay_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">保险熔断</translation>
     </message>
     <message id="common_words_manual_control">
-      <location filename="../../components/CommonWords.qml" line="256"/>
-      <source>Manual control</source>
-      <translation>手动控制</translation>
+        <location filename="../components/CommonWords.qml" line="256"/>
+        <source>Manual control</source>
+        <translation>手动控制</translation>
     </message>
     <message id="batterysettingrelay_always_open_dont_use_the_relay">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
-      <source>Always open (don't use the relay)</source>
-      <translation>始终打开（不使用继电器）</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+        <source>Always open (don&apos;t use the relay)</source>
+        <translation>始终打开（不使用继电器）</translation>
     </message>
     <message id="batterysettingrelay_low_state_of_charge_setting_note">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
-      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
-      <translation>请注意，更改低充电状态设置也会更改电池菜单中的放电下限时间设置。</translation>
+        <location filename="../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+        <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+        <translation>请注意，更改低充电状态设置也会更改电池菜单中的放电下限时间设置。</translation>
     </message>
     <message id="lynxdistributor_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
-      <source>Fuse blown</source>
-      <translation>保险熔断</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+        <source>Fuse blown</source>
+        <translation>保险熔断</translation>
     </message>
     <message id="batterydiagnostics_status_leds">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
-      <source>Status LEDs</source>
-      <translation>状态指示灯</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+        <source>Status LEDs</source>
+        <translation>状态指示灯</translation>
+    </message>
+    <message id="batterydiagnostics_none">
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
+        <source>None</source>
+        <extracomment>Indicates no alarm is set</extracomment>
+        <translation type="unfinished">无</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
-      <source>Main Switch</source>
-      <translation>主开关</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+        <source>Main Switch</source>
+        <translation>主开关</translation>
     </message>
     <message id="batterydiagnostics_heater">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
-      <source>Heater</source>
-      <translation>加热器</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+        <source>Heater</source>
+        <translation>加热器</translation>
     </message>
     <message id="batterydiagnostics_internal_fan">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
-      <source>Internal Fan</source>
-      <translation>内部风扇</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+        <source>Internal Fan</source>
+        <translation>内部风扇</translation>
     </message>
     <message id="batterydiagnostics_warning_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
-      <source>Warning Flags</source>
-      <translation>警告标志</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+        <source>Warning Flags</source>
+        <translation>警告标志</translation>
     </message>
     <message id="batterydiagnostics_alarm_flags">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
-      <source>Alarm Flags</source>
-      <translation>报警标志</translation>
+        <location filename="../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+        <source>Alarm Flags</source>
+        <translation>报警标志</translation>
     </message>
     <message id="common_words_switch">
-      <location filename="../../components/CommonWords.qml" line="462"/>
-      <source>Switch</source>
-      <extracomment>Change the battery mode</extracomment>
-      <translation>开关</translation>
+        <location filename="../components/CommonWords.qml" line="462"/>
+        <source>Switch</source>
+        <extracomment>Change the mode value</extracomment>
+        <translation>开关</translation>
     </message>
     <message id="devicelist_battery_initializing">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
-      <source>Initializing</source>
-      <translation>初始化</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="42"/>
+        <source>Initializing</source>
+        <translation>初始化</translation>
     </message>
     <message id="devicelist_battery_shutdown">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
-      <source>Shutdown</source>
-      <extracomment>Status is 'Shutdown'</extracomment>
-      <translation>关机</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="53"/>
+        <source>Shutdown</source>
+        <extracomment>Status is &apos;Shutdown&apos;</extracomment>
+        <translation>关机</translation>
     </message>
     <message id="devicelist_battery_updating">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
-      <source>Updating</source>
-      <extracomment>Status is 'Updating'</extracomment>
-      <translation>正在更新</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+        <source>Updating</source>
+        <extracomment>Status is &apos;Updating&apos;</extracomment>
+        <translation>正在更新</translation>
     </message>
     <message id="devicelist_battery_going_to_run">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
-      <source>Going to run</source>
-      <extracomment>Status is 'Going to run'</extracomment>
-      <translation>即将运行</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="63"/>
+        <source>Going to run</source>
+        <extracomment>Status is &apos;Going to run&apos;</extracomment>
+        <translation>即将运行</translation>
     </message>
     <message id="devicelist_battery_pre_charging">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
-      <source>Pre-Charging</source>
-      <extracomment>Status is 'Pre-Charging'</extracomment>
-      <translation>预充电</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+        <source>Pre-Charging</source>
+        <extracomment>Status is &apos;Pre-Charging&apos;</extracomment>
+        <translation>预充电</translation>
     </message>
     <message id="devicelist_battery_contactor_check">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
-      <source>Contactor check</source>
-      <extracomment>Status is 'Contactor check'</extracomment>
-      <translation>接触器检查</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+        <source>Contactor check</source>
+        <extracomment>Status is &apos;Contactor check&apos;</extracomment>
+        <translation>接触器检查</translation>
     </message>
     <message id="batteryalarms_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
-      <source>State of health</source>
-      <translation>健康状态</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+        <source>State of health</source>
+        <translation>健康状态</translation>
     </message>
     <message id="common_words_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery temperature</source>
-      <translation>电池温度</translation>
+        <location filename="../components/CommonWords.qml" line="89"/>
+        <source>Battery temperature</source>
+        <translation>电池温度</translation>
     </message>
     <message id="battery_air_temp">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
-      <source>Air temperature</source>
-      <translation>空气温度</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="176"/>
+        <source>Air temperature</source>
+        <translation>空气温度</translation>
     </message>
     <message id="battery_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
-      <source>Starter voltage</source>
-      <translation>启动电池电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="183"/>
+        <source>Starter voltage</source>
+        <translation>启动电池电压</translation>
     </message>
     <message id="battery_buss_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
-      <source>Bus voltage</source>
-      <translation>总线电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+        <source>Bus voltage</source>
+        <translation>总线电压</translation>
     </message>
     <message id="battery_top_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
-      <source>Top section voltage</source>
-      <translation>顶边电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="199"/>
+        <source>Top section voltage</source>
+        <translation>顶边电压</translation>
+    </message>
+    <message id="battery_bank_error_communication">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="95"/>
+        <source>Communication error</source>
+        <translation type="unfinished">通信错误</translation>
+    </message>
+    <message id="battery_state_of_health">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="161"/>
+        <source>State of health</source>
+        <translation type="unfinished">健康状态</translation>
+    </message>
+    <message id="battery_bus_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="191"/>
+        <source>Bus voltage</source>
+        <translation type="unfinished">总线电压</translation>
     </message>
     <message id="battery_bottom_section_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
-      <source>Bottom section voltage</source>
-      <translation>底边电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+        <source>Bottom section voltage</source>
+        <translation>底边电压</translation>
     </message>
     <message id="battery_mid_point_deviation">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
-      <source>Mid-point deviation</source>
-      <translation>中间点差异</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="215"/>
+        <source>Mid-point deviation</source>
+        <translation>中间点差异</translation>
     </message>
     <message id="battery_consumed_amphours">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
-      <source>Consumed AmpHours</source>
-      <translation>消耗安时数</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+        <source>Consumed AmpHours</source>
+        <translation>消耗安时数</translation>
     </message>
     <message id="battery_time_to_go">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
-      <source>Time-to-go</source>
-      <translation>剩余时间</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+        <source>Time-to-go</source>
+        <translation>剩余时间</translation>
     </message>
     <message id="battery_details">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
-      <source>Details</source>
-      <translation>细节</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+        <source>Details</source>
+        <translation>细节</translation>
     </message>
     <message id="battery_module_level_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
-      <source>Module level alarms</source>
-      <translation>模块级报警</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+        <source>Module level alarms</source>
+        <translation>模块级报警</translation>
     </message>
     <message id="battery_settings_diagnostics">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
-      <source>Diagnostics</source>
-      <translation>诊断</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="314"/>
+        <source>Diagnostics</source>
+        <translation>诊断</translation>
     </message>
     <message id="battery_settings_fuses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
-      <source>Fuses</source>
-      <translation>保险</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="339"/>
+        <source>Fuses</source>
+        <translation>保险</translation>
     </message>
     <message id="battery_settings_io">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
-      <source>IO</source>
-      <translation>IO</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="355"/>
+        <source>IO</source>
+        <translation>IO</translation>
     </message>
     <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
-      <source>System</source>
-      <translation>系统</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="370"/>
+        <source>System</source>
+        <translation>系统</translation>
     </message>
     <message id="battery_settings_parameters">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
-      <source>Parameters</source>
-      <translation>参数</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="393"/>
+        <source>Parameters</source>
+        <translation>参数</translation>
     </message>
     <message id="battery_redetect_battery">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
-      <source>Redetect Battery</source>
-      <translation>重新检测电池</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="418"/>
+        <source>Redetect Battery</source>
+        <translation>重新检测电池</translation>
+    </message>
+    <message id="battery_press_to_redetect">
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="420"/>
+        <source>Press to redetect</source>
+        <translation type="unfinished">按下重新检测</translation>
     </message>
     <message id="vebus_device_press_to_redetect">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
-      <source>Press to redetect</source>
-      <translation>按下重新检测</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+        <source>Press to redetect</source>
+        <translation>按下重新检测</translation>
     </message>
     <message id="battery_redetecting_the_battery_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
-      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
-      <translation>重新检测电池可能要花60秒。期间电池名称可能有误。</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="427"/>
+        <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+        <translation>重新检测电池可能要花60秒。期间电池名称可能有误。</translation>
     </message>
     <message id="batteryalarms_high_charge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
-      <source>High charge current</source>
-      <translation>充电电流大</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+        <source>High charge current</source>
+        <translation>充电电流大</translation>
     </message>
     <message id="batteryalarms_high_discharge_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
-      <source>High discharge current</source>
-      <translation>放电电流大</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+        <source>High discharge current</source>
+        <translation>放电电流大</translation>
     </message>
     <message id="evchargers_status_low_state_of_charge">
-      <location filename="../../data/EvChargers.qml" line="106"/>
-      <source>Low SOC</source>
-      <translation>SOC低</translation>
+        <location filename="../data/EvChargers.qml" line="106"/>
+        <source>Low SOC</source>
+        <translation>SOC低</translation>
+    </message>
+    <message id="batteryalarms_high_battery_voltage">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
+        <source>High battery voltage</source>
+        <translation type="unfinished">电池电压高</translation>
+    </message>
+    <message id="batteryalarms_low_soc">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+        <source>Low SOC</source>
+        <translation type="unfinished">SOC低</translation>
     </message>
     <message id="batteryalarms_low_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low starter voltage</source>
-      <translation>启动电池电压低</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
+        <source>Low starter voltage</source>
+        <translation>启动电池电压低</translation>
     </message>
     <message id="batteryalarms_high_starter_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
-      <source>High starter voltage</source>
-      <translation>启动电压高</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+        <source>High starter voltage</source>
+        <translation>启动电压高</translation>
     </message>
     <message id="batteryalarms_battery_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
-      <source>Battery temperature sensor</source>
-      <translation>电池温度传感器</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="85"/>
+        <source>Battery temperature sensor</source>
+        <translation>电池温度传感器</translation>
     </message>
     <message id="batteryalarms_mid_point_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
-      <source>Mid-point voltage</source>
-      <translation>中间点电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="92"/>
+        <source>Mid-point voltage</source>
+        <translation>中间点电压</translation>
+    </message>
+    <message id="batteryalarms_fuse_blown">
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+        <source>Fuse blown</source>
+        <translation type="unfinished">保险熔断</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
-      <source>High internal temperature</source>
-      <translation>内部温度高</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+        <source>High internal temperature</source>
+        <translation>内部温度高</translation>
     </message>
     <message id="batteryalarms_low_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Low charge temperature</source>
-      <translation>充电温度低</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
+        <source>Low charge temperature</source>
+        <translation>充电温度低</translation>
     </message>
     <message id="batteryalarms_high_charge_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
-      <source>High charge temperature</source>
-      <translation>充电温度高</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+        <source>High charge temperature</source>
+        <translation>充电温度高</translation>
     </message>
     <message id="batteryalarms_internal_failure">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
-      <source>Internal failure</source>
-      <translation>内部故障</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+        <source>Internal failure</source>
+        <translation>内部故障</translation>
     </message>
     <message id="batteryalarms_circuit_breaker_tripped">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
-      <source>Circuit breaker tripped</source>
-      <translation>断路器跳闸</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+        <source>Circuit breaker tripped</source>
+        <translation>断路器跳闸</translation>
     </message>
     <message id="batteryalarms_cell_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
-      <source>Cell imbalance</source>
-      <translation>电芯不平衡</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+        <source>Cell imbalance</source>
+        <translation>电芯不平衡</translation>
     </message>
     <message id="batteryalarms_low_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
-      <source>Low cell voltage</source>
-      <translation>电芯电压低</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+        <source>Low cell voltage</source>
+        <translation>电芯电压低</translation>
     </message>
     <message id="batterydetails_lowest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
-      <source>Lowest cell voltage</source>
-      <translation>最低电芯电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+        <source>Lowest cell voltage</source>
+        <translation>最低电芯电压</translation>
     </message>
     <message id="batterydetails_highest_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
-      <source>Highest cell voltage</source>
-      <translation>最高电芯电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+        <source>Highest cell voltage</source>
+        <translation>最高电芯电压</translation>
     </message>
     <message id="batterydetails_minimum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
-      <source>Minimum cell temperature</source>
-      <translation>最低电芯温度</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+        <source>Minimum cell temperature</source>
+        <translation>最低电芯温度</translation>
     </message>
     <message id="batterydetails_maximum_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
-      <source>Maximum cell temperature</source>
-      <translation>最高电芯温度</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+        <source>Maximum cell temperature</source>
+        <translation>最高电芯温度</translation>
     </message>
     <message id="batterydetails_modules">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
-      <source>Battery modules</source>
-      <translation>电池模快</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+        <source>Battery modules</source>
+        <translation>电池模快</translation>
     </message>
     <message id="devicelist_batterydetails_modules_online">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
-      <source>%1 online</source>
-      <extracomment>%1 = number of battery modules that are online</extracomment>
-      <translation>%1 在线</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+        <source>%1 online</source>
+        <extracomment>%1 = number of battery modules that are online</extracomment>
+        <translation>%1 在线</translation>
     </message>
     <message id="devicelist_batterydetails_modules_offline">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
-      <source>%1 offline</source>
-      <extracomment>%1 = number of battery modules that are offline</extracomment>
-      <translation>%1 离线</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+        <source>%1 offline</source>
+        <extracomment>%1 = number of battery modules that are offline</extracomment>
+        <translation>%1 离线</translation>
     </message>
     <message id="batterydetails_number_of_modules_blocking_charge_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
-      <source>Number of modules blocking charge / discharge</source>
-      <translation>阻止充电/放电的模块数量</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+        <source>Number of modules blocking charge / discharge</source>
+        <translation>阻止充电/放电的模块数量</translation>
     </message>
     <message id="batterydetails_installed_available_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
-      <source>Installed / Available capacity</source>
-      <translation>装机/可用容量</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+        <source>Installed / Available capacity</source>
+        <translation>装机/可用容量</translation>
     </message>
     <message id="batteryalarms_deepest_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
-      <source>Deepest discharge</source>
-      <translation>最大深度放电</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+        <source>Deepest discharge</source>
+        <translation>最大深度放电</translation>
     </message>
     <message id="batteryhistory_last_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
-      <source>Last discharge</source>
-      <translation>上次放电</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+        <source>Last discharge</source>
+        <translation>上次放电</translation>
     </message>
     <message id="batteryhistory_average_discharge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
-      <source>Average discharge</source>
-      <translation>平均放电</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+        <source>Average discharge</source>
+        <translation>平均放电</translation>
     </message>
     <message id="batteryhistory_total_charge_cycles">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
-      <source>Total charge cycles</source>
-      <translation>总计充电循环</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+        <source>Total charge cycles</source>
+        <translation>总计充电循环</translation>
     </message>
     <message id="batteryhistory_number_of_full_discharges">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
-      <source>Number of full discharges</source>
-      <translation>完全放电次数</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+        <source>Number of full discharges</source>
+        <translation>完全放电次数</translation>
     </message>
     <message id="batteryhistory_cumulative_ah_drawn">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
-      <source>Cumulative Ah drawn</source>
-      <translation>累计消耗安时数</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+        <source>Cumulative Ah drawn</source>
+        <translation>累计消耗安时数</translation>
     </message>
     <message id="batteryhistory_minimum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
-      <source>Minimum cell voltage</source>
-      <translation>最低电芯电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+        <source>Minimum cell voltage</source>
+        <translation>最低电芯电压</translation>
     </message>
     <message id="batteryhistory_maximum_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
-      <source>Maximum cell voltage</source>
-      <translation>最高电芯电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+        <source>Maximum cell voltage</source>
+        <translation>最高电芯电压</translation>
     </message>
     <message id="batteryhistory_time_since_last_full_charge">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
-      <source>Time since last full charge</source>
-      <translation>上次充满电到现在的时间</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+        <source>Time since last full charge</source>
+        <translation>上次充满电到现在的时间</translation>
     </message>
     <message id="batteryhistory_synchronisation_count">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
-      <source>Synchronisation count</source>
-      <translation>同步计数</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+        <source>Synchronisation count</source>
+        <translation>同步计数</translation>
     </message>
     <message id="batteryhistory_low_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
-      <source>Low starter battery voltage alarms</source>
-      <translation>启动电池电压低警报</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+        <source>Low starter battery voltage alarms</source>
+        <translation>启动电池电压低警报</translation>
     </message>
     <message id="batteryhistory_minimum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
-      <source>Minimum starter battery voltage</source>
-      <translation>启动电池最低电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+        <source>Minimum starter battery voltage</source>
+        <translation>启动电池最低电压</translation>
     </message>
     <message id="batteryhistory_maximum_starter_bat_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
-      <source>Maximum starter battery voltage</source>
-      <translation>启动电池最高电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+        <source>Maximum starter battery voltage</source>
+        <translation>启动电池最高电压</translation>
     </message>
     <message id="batteryhistory_discharged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
-      <source>Discharged energy</source>
-      <translation>放电量</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+        <source>Discharged energy</source>
+        <translation>放电量</translation>
     </message>
     <message id="batteryhistory_charged_energy">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
-      <source>Charged energy</source>
-      <translation>充电量</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+        <source>Charged energy</source>
+        <translation>充电量</translation>
     </message>
     <message id="batteryparameters_charge_voltage_limit_cvl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
-      <source>Charge Voltage Limit (CVL)</source>
-      <translation>充电电压限制(CVL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+        <source>Charge Voltage Limit (CVL)</source>
+        <translation>充电电压限制(CVL)</translation>
     </message>
     <message id="batteryparameters_charge_current_limit_ccl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
-      <source>Charge Current Limit (CCL)</source>
-      <translation>充电电流限制(CCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+        <source>Charge Current Limit (CCL)</source>
+        <translation>充电电流限制(CCL)</translation>
     </message>
     <message id="batteryparameters_discharge_current_limit_dcl">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
-      <source>Discharge Current Limit (DCL)</source>
-      <translation>放电电流限制(DCL)</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+        <source>Discharge Current Limit (DCL)</source>
+        <translation>放电电流限制(DCL)</translation>
     </message>
     <message id="batteryparameters_low_voltage_disconnect_always_ignored">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
-      <source>Low Voltage Disconnect (always ignored)</source>
-      <translation>低压断开（始终忽略）</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+        <source>Low Voltage Disconnect (always ignored)</source>
+        <translation>低压断开（始终忽略）</translation>
     </message>
     <message id="batterysettings_battery_bank">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
-      <source>Battery bank</source>
-      <translation>电池组</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+        <source>Battery bank</source>
+        <translation>电池组</translation>
     </message>
     <message id="batterysettings_relay_on_battery_monitor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
-      <source>Relay (on battery monitor)</source>
-      <translation>继电器（电池监测仪上）</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+        <source>Relay (on battery monitor)</source>
+        <translation>继电器（电池监测仪上）</translation>
     </message>
     <message id="batterysettings_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
-      <source>Restore factory defaults</source>
-      <translation>恢复出厂默认设置</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+        <source>Restore factory defaults</source>
+        <translation>恢复出厂默认设置</translation>
     </message>
     <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation>按下恢复</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+        <source>Press to restore</source>
+        <translation>按下恢复</translation>
     </message>
     <message id="batterysettings_confirm_restore_factory_defaults">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
-      <source>Restore factory defaults?</source>
-      <translation>恢复出厂默认设置？</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+        <source>Restore factory defaults?</source>
+        <translation>恢复出厂默认设置？</translation>
     </message>
     <message id="batterysettings_bluetooth_enabled">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
-      <source>Bluetooth Enabled</source>
-      <translation>蓝牙已启用</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+        <source>Bluetooth Enabled</source>
+        <translation>蓝牙已启用</translation>
     </message>
     <message id="batterysettingsbattery_nominal_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
-      <source>Nominal Voltage</source>
-      <translation>额定电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+        <source>Nominal Voltage</source>
+        <translation>额定电压</translation>
     </message>
     <message id="batterysettingsbattery_12_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
-      <source>12 Volt</source>
-      <translation>12V</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+        <source>12 Volt</source>
+        <translation>12V</translation>
     </message>
     <message id="batterysettingsbattery_24_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
-      <source>24 Volt</source>
-      <translation>24V</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+        <source>24 Volt</source>
+        <translation>24V</translation>
     </message>
     <message id="batterysettingsbattery_48_volt">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
-      <source>48 Volt</source>
-      <translation>48V</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+        <source>48 Volt</source>
+        <translation>48V</translation>
     </message>
     <message id="devicelist_tanksetup_capacity">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
-      <source>Capacity</source>
-      <translation>容量</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+        <source>Capacity</source>
+        <translation>容量</translation>
+    </message>
+    <message id="batterysettingsbattery_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
+        <source>Capacity</source>
+        <translation type="unfinished">容量</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
-      <source>Charged voltage</source>
-      <translation>充电电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+        <source>Charged voltage</source>
+        <translation>充电电压</translation>
     </message>
     <message id="batterysettingsbattery_tail_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
-      <source>Tail current</source>
-      <translation>尾电流</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+        <source>Tail current</source>
+        <translation>尾电流</translation>
     </message>
     <message id="batterysettingsbattery_charged_detection_time">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
-      <source>Charged detection time</source>
-      <translation>已充电侦测时间</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+        <source>Charged detection time</source>
+        <translation>已充电侦测时间</translation>
     </message>
     <message id="batterysettingsbattery_peukert_exponent">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
-      <source>Peukert exponent</source>
-      <translation>Peukert因子</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+        <source>Peukert exponent</source>
+        <translation>Peukert因子</translation>
     </message>
     <message id="batterysettingsbattery_charge_efficiency_factor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
-      <source>Charge efficiency factor</source>
-      <translation>充电效率因数</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+        <source>Charge efficiency factor</source>
+        <translation>充电效率因数</translation>
     </message>
     <message id="batterysettingsbattery_current_threshold">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
-      <source>Current threshold</source>
-      <translation>电流阀值</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+        <source>Current threshold</source>
+        <translation>电流阀值</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_averaging_period">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
-      <source>Time-to-go averaging period</source>
-      <translation>可使用平均时间</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+        <source>Time-to-go averaging period</source>
+        <translation>可使用平均时间</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_floor">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
-      <source>Time-to-go discharge floor</source>
-      <translation>剩余时间放电量</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+        <source>Time-to-go discharge floor</source>
+        <translation>剩余时间放电量</translation>
     </message>
     <message id="batterysettingsbattery_current_offset">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
-      <source>Current offset</source>
-      <translation>电流偏移</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+        <source>Current offset</source>
+        <translation>电流偏移</translation>
     </message>
     <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
-      <source>Synchronise state-of-charge to 100%</source>
-      <translation>电量同步为100%</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+        <source>Synchronise state-of-charge to 100%</source>
+        <translation>电量同步为100%</translation>
     </message>
     <message id="batterysettingsbattery_press_to_sync">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
-      <source>Press to sync</source>
-      <translation>按下同步</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+        <source>Press to sync</source>
+        <translation>按下同步</translation>
     </message>
     <message id="batterysettingsbattery_calibrate_zero_current">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
-      <source>Calibrate zero current</source>
-      <translation>校准零位电流</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+        <source>Calibrate zero current</source>
+        <translation>校准零位电流</translation>
     </message>
     <message id="batterysettingsbattery_press_to_set_to_0">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
-      <source>Press to set to 0</source>
-      <translation>按下设置为0</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+        <source>Press to set to 0</source>
+        <translation>按下设置为0</translation>
     </message>
     <message id="batterylynxdistibutor_distributor">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
-      <source>Distributor %1</source>
-      <translation>配电盒 %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+        <source>Distributor %1</source>
+        <translation>配电盒 %1</translation>
     </message>
     <message id="lynxdistributor_no_power_on_busbar">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
-      <source>No power on busbar</source>
-      <translation>母排无供电</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+        <source>No power on busbar</source>
+        <translation>母排无供电</translation>
+    </message>
+    <message id="lynxdistributor_connection_lost">
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
+        <source>Connection lost</source>
+        <translation type="unfinished">连接丢失</translation>
     </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
-      <source>%n fuse(s) blown</source>
-      <extracomment>%n = number of fuses that have blown</extracomment>
-      <translation>
-        <numerusform>%n 保险丝烧断</numerusform>
-      </translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+        <source>%n fuse(s) blown</source>
+        <extracomment>%n = number of fuses that have blown</extracomment>
+        <translation>
+            <numerusform>%n 保险丝烧断</numerusform>
+        </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
-      <source>No information available, see previous page for Distributor status.</source>
-      <translation>无可用信息，请参阅前一页了解配电盒状态。</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+        <source>No information available, see previous page for Distributor status.</source>
+        <translation>无可用信息，请参阅前一页了解配电盒状态。</translation>
     </message>
     <message id="lynxdistributor_fuse_name">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
-      <source>Fuse %1</source>
-      <extracomment>%1 = name of this fuse</extracomment>
-      <translation>保险 %1</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+        <source>Fuse %1</source>
+        <extracomment>%1 = name of this fuse</extracomment>
+        <translation>保险 %1</translation>
     </message>
     <message id="lynxdistributor_not_used">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
-      <source>Not used</source>
-      <translation>没有使用</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+        <source>Not used</source>
+        <translation>没有使用</translation>
     </message>
     <message id="lynxdistributor_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
-      <source>Blown</source>
-      <translation>熔断</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+        <source>Blown</source>
+        <translation>熔断</translation>
     </message>
     <message id="lynxiondiagnostics_shutdowns_due_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
-      <source>Shutdowns due error</source>
-      <translation>出错关机</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+        <source>Shutdowns due error</source>
+        <translation>出错关机</translation>
+    </message>
+    <message id="lynxiondiagnostics_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
+        <source>Last error</source>
+        <translation type="unfinished">上次出错</translation>
+    </message>
+    <message id="lynxiondiagnostics_2nd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
+        <source>2nd last error</source>
+        <translation type="unfinished">第二次出错</translation>
+    </message>
+    <message id="lynxiondiagnostics_3rd_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
+        <source>3rd last error</source>
+        <translation type="unfinished">第三次出错</translation>
+    </message>
+    <message id="lynxiondiagnostics_4th_last_error">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
+        <source>4th last error</source>
+        <translation type="unfinished">第四次出错</translation>
     </message>
     <message id="lynxionio_system_switch">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
-      <source>System Switch</source>
-      <translation>系统开关</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+        <source>System Switch</source>
+        <translation>系统开关</translation>
     </message>
     <message id="lynxionio_external_relay">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
-      <source>External relay</source>
-      <translation>外部继电器</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+        <source>External relay</source>
+        <translation>外部继电器</translation>
     </message>
     <message id="lynxionio_programmable_contact">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
-      <source>Programmable Contact</source>
-      <translation>可编程继电器</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+        <source>Programmable Contact</source>
+        <translation>可编程继电器</translation>
     </message>
     <message id="battery_list_page_title">
-      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
-      <source>Batteries</source>
-      <translation>电池</translation>
+        <location filename="../pages/battery/BatteryListPage.qml" line="15"/>
+        <source>Batteries</source>
+        <translation>电池</translation>
+    </message>
+    <message id="lynxionsystem_capacity">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
+        <source>Capacity</source>
+        <translation type="unfinished">容量</translation>
+    </message>
+    <message id="lynxionsystem_batteries">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="25"/>
+        <source>Batteries</source>
+        <translation type="unfinished">电池</translation>
     </message>
     <message id="lynxionsystem_parallel">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
-      <source>Parallel</source>
-      <translation>并联</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+        <source>Parallel</source>
+        <translation>并联</translation>
     </message>
     <message id="lynxionsystem_series">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
-      <source>Series</source>
-      <translation>串联</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+        <source>Series</source>
+        <translation>串联</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
-      <source>Min/max cell voltage</source>
-      <translation>最小/最大电芯电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+        <source>Min/max cell voltage</source>
+        <translation>最小/最大电芯电压</translation>
     </message>
     <message id="lynxionsystem_min_max_cell_temperature">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
-      <source>Min/max cell temperature</source>
-      <translation>最低/最高电芯温度</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="63"/>
+        <source>Min/max cell temperature</source>
+        <translation>最低/最高电芯温度</translation>
+    </message>
+    <message id="lynxionsystem_balancing">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="89"/>
+        <source>Balancing</source>
+        <translation type="unfinished">均衡中</translation>
     </message>
     <message id="lynxionsystem_balancer_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
-      <source>Balancing</source>
-      <translation>均衡中</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="107"/>
+        <source>Balancing</source>
+        <translation>均衡中</translation>
+    </message>
+    <message id="lynxionsystem_balancer_unknown">
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="114"/>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
     </message>
     <message id="dc_output">
-      <location filename="../../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
-      <source>Output</source>
-      <extracomment>DC output measurement values</extracomment>
-      <translation>输出</translation>
+        <location filename="../components/settings/ListDcOutputQuantityGroup.qml" line="16"/>
+        <source>Output</source>
+        <extracomment>DC output measurement values</extracomment>
+        <translation>输出</translation>
     </message>
     <message id="alternator_wakespeed_field_drive">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
-      <source>Field drive</source>
-      <translation>现场驱动</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+        <source>Field drive</source>
+        <translation>现场驱动</translation>
     </message>
     <message id="alternator_wakespeed_engine_speed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
-      <source>Engine speed</source>
-      <translation>发动机转速</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="82"/>
+        <source>Engine speed</source>
+        <translation>发动机转速</translation>
     </message>
     <message id="dcmeter_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
-      <source>Aux voltage</source>
-      <translation>辅助电压</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+        <source>Aux voltage</source>
+        <translation>辅助电压</translation>
     </message>
     <message id="dcmeter_alarms_no_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
-      <source>No alarms</source>
-      <translation>无报警</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+        <source>No alarms</source>
+        <translation>无报警</translation>
     </message>
     <message id="dcmeter_alarms_low_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
-      <source>Low voltage</source>
-      <translation>低电压</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+        <source>Low voltage</source>
+        <translation>低电压</translation>
     </message>
     <message id="dcmeter_alarms_high_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
-      <source>High voltage</source>
-      <translation>高电压</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+        <source>High voltage</source>
+        <translation>高电压</translation>
     </message>
     <message id="dcmeter_alarms_low_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
-      <source>Low aux voltage</source>
-      <translation>辅助电压低</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+        <source>Low aux voltage</source>
+        <translation>辅助电压低</translation>
     </message>
     <message id="dcmeter_alarms_high_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
-      <source>High aux voltage</source>
-      <translation>辅助电压高</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+        <source>High aux voltage</source>
+        <translation>辅助电压高</translation>
     </message>
     <message id="dcmeter_history_low_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
-      <source>Low aux voltage alarms</source>
-      <translation>辅助电压低报警</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+        <source>Low aux voltage alarms</source>
+        <translation>辅助电压低报警</translation>
     </message>
     <message id="dcmeter_history_high_aux_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
-      <source>High aux voltage alarms</source>
-      <translation>辅助电压高报警</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+        <source>High aux voltage alarms</source>
+        <translation>辅助电压高报警</translation>
     </message>
     <message id="dcmeter_history_minimum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
-      <source>Minimum aux voltage</source>
-      <translation>最小辅助电压</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+        <source>Minimum aux voltage</source>
+        <translation>最小辅助电压</translation>
     </message>
     <message id="dcmeter_history_maximum_aux_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
-      <source>Maximum aux voltage</source>
-      <translation>最高辅助电压</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+        <source>Maximum aux voltage</source>
+        <translation>最高辅助电压</translation>
     </message>
     <message id="dcmeter_history_produced_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
-      <source>Produced energy</source>
-      <translation>产出电量</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+        <source>Produced energy</source>
+        <translation>产出电量</translation>
     </message>
     <message id="dcmeter_history_consumed_energy">
-      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
-      <source>Consumed energy</source>
-      <translation>消耗电量</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+        <source>Consumed energy</source>
+        <translation>消耗电量</translation>
     </message>
     <message id="devicelist_tankalarm_enable_alarm">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
-      <source>Enable alarm</source>
-      <translation>启用报警</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+        <source>Enable alarm</source>
+        <translation>启用报警</translation>
     </message>
     <message id="devicelist_tankalarm_active_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
-      <source>Active level</source>
-      <translation>激活液位量</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+        <source>Active level</source>
+        <translation>激活液位量</translation>
     </message>
     <message id="devicelist_tankalarm_restore_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
-      <source>Restore level</source>
-      <translation>清除液位量</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+        <source>Restore level</source>
+        <translation>清除液位量</translation>
     </message>
     <message id="devicelist_tankalarm_delay">
-      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
-      <source>Delay</source>
-      <translation>延迟</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+        <source>Delay</source>
+        <translation>延迟</translation>
     </message>
     <message id="devicelist_tanksensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
-      <source>Level</source>
-      <translation>液位</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="24"/>
+        <source>Level</source>
+        <translation>液位</translation>
     </message>
     <message id="devicelist_tanksensor_remaining">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
-      <source>Remaining</source>
-      <translation>剩余</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+        <source>Remaining</source>
+        <translation>剩余</translation>
+    </message>
+    <message id="devicelist_tanksensor_sensor_battery">
+        <location filename="../pages/settings/devicelist/tank/PageTankSensor.qml" line="46"/>
+        <source>Sensor battery</source>
+        <translation type="unfinished">感应器电池</translation>
     </message>
     <message id="temperature_sensor_battery">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>Sensor battery</source>
-      <translation>感应器电池</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+        <source>Sensor battery</source>
+        <translation>感应器电池</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
-      <source>Sensor type</source>
-      <translation>感应器类型</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+        <source>Sensor type</source>
+        <translation>感应器类型</translation>
     </message>
     <message id="devicelist_tanksetup_standard">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
-      <source>Standard</source>
-      <translation>标准</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+        <source>Standard</source>
+        <translation>标准</translation>
     </message>
     <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
-      <source>European (0 to 180 Ohm)</source>
-      <translation>欧式(0 to 180 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+        <source>European (0 to 180 Ohm)</source>
+        <translation>欧式(0 to 180 Ohm)</translation>
     </message>
     <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
-      <source>US (240 to 30 Ohm)</source>
-      <translation>美式(240 to 30 Ohm)</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+        <source>US (240 to 30 Ohm)</source>
+        <translation>美式(240 to 30 Ohm)</translation>
     </message>
     <message id="settings_tailscale_custom">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
-      <source>Custom</source>
-      <translation>自定义</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="113"/>
+        <source>Custom</source>
+        <translation>自定义</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="54"/>
+        <source>Custom</source>
+        <translation type="unfinished">自定义</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
-      <source>Sensor value when empty</source>
-      <translation>空时传感器值</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+        <source>Sensor value when empty</source>
+        <translation>空时传感器值</translation>
     </message>
     <message id="devicelist_tanksetup_fluid_type">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
-      <source>Fluid type</source>
-      <translation>流体类型</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+        <source>Fluid type</source>
+        <translation>流体类型</translation>
     </message>
     <message id="devicelist_tanksetup_butane_ratio">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
-      <source>Butane ratio</source>
-      <translation>丁烷比</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+        <source>Butane ratio</source>
+        <translation>丁烷比</translation>
     </message>
     <message id="devicelist_tanksetup_custom_shape">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
-      <source>Custom shape</source>
-      <translation>自定义形状</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+        <source>Custom shape</source>
+        <translation>自定义形状</translation>
     </message>
     <message id="devicelist_tanksetup_averaging_time">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
-      <source>Averaging time</source>
-      <translation>平均时间</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+        <source>Averaging time</source>
+        <translation>平均时间</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
-      <source>Sensor value</source>
-      <translation>感应器数值</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+        <source>Sensor value</source>
+        <translation>感应器数值</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
-      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
-      <translation>未定义自定义形状。您最多可以定义 10 个点。请注意，0% 和 100% 是隐含的。</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+        <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+        <translation>未定义自定义形状。您最多可以定义 10 个点。请注意，0% 和 100% 是隐含的。</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
-      <source>Point %1</source>
-      <extracomment>%1 = the point number</extracomment>
-      <translation>点 %1</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+        <source>Point %1</source>
+        <extracomment>%1 = the point number</extracomment>
+        <translation>点 %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
-      <source>Add point</source>
-      <translation>添加点</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+        <source>Add point</source>
+        <translation>添加点</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
-      <source>Sensor level</source>
-      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
-      <translation>传感器液位</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+        <source>Sensor level</source>
+        <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+        <translation>传感器液位</translation>
+    </message>
+    <message id="devicelist_tankshape_volume">
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="170"/>
+        <source>Volume</source>
+        <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+        <translation type="unfinished">容积</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
-      <source>Duplicate sensor level values are not allowed.</source>
-      <translation>不允许重复传感器数值。</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+        <source>Duplicate sensor level values are not allowed.</source>
+        <translation>不允许重复传感器数值。</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
-      <source>Volume values must be increasing.</source>
-      <translation>体积值必须不断增加。</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+        <source>Volume values must be increasing.</source>
+        <translation>体积值必须不断增加。</translation>
     </message>
     <message id="cycle_history_watchdog">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
-      <source>Watchdog</source>
-      <translation>看门狗</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+        <source>Watchdog</source>
+        <translation>看门狗</translation>
     </message>
     <message id="ac-in-setup_unlocked_(kvarh)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
-      <source>Unlocked (kVARh)</source>
-      <translation>解锁 (kVARh)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+        <source>Unlocked (kVARh)</source>
+        <translation>解锁 (kVARh)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(2)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
-      <source>Unlocked (2)</source>
-      <translation>解锁 (2)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+        <source>Unlocked (2)</source>
+        <translation>解锁 (2)</translation>
     </message>
     <message id="ac-in-setup_unlocked_(1)">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
-      <source>Unlocked (1)</source>
-      <translation>解锁 (1)</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+        <source>Unlocked (1)</source>
+        <translation>解锁 (1)</translation>
     </message>
     <message id="ac-in-setup_locked">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
-      <source>Locked</source>
-      <translation>锁定</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+        <source>Locked</source>
+        <translation>锁定</translation>
     </message>
     <message id="ac-in-setup_phase_configuration">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
-      <source>Phase configuration</source>
-      <translation>相位配置</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="101"/>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="132"/>
+        <source>Phase configuration</source>
+        <translation>相位配置</translation>
     </message>
     <message id="ac-in-setup_switch_position">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
-      <source>Switch position</source>
-      <translation>开关位置</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="117"/>
+        <source>Switch position</source>
+        <translation>开关位置</translation>
+    </message>
+    <message id="ac-in-setup_single_phase">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+        <source>Single phase</source>
+        <translation type="unfinished">单相</translation>
     </message>
     <message id="ac-in-setup_two_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
-      <source>2-phase</source>
-      <translation>二相</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="139"/>
+        <source>2-phase</source>
+        <translation>二相</translation>
     </message>
     <message id="ac-in-setup_three_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
-      <source>3-phase</source>
-      <translation>三相</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="141"/>
+        <source>3-phase</source>
+        <translation>三相</translation>
+    </message>
+    <message id="ac-in-setup_devices">
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="156"/>
+        <source>Devices</source>
+        <translation type="unfinished">设备</translation>
     </message>
     <message id="ac-in-genset_ac">
-      <location filename="../../components/PageGensetModel.qml" line="158"/>
-      <source>AC</source>
-      <translation>交流</translation>
+        <location filename="../components/PageGensetModel.qml" line="158"/>
+        <source>AC</source>
+        <translation>交流</translation>
     </message>
     <message id="ac-in-genset_engine">
-      <location filename="../../components/PageGensetModel.qml" line="197"/>
-      <source>Engine</source>
-      <translation>引擎</translation>
+        <location filename="../components/PageGensetModel.qml" line="197"/>
+        <source>Engine</source>
+        <translation>引擎</translation>
+    </message>
+    <message id="ac-in-genset_speed">
+        <location filename="../components/PageGensetModel.qml" line="210"/>
+        <source>Speed</source>
+        <translation type="unfinished">速度</translation>
+    </message>
+    <message id="ac-in-genset_load">
+        <location filename="../components/PageGensetModel.qml" line="217"/>
+        <source>Load</source>
+        <translation type="unfinished">负载</translation>
     </message>
     <message id="ac-in-genset_coolant_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="241"/>
-      <source>Coolant temperature</source>
-      <translation>冷却剂温度</translation>
+        <location filename="../components/PageGensetModel.qml" line="241"/>
+        <source>Coolant temperature</source>
+        <translation>冷却剂温度</translation>
     </message>
     <message id="ac-in-genset_exhaust_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="249"/>
-      <source>Exhaust temperature</source>
-      <translation>排气温度</translation>
+        <location filename="../components/PageGensetModel.qml" line="249"/>
+        <source>Exhaust temperature</source>
+        <translation>排气温度</translation>
     </message>
     <message id="ac-in-genset_winding_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="256"/>
-      <source>Winding temperature</source>
-      <translation>线圈温度</translation>
+        <location filename="../components/PageGensetModel.qml" line="256"/>
+        <source>Winding temperature</source>
+        <translation>线圈温度</translation>
     </message>
     <message id="ac-in-genset_starter_battery_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="270"/>
-      <source>Starter battery voltage</source>
-      <translation>启动电池电压</translation>
+        <location filename="../components/PageGensetModel.qml" line="270"/>
+        <source>Starter battery voltage</source>
+        <translation>启动电池电压</translation>
     </message>
     <message id="ac-in-genset_number_of_starts">
-      <location filename="../../components/PageGensetModel.qml" line="278"/>
-      <source>Number of starts</source>
-      <translation>启动次数</translation>
+        <location filename="../components/PageGensetModel.qml" line="278"/>
+        <source>Number of starts</source>
+        <translation>启动次数</translation>
+    </message>
+    <message id="genset_bms_control">
+        <location filename="../components/PageGensetModel.qml" line="369"/>
+        <source>BMS control</source>
+        <translation type="unfinished">BMS控制</translation>
     </message>
     <message id="ac-in-modeldefault_front_selector_locked">
-      <location filename="../../components/settings/ListAcInError.qml" line="23"/>
-      <source>Front selector locked (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>前置选择器锁定 (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="23"/>
+        <source>Front selector locked (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>前置选择器锁定 (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_no_error">
-      <location filename="../../components/settings/ListAcInError.qml" line="27"/>
-      <source>No error (%1)</source>
-      <extracomment>%1 = the error number</extracomment>
-      <translation>无错误 (%1)</translation>
+        <location filename="../components/settings/ListAcInError.qml" line="27"/>
+        <source>No error (%1)</source>
+        <extracomment>%1 = the error number</extracomment>
+        <translation>无错误 (%1)</translation>
     </message>
     <message id="ac-in-modeldefault_ac_totals">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
-      <source>AC Totals</source>
-      <translation>交流总计</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="78"/>
+        <source>AC Totals</source>
+        <translation>交流总计</translation>
     </message>
     <message id="ac-in-modeldefault_energy_x">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
-      <source>Energy L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>能量 L%1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="103"/>
+        <source>Energy L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>能量 L%1</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
-      <source>Phase Sequence</source>
-      <translation>相序</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="119"/>
+        <source>Phase Sequence</source>
+        <translation>相序</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_l3_first">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
-      <source>L1-L3-L2</source>
-      <extracomment>Phase sequence L1-L3-L2</extracomment>
-      <translation>L1-L3-L2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="125"/>
+        <source>L1-L3-L2</source>
+        <extracomment>Phase sequence L1-L3-L2</extracomment>
+        <translation>L1-L3-L2</translation>
     </message>
     <message id="ac-in-modeldefault_phase_sequence_ordered">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
-      <source>L1-L2-L3</source>
-      <extracomment>Phase sequence L1-L2-L3</extracomment>
-      <translation>L1-L2-L3</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="128"/>
+        <source>L1-L2-L3</source>
+        <extracomment>Phase sequence L1-L2-L3</extracomment>
+        <translation>L1-L2-L3</translation>
     </message>
     <message id="ac-in-modeldefault_data_manager_version">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
-      <source>Data manager version</source>
-      <translation>数据管理器版本</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="168"/>
+        <source>Data manager version</source>
+        <translation>数据管理器版本</translation>
     </message>
     <message id="smappee_ct_list_type">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
-      <source>%1: %2</source>
-      <extracomment>%1 = device number, %2 = device type</extracomment>
-      <translation>%1: %2</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+        <source>%1: %2</source>
+        <extracomment>%1 = device number, %2 = device type</extracomment>
+        <translation>%1: %2</translation>
     </message>
     <message id="smappeect_title">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
-      <source>CT %1</source>
-      <extracomment>%1 = CT device number</extracomment>
-      <translation>CT %1</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+        <source>CT %1</source>
+        <extracomment>%1 = CT device number</extracomment>
+        <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_phase_none">
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
+        <source>None</source>
+        <extracomment>Indicates no phase</extracomment>
+        <translation type="unfinished">无</translation>
     </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
-      <source>Flashing LED indicates this CT</source>
-      <translation>电流互感器用闪烁的LED灯来表示</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+        <source>Flashing LED indicates this CT</source>
+        <translation>电流互感器用闪烁的LED灯来表示</translation>
     </message>
     <message id="smappee_device_list_bus_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
-      <source>Smappee bus devices</source>
-      <translation>Smappee总线设备</translation>
+        <location filename="../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+        <source>Smappee bus devices</source>
+        <translation>Smappee总线设备</translation>
     </message>
     <message id="solardevices_pv_charger">
-      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
-      <source>PV Charger</source>
-      <translation>光伏充电器</translation>
+        <location filename="../pages/solar/SolarDeviceListPage.qml" line="118"/>
+        <source>PV Charger</source>
+        <translation>光伏充电器</translation>
     </message>
     <message id="common_words_setting_disabled_when_dmc_connected">
-      <location filename="../../components/CommonWords.qml" line="301"/>
-      <source>This setting is disabled when a Digital Multi Control is connected.</source>
-      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>连接数字多功能控制器时，此设置将被禁用。</translation>
+        <location filename="../components/CommonWords.qml" line="301"/>
+        <source>This setting is disabled when a Digital Multi Control is connected.</source>
+        <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>连接数字多功能控制器时，此设置将被禁用。</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
-      <location filename="../../components/CommonWords.qml" line="304"/>
-      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
-      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
-      <translation>连接 VE.Bus BMS 时，此设置将被禁用。</translation>
+        <location filename="../components/CommonWords.qml" line="304"/>
+        <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+        <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute &apos;Redetect system&apos; that is available below on this menu.</oldsource>
+        <translation>连接 VE.Bus BMS 时，此设置将被禁用。</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
-      <source>AC in %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>交流电在 %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="165"/>
+        <source>AC in %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>交流电在 %1</translation>
     </message>
     <message id="common_words_dc">
-      <location filename="../../components/CommonWords.qml" line="129"/>
-      <source>DC</source>
-      <translation>直流</translation>
+        <location filename="../components/CommonWords.qml" line="129"/>
+        <source>DC</source>
+        <translation>直流</translation>
     </message>
     <message id="pulsecounter_setup_inverted">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
-      <source>Inverted</source>
-      <translation>倒置</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+        <source>Inverted</source>
+        <translation>倒置</translation>
+    </message>
+    <message id="digitalinput_enable_alarm">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="40"/>
+        <source>Enable alarm</source>
+        <translation type="unfinished">启用报警</translation>
+    </message>
+    <message id="digitalinput_inverted">
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="46"/>
+        <source>Inverted</source>
+        <translation type="unfinished">倒置</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
-      <source>Invert alarm logic</source>
-      <translation>警报逻辑倒置</translation>
+        <location filename="../pages/settings/devicelist/PageDigitalInput.qml" line="52"/>
+        <source>Invert alarm logic</source>
+        <translation>警报逻辑倒置</translation>
     </message>
     <message id="page_meteo_irradiance">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="27"/>
-      <source>Irradiance</source>
-      <translation>辐照度</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="27"/>
+        <source>Irradiance</source>
+        <translation>辐照度</translation>
     </message>
     <message id="page_meteo_cell_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="36"/>
-      <source>Cell temperature</source>
-      <translation>电池温度</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="36"/>
+        <source>Cell temperature</source>
+        <translation>电池温度</translation>
     </message>
     <message id="page_meteo_external_temperature_1">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="44"/>
-      <source>External temperature (1)</source>
-      <translation>外部温度 (1)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="44"/>
+        <source>External temperature (1)</source>
+        <translation>外部温度 (1)</translation>
     </message>
     <message id="page_meteo_external_temperature">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="46"/>
-      <source>External temperature</source>
-      <translation>外部温度</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="46"/>
+        <source>External temperature</source>
+        <translation>外部温度</translation>
     </message>
     <message id="page_meteo_external_temperature_2">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
-      <source>External temperature (2)</source>
-      <translation>外部温度 (2)</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+        <source>External temperature (2)</source>
+        <translation>外部温度 (2)</translation>
     </message>
     <message id="page_meteo_wind_speed">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="64"/>
-      <source>Wind speed</source>
-      <translation>风速</translation>
+        <location filename="../pages/settings/devicelist/PageMeteo.qml" line="64"/>
+        <source>Wind speed</source>
+        <translation>风速</translation>
     </message>
     <message id="page_meteo_settings_auto_detect">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
-      <source>Auto-detect</source>
-      <translation>自动检测</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+        <source>Auto-detect</source>
+        <translation>自动检测</translation>
     </message>
     <message id="page_meteo_settings_wind_speed_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
-      <source>Wind speed sensor</source>
-      <translation>风速传感器</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+        <source>Wind speed sensor</source>
+        <translation>风速传感器</translation>
     </message>
     <message id="page_meteo_settings_external_temperature_sensor">
-      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
-      <source>External temperature sensor</source>
-      <translation>外部温度传感器</translation>
+        <location filename="../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+        <source>External temperature sensor</source>
+        <translation>外部温度传感器</translation>
     </message>
     <message id="pulsecounter_aggregate">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
-      <source>Aggregate</source>
-      <translation>合计</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="18"/>
+        <source>Aggregate</source>
+        <translation>合计</translation>
     </message>
     <message id="pulsecounter_setup_multiplier">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
-      <source>Multiplier</source>
-      <translation>乘</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+        <source>Multiplier</source>
+        <translation>乘</translation>
     </message>
     <message id="pulsecounter_setup_reset_counter">
-      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
-      <source>Reset counter</source>
-      <translation>复位计数器</translation>
+        <location filename="../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+        <source>Reset counter</source>
+        <translation>复位计数器</translation>
+    </message>
+    <message id="temperature_short_circuited">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
+        <source>Short circuited</source>
+        <translation type="unfinished">短路</translation>
+    </message>
+    <message id="temperature_reverse_polarity">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="41"/>
+        <source>Reverse polarity</source>
+        <translation type="unfinished">极性接反</translation>
     </message>
     <message id="temperature_sensor_battery_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
-      <source>Sensor battery low</source>
-      <translation>感应器电量低</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="44"/>
+        <source>Sensor battery low</source>
+        <translation>感应器电量低</translation>
     </message>
     <message id="temperature_humidity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
-      <source>Humidity</source>
-      <translation>湿度</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="60"/>
+        <source>Humidity</source>
+        <translation>湿度</translation>
     </message>
     <message id="temperature_pressure">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
-      <source>Pressure</source>
-      <translation>压力</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="68"/>
+        <source>Pressure</source>
+        <translation>压力</translation>
+    </message>
+    <message id="temperature_sensor_battery_status_low">
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="99"/>
+        <source>Low</source>
+        <translation type="unfinished">低</translation>
     </message>
     <message id="temperature_offset">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
-      <source>Offset</source>
-      <translation>偏移</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+        <source>Offset</source>
+        <translation>偏移</translation>
     </message>
     <message id="temperature_scale">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
-      <source>Scale</source>
-      <translation>规模</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+        <source>Scale</source>
+        <translation>规模</translation>
     </message>
     <message id="temperature_sensor_voltage">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
-      <source>Sensor voltage</source>
-      <translation>传感器电压</translation>
+        <location filename="../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+        <source>Sensor voltage</source>
+        <translation>传感器电压</translation>
     </message>
     <message id="settings_multirs_total_pv_power">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
-      <source>Total PV Power</source>
-      <translation>总的光伏功率</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="215"/>
+        <source>Total PV Power</source>
+        <translation>总的光伏功率</translation>
     </message>
     <message id="common_words_product_page">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Product page</source>
-      <translation>产品页面</translation>
+        <location filename="../components/CommonWords.qml" line="371"/>
+        <source>Product page</source>
+        <translation>产品页面</translation>
     </message>
     <message id="vebus_device_ac_sensor_x_y">
-      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
-      <source>AC sensor %1 %2</source>
-      <translation>交流传感器 %1 %2</translation>
+        <location filename="../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+        <source>AC sensor %1 %2</source>
+        <translation>交流传感器 %1 %2</translation>
     </message>
     <message id="vebus_mk3_new_version_available">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="97"/>
-      <source>A new MK3 version is available.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="97"/>
+        <source>A new MK3 version is available.
 NOTE: The update might temporarily stop the system.</source>
-      <translation>新的 MK3 版本可用。
+        <translation>新的 MK3 版本可用。
 注意：更新可能会暂时停止系统。</translation>
     </message>
     <message id="vebus_device_update_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
-      <source>Update the MK3</source>
-      <translation>更新 MK3</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="103"/>
+        <source>Update the MK3</source>
+        <translation>更新 MK3</translation>
     </message>
     <message id="vebus_device_press_to_update">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
-      <source>Press to update</source>
-      <translation>按下更新</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="105"/>
+        <source>Press to update</source>
+        <translation>按下更新</translation>
     </message>
     <message id="vebus_device_updating_the_mk3">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="109"/>
-      <source>Updating the MK3, values will reappear after the update is complete</source>
-      <translation>更新MK3，更新完成后数值会重新出现</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="109"/>
+        <source>Updating the MK3, values will reappear after the update is complete</source>
+        <translation>更新MK3，更新完成后数值会重新出现</translation>
+    </message>
+    <message id="vebus_device_charging_to_100">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="141"/>
+        <source>Charging the battery to 100%</source>
+        <translation type="unfinished">电池充满到100%</translation>
     </message>
     <message id="vebus_device_charging_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="156"/>
-      <source>Charging the battery to 100%</source>
-      <translation>电池充满到100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="156"/>
+        <source>Charging the battery to 100%</source>
+        <translation>电池充满到100%</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="252"/>
+        <source>Advanced</source>
+        <translation type="unfinished">高级</translation>
     </message>
     <message id="vebus_device_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="143"/>
-      <source>In progress</source>
-      <translation>进行中</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="143"/>
+        <source>In progress</source>
+        <translation>进行中</translation>
     </message>
     <message id="vebus_device_press_to_stop">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="150"/>
-      <source>Press to stop</source>
-      <translation>按键停止</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="150"/>
+        <source>Press to stop</source>
+        <translation>按键停止</translation>
     </message>
     <message id="vebus_device_press_to_start">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="153"/>
-      <source>Press to start</source>
-      <translation>按下启动</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="112"/>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="153"/>
+        <source>Press to start</source>
+        <translation>按下启动</translation>
     </message>
     <message id="vebus_device_charge_the_battery_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
-      <source>Charge the battery to 100%</source>
-      <translation>电池充满到100%</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="159"/>
+        <source>Charge the battery to 100%</source>
+        <translation>电池充满到100%</translation>
     </message>
     <message id="vebus_device_return_to_normal_operation">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="168"/>
-      <source>The system will return to normal operation, prioritizing renewable energy.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="168"/>
+        <source>The system will return to normal operation, prioritizing renewable energy.
 Do you want to continue?</source>
-      <translation>该系统将恢复正常运行，优先考虑可再生能源。
+        <translation>该系统将恢复正常运行，优先考虑可再生能源。
 是否要继续？</translation>
     </message>
     <message id="vebus_device_use_shore_power">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="186"/>
-      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="186"/>
+        <source>Shore power will be used when available and the &quot;Solar &amp; wind priority&quot; option will be ignored.
 Do you want to continue?</source>
-      <translation>岸电将在可用时使用，“太阳能和风能优先”选项将被忽略。
+        <translation>岸电将在可用时使用，“太阳能和风能优先”选项将被忽略。
 是否要继续？</translation>
     </message>
     <message id="ebus_device_use_shore_power_once">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="191"/>
-      <source>Shore power will be used to complete a full battery charge for one time.
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="191"/>
+        <source>Shore power will be used to complete a full battery charge for one time.
 After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
 Do you want to continue?</source>
-      <translation>岸电将用于完成一次电池完全充电。
+        <translation>岸电将用于完成一次电池完全充电。
 充电过程完成后，系统将恢复正常运行，优先考虑太阳能和风能。
 是否要继续？</translation>
     </message>
     <message id="vebus_device_page_dc_voltage">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="219"/>
-      <source>DC Voltage</source>
-      <translation>直流电压</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="219"/>
+        <source>DC Voltage</source>
+        <translation>直流电压</translation>
     </message>
     <message id="vebus_device_page_dc_current">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="226"/>
-      <source>DC Current</source>
-      <translation>直流电流</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="226"/>
+        <source>DC Current</source>
+        <translation>直流电流</translation>
     </message>
     <message id="settings_tailscale_advanced">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
-      <source>Advanced</source>
-      <translation>高级</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="300"/>
+        <source>Advanced</source>
+        <translation>高级</translation>
     </message>
     <message id="common_words_alarm_setup">
-      <location filename="../../components/CommonWords.qml" line="59"/>
-      <source>Alarm setup</source>
-      <translation>报警设置</translation>
+        <location filename="../components/CommonWords.qml" line="59"/>
+        <source>Alarm setup</source>
+        <translation>报警设置</translation>
     </message>
     <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="281"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
-      <translation>需要保护电池时，VE BUS BMS自动关闭系统。因此不能用Color Control来控制系统。</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="281"/>
+        <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+        <translation>需要保护电池时，VE BUS BMS自动关闭系统。因此不能用Color Control来控制系统。</translation>
     </message>
     <message id="vebus_device_bms_not_found">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="287"/>
-      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
-      <translation>安装为VE.Bus BMS配置的辅助BMS，但VE.Bus BMS未找到!</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="287"/>
+        <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+        <translation>安装为VE.Bus BMS配置的辅助BMS，但VE.Bus BMS未找到!</translation>
     </message>
     <message id="vebus_device_vebus_bms">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="293"/>
-      <source>VE.Bus BMS</source>
-      <translation>VE.Bus BMS</translation>
+        <location filename="../pages/vebusdevice/PageVeBus.qml" line="293"/>
+        <source>VE.Bus BMS</source>
+        <translation>VE.Bus BMS</translation>
     </message>
     <message id="vebus_device_warning">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
-      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
-      <translation>警告：在带有太阳能充电器的 ESS 系统中激活均衡可能会导致电池在高电压下以过高的电流充电。</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="87"/>
+        <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+        <translation>警告：在带有太阳能充电器的 ESS 系统中激活均衡可能会导致电池在高电压下以过高的电流充电。</translation>
     </message>
     <message id="vebus_device_switch_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
-      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
-      <translation>均衡充电完成后，系统将自动切换到浮充状态.</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+        <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+        <translation>均衡充电完成后，系统将自动切换到浮充状态.</translation>
     </message>
     <message id="vebus_device_interrupt_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
-      <source>Interrupt equalization</source>
-      <translation>断开均衡充电</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="98"/>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="146"/>
+        <source>Interrupt equalization</source>
+        <translation>断开均衡充电</translation>
     </message>
     <message id="vebus_device_equalization">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
-      <source>Equalization</source>
-      <translation>均衡</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="100"/>
+        <source>Equalization</source>
+        <translation>均衡</translation>
     </message>
     <message id="vebus_device_interrupting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
-      <source>Interrupting...</source>
-      <translation>正在断开...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+        <source>Interrupting...</source>
+        <translation>正在断开...</translation>
     </message>
     <message id="settings_tailscale_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
-      <source>Starting...</source>
-      <translation>正在启动...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="51"/>
+        <source>Starting...</source>
+        <translation>正在启动...</translation>
+    </message>
+    <message id="vebus_device_starting">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="107"/>
+        <source>Starting...</source>
+        <translation type="unfinished">正在启动...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
-      <source>Press to interrupt</source>
-      <translation>按下断开</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="110"/>
+        <source>Press to interrupt</source>
+        <translation>按下断开</translation>
     </message>
     <message id="vebus_device_interrupt_and_restart_absorption">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
-      <source>Interrupt and restart absorption</source>
-      <translation>断开并重新开始均充</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="150"/>
+        <source>Interrupt and restart absorption</source>
+        <translation>断开并重新开始均充</translation>
     </message>
     <message id="vebus_device_interrupt_and_go_to_float">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
-      <source>Interrupt and go to float</source>
-      <translation>断开并启动浮充</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="156"/>
+        <source>Interrupt and go to float</source>
+        <translation>断开并启动浮充</translation>
     </message>
     <message id="vebus_device_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
-      <source>Interrupt</source>
-      <translation>断开</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="162"/>
+        <source>Interrupt</source>
+        <translation>断开</translation>
     </message>
     <message id="vebus_device_do_not_interrupt">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
-      <source>Do not interrupt</source>
-      <translation>不要断开</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="168"/>
+        <source>Do not interrupt</source>
+        <translation>不要断开</translation>
     </message>
     <message id="vebus_device_redectect_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
-      <source>Redetect VE.Bus system</source>
-      <translation>重新检测VE.Bus系统</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="193"/>
+        <source>Redetect VE.Bus system</source>
+        <translation>重新检测VE.Bus系统</translation>
     </message>
     <message id="vebus_device_redetecting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
-      <source>Redetecting...</source>
-      <translation>重新检测...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="196"/>
+        <source>Redetecting...</source>
+        <translation>重新检测...</translation>
     </message>
     <message id="vebus_device_restart_vebus_system">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
-      <source>Restart VE.Bus system</source>
-      <translation>重启 VE.Bus 系统</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="206"/>
+        <source>Restart VE.Bus system</source>
+        <translation>重启 VE.Bus 系统</translation>
     </message>
     <message id="vebus_device_restarting">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
-      <source>Restarting...</source>
-      <translation>重新启动...</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="209"/>
+        <source>Restarting...</source>
+        <translation>重新启动...</translation>
     </message>
     <message id="vebus_device_press_to_restart">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
-      <source>Press to restart</source>
-      <translation>按重新启动</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="211"/>
+        <source>Press to restart</source>
+        <translation>按重新启动</translation>
     </message>
     <message id="vebus_device_ac_input_1_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
-      <source>AC input 1 ignored</source>
-      <translation>交流输入1已忽略</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="219"/>
+        <source>AC input 1 ignored</source>
+        <translation>交流输入1已忽略</translation>
     </message>
     <message id="vebus_device_ac_input_2_ignored">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
-      <source>AC input 2 ignored</source>
-      <translation>交流输入2已忽略</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+        <source>AC input 2 ignored</source>
+        <translation>交流输入2已忽略</translation>
     </message>
     <message id="vebus_device_ess_relay_test">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
-      <source>ESS Relay test</source>
-      <translation>ESS继电器测试</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
+        <source>ESS Relay test</source>
+        <translation>ESS继电器测试</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_completed">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="241"/>
+        <source>Completed</source>
+        <translation type="unfinished">已完成</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test_pending">
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="243"/>
+        <source>Pending</source>
+        <translation type="unfinished">等待中</translation>
     </message>
     <message id="cycle_history_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
-      <source>Completed</source>
-      <translation>已完成</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+        <source>Completed</source>
+        <translation>已完成</translation>
     </message>
     <message id="common_words_pending">
-      <location filename="../../components/CommonWords.qml" line="345"/>
-      <source>Pending</source>
-      <translation>等待中</translation>
+        <location filename="../components/CommonWords.qml" line="345"/>
+        <source>Pending</source>
+        <translation>等待中</translation>
     </message>
     <message id="vebus_diagnostics">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
-      <source>VE.Bus diagnostics</source>
-      <translation>VE.Bus诊断</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="250"/>
+        <source>VE.Bus diagnostics</source>
+        <translation>VE.Bus诊断</translation>
     </message>
     <message id="vebus_veice_network_quality_counter">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
-      <source>Network quality counter Phase L%1, device %2 (%3)</source>
-      <translation>网络质量计数器相位 L%1，设备 %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="269"/>
+        <source>Network quality counter Phase L%1, device %2 (%3)</source>
+        <translation>网络质量计数器相位 L%1，设备 %2 (%3)</translation>
     </message>
     <message id="vebus_device_error_8_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
-      <source>VE.Bus Error 8 / 11 report</source>
-      <translation>VE.BUs错误 8 / 11 报告</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+        <source>VE.Bus Error 8 / 11 report</source>
+        <translation>VE.BUs错误 8 / 11 报告</translation>
     </message>
     <message id="alarm_level_alarm_only">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
-      <source>Alarm only</source>
-      <translation>只报警</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="13"/>
+        <source>Alarm only</source>
+        <translation>只报警</translation>
     </message>
     <message id="alarm_level_alarms_and_warnings">
-      <location filename="../../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
-      <source>Alarms &amp; warnings</source>
-      <translation>报警&amp;警告</translation>
+        <location filename="../components/settings/AlarmLevelRadioButtonGroup.qml" line="15"/>
+        <source>Alarms &amp; warnings</source>
+        <translation>报警&amp;警告</translation>
     </message>
     <message id="vebus_device_bms_error">
-      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
-      <source>BMS Error</source>
-      <translation>BMS错误</translation>
+        <location filename="../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+        <source>BMS Error</source>
+        <translation>BMS错误</translation>
     </message>
     <message id="vebus_device_serial_numbers">
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
-      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
-      <source>Serial numbers</source>
-      <translation>序列号</translation>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+        <location filename="../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+        <source>Serial numbers</source>
+        <translation>序列号</translation>
     </message>
     <message id="vebus_device_last_vebus_error_11_report">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
-      <source>Last VE.Bus Error 11 report #%1</source>
-      <translation>最后一次 VE.Bus 错误 11 报告 #%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+        <source>Last VE.Bus Error 11 report #%1</source>
+        <translation>最后一次 VE.Bus 错误 11 报告 #%1</translation>
     </message>
     <message id="vebus_device_bf_safety_test_in_progress">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
-      <source>BF safety test in progress</source>
-      <translation>正在进行 BF 安全测试</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+        <source>BF safety test in progress</source>
+        <translation>正在进行 BF 安全测试</translation>
     </message>
     <message id="vebus_device_bf_safety_test_ok">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
-      <source>BF safety test OK</source>
-      <translation>BF 安全测试正常</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+        <source>BF safety test OK</source>
+        <translation>BF 安全测试正常</translation>
     </message>
     <message id="vebus_device_ac0_ac1_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
-      <source>AC0 /AC1 mismatch</source>
-      <translation>AC0 /AC1 不匹配</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+        <source>AC0 /AC1 mismatch</source>
+        <translation>AC0 /AC1 不匹配</translation>
     </message>
     <message id="vebus_device_communication_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
-      <source>Communication error</source>
-      <translation>通信错误</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+        <source>Communication error</source>
+        <translation>通信错误</translation>
     </message>
     <message id="vebus_device_ground_relay_error">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
-      <source>GND Relay Error</source>
-      <translation>GND 继电器错误</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+        <source>GND Relay Error</source>
+        <translation>GND 继电器错误</translation>
     </message>
     <message id="vebus_device_umains_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
-      <source>UMains mismatch</source>
-      <translation>UMains 不匹配</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+        <source>UMains mismatch</source>
+        <translation>UMains 不匹配</translation>
     </message>
     <message id="vebus_device_period_time_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
-      <source>Period Time mismatch</source>
-      <translation>周期时间不匹配</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+        <source>Period Time mismatch</source>
+        <translation>周期时间不匹配</translation>
     </message>
     <message id="vebus_device_drive_of_bf_relay_mismatch">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
-      <source>Drive of BF relay mismatch</source>
-      <translation>BF 继电器的驱动器不匹配</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+        <source>Drive of BF relay mismatch</source>
+        <translation>BF 继电器的驱动器不匹配</translation>
     </message>
     <message id="vebus_device_error_pe2_open">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
-      <source>Error: PE2 open</source>
-      <translation>错误：PE2 打开</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+        <source>Error: PE2 open</source>
+        <translation>错误：PE2 打开</translation>
     </message>
     <message id="vebus_device_error_pe2_closed">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
-      <source>Error: PE2 closed</source>
-      <translation>错误：PE2 已关闭</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+        <source>Error: PE2 closed</source>
+        <translation>错误：PE2 已关闭</translation>
     </message>
     <message id="vebus_device_failing_step">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
-      <source>Failing step: %1</source>
-      <translation>失败步骤：%1</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+        <source>Failing step: %1</source>
+        <translation>失败步骤：%1</translation>
     </message>
     <message id="vebus_device_phase_x_device_x_index_x">
-      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
-      <source>Phase L%1, device %2 (%3)</source>
-      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
-      <translation>相位 L%1，设备 %2 (%3)</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+        <source>Phase L%1, device %2 (%3)</source>
+        <extracomment>eg. &apos;Phase L1, device 3 (6)&apos;, where &apos;(6)&apos; is the index into the list of reported values</extracomment>
+        <translation>相位 L%1，设备 %2 (%3)</translation>
     </message>
     <message id="vebus_error_11_reporting_requires_v454">
-      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
-      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
-      <translation>VE.Bus错误11报告要求使用最低VE.Bus固件版本454。</translation>
+        <location filename="../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+        <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+        <translation>VE.Bus错误11报告要求使用最低VE.Bus固件版本454。</translation>
     </message>
     <message id="vebus_quirks">
-      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
-      <source>VE.Bus Quirks</source>
-      <translation>VE.Bus 异常</translation>
+        <location filename="../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+        <source>VE.Bus Quirks</source>
+        <translation>VE.Bus 异常</translation>
     </message>
     <message id="vebus_ac_sensor_energy">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
-      <source>energy</source>
-      <translation>能源</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+        <source>energy</source>
+        <translation>能源</translation>
     </message>
     <message id="vebus_ac_sensor_power">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
-      <source>power</source>
-      <translation>功率</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+        <source>power</source>
+        <translation>功率</translation>
     </message>
     <message id="vebus_ac_sensor_voltage">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
-      <source>voltage</source>
-      <translation>电压</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+        <source>voltage</source>
+        <translation>电压</translation>
     </message>
     <message id="vebus_ac_sensor_current">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
-      <source>current</source>
-      <translation>电流</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+        <source>current</source>
+        <translation>电流</translation>
     </message>
     <message id="vebus_ac_sensor_location">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
-      <source>location</source>
-      <translation>位置</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+        <source>location</source>
+        <translation>位置</translation>
     </message>
     <message id="vebus_ac_sensor_phase">
-      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
-      <source>phase</source>
-      <translation>相位</translation>
+        <location filename="../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+        <source>phase</source>
+        <translation>相位</translation>
     </message>
     <message id="vebus_device_active_ac_input">
-      <location filename="../../components/settings/ActiveAcInputTextItem.qml" line="21"/>
-      <source>Active AC Input</source>
-      <translation>有效交流输入</translation>
+        <location filename="../components/settings/ActiveAcInputTextItem.qml" line="21"/>
+        <source>Active AC Input</source>
+        <translation>有效交流输入</translation>
     </message>
     <message id="vebus_device_high_dc_ripple">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
-      <source>High DC ripple</source>
-      <translation>直流纹波高</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+        <source>High DC ripple</source>
+        <translation>直流纹波高</translation>
     </message>
     <message id="vebus_device_high_dc_voltage">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
-      <source>High DC voltage</source>
-      <translation>直流电压高</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+        <source>High DC voltage</source>
+        <translation>直流电压高</translation>
     </message>
     <message id="vebus_device_high_dc_current">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
-      <source>High DC current</source>
-      <translation>直流电流高</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+        <source>High DC current</source>
+        <translation>直流电流高</translation>
     </message>
     <message id="vebus_device_temperature_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
-      <source>Temperature sense error</source>
-      <translation>温度感应错误</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+        <source>Temperature sense error</source>
+        <translation>温度感应错误</translation>
     </message>
     <message id="vebus_device_voltage_sense_error">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
-      <source>Voltage sense error</source>
-      <translation>电压感应错误</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+        <source>Voltage sense error</source>
+        <translation>电压感应错误</translation>
     </message>
     <message id="rssystemalarms_overload">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation>过载</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+        <source>Overload</source>
+        <translation>过载</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
-      <location filename="../../components/CommonWords.qml" line="56"/>
-      <source>DC ripple</source>
-      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
-      <translation>直流纹波</translation>
+        <location filename="../components/CommonWords.qml" line="56"/>
+        <source>DC ripple</source>
+        <extracomment>Alarm configuration when &apos;DC ripple&apos; state is triggered</extracomment>
+        <translation>直流纹波</translation>
     </message>
     <message id="vebus_device_voltage_sensor">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
-      <source>Voltage Sensor</source>
-      <translation>电压传感器</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+        <source>Voltage Sensor</source>
+        <translation>电压传感器</translation>
+    </message>
+    <message id="vebus_device_phase_rotation">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
+        <source>Phase rotation</source>
+        <translation type="unfinished">相位旋转</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
-      <source>Phase rotation</source>
-      <translation>相位旋转</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+        <source>Phase rotation</source>
+        <translation>相位旋转</translation>
     </message>
     <message id="vebus_device_vebus_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
-      <source>VE.Bus version</source>
-      <translation>VE.Bus版本</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+        <source>VE.Bus version</source>
+        <translation>VE.Bus版本</translation>
     </message>
     <message id="vebus_device_mk2_device">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
-      <source>MK2 device</source>
-      <translation>MK2设备</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+        <source>MK2 device</source>
+        <translation>MK2设备</translation>
     </message>
     <message id="vebus_device_mk2_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
-      <source>MK2 version</source>
-      <translation>MK2版本</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+        <source>MK2 version</source>
+        <translation>MK2版本</translation>
     </message>
     <message id="vebus_device_multi_control_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
-      <source>Multi Control version</source>
-      <translation>Multi Control版本</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+        <source>Multi Control version</source>
+        <translation>Multi Control版本</translation>
     </message>
     <message id="vebus_device_bms_version">
-      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
-      <source>VE.Bus BMS version</source>
-      <translation>VE.Bus BMS版本</translation>
+        <location filename="../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+        <source>VE.Bus BMS version</source>
+        <translation>VE.Bus BMS版本</translation>
     </message>
     <message id="ess_unless_grid_fails">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
-      <source>Unless grid fails</source>
-      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
-      <translation>除非电网丢失</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="40"/>
+        <source>Unless grid fails</source>
+        <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+        <translation>除非电网丢失</translation>
     </message>
     <message id="common_words_ac_in">
-      <location filename="../../components/CommonWords.qml" line="14"/>
-      <source>AC In</source>
-      <translation>交流输入</translation>
+        <location filename="../components/CommonWords.qml" line="14"/>
+        <source>AC In</source>
+        <translation>交流输入</translation>
     </message>
     <message id="common_words_ac_input">
-      <location filename="../../components/CommonWords.qml" line="525"/>
-      <source>AC Input</source>
-      <translation>交流输入</translation>
+        <location filename="../components/CommonWords.qml" line="525"/>
+        <source>AC Input</source>
+        <translation>交流输入</translation>
     </message>
     <message id="common_words_ac_input_1">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>AC Input 1</source>
-      <translation>交流输入1</translation>
+        <location filename="../components/CommonWords.qml" line="521"/>
+        <source>AC Input 1</source>
+        <translation>交流输入1</translation>
     </message>
     <message id="common_words_ac_input_2">
-      <location filename="../../components/CommonWords.qml" line="523"/>
-      <source>AC Input 2</source>
-      <translation>交流输入2</translation>
+        <location filename="../components/CommonWords.qml" line="523"/>
+        <source>AC Input 2</source>
+        <translation>交流输入2</translation>
     </message>
     <message id="common_words_ac_input_role">
-      <location filename="../../components/CommonWords.qml" line="21"/>
-      <source>Role</source>
-      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
-      <translation>作用</translation>
+        <location filename="../components/CommonWords.qml" line="21"/>
+        <source>Role</source>
+        <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+        <translation>作用</translation>
     </message>
     <message id="common_words_ac_load">
-      <location filename="../../components/CommonWords.qml" line="24"/>
-      <source>AC load</source>
-      <translation>交流负载</translation>
+        <location filename="../components/CommonWords.qml" line="24"/>
+        <source>AC load</source>
+        <translation>交流负载</translation>
     </message>
     <message id="common_words_ac_out">
-      <location filename="../../components/CommonWords.qml" line="27"/>
-      <source>AC Out</source>
-      <translation>交流输出</translation>
+        <location filename="../components/CommonWords.qml" line="27"/>
+        <source>AC Out</source>
+        <translation>交流输出</translation>
     </message>
     <message id="common_words_ac_output">
-      <location filename="../../components/CommonWords.qml" line="30"/>
-      <source>AC Output</source>
-      <translation>交流输出</translation>
+        <location filename="../components/CommonWords.qml" line="30"/>
+        <source>AC Output</source>
+        <translation>交流输出</translation>
     </message>
     <message id="common_words_ac_phase_x">
-      <location filename="../../components/CommonWords.qml" line="34"/>
-      <source>AC Phase L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>交流相 L%1</translation>
+        <location filename="../components/CommonWords.qml" line="34"/>
+        <source>AC Phase L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>交流相 L%1</translation>
     </message>
     <message id="common_words_ac_sensor_x">
-      <location filename="../../components/CommonWords.qml" line="37"/>
-      <source>AC Sensor %1</source>
-      <translation>交流传感器%1</translation>
+        <location filename="../components/CommonWords.qml" line="37"/>
+        <source>AC Sensor %1</source>
+        <translation>交流传感器%1</translation>
     </message>
     <message id="common_words_ac_sensor">
-      <location filename="../../components/CommonWords.qml" line="40"/>
-      <source>AC Sensors</source>
-      <translation>交流传感器</translation>
+        <location filename="../components/CommonWords.qml" line="40"/>
+        <source>AC Sensors</source>
+        <translation>交流传感器</translation>
     </message>
     <message id="common_words_active">
-      <location filename="../../components/CommonWords.qml" line="44"/>
-      <source>Active</source>
-      <extracomment>Status is 'active'</extracomment>
-      <translation>激活</translation>
+        <location filename="../components/CommonWords.qml" line="44"/>
+        <source>Active</source>
+        <extracomment>Status is &apos;active&apos;</extracomment>
+        <translation>激活</translation>
+    </message>
+    <message id="common_words_alarm">
+        <location filename="../components/CommonWords.qml" line="48"/>
+        <source>Alarm</source>
+        <extracomment>Voltage alarm is at &quot;Alarm&quot; level</extracomment>
+        <translation type="unfinished">报警</translation>
+    </message>
+    <message id="common_words_alarm_setting_overload">
+        <location filename="../components/CommonWords.qml" line="52"/>
+        <source>Overload</source>
+        <extracomment>Alarm configuration when &apos;overload&apos; state is triggered</extracomment>
+        <translation type="unfinished">过载</translation>
     </message>
     <message id="common_words_alarm_status">
-      <location filename="../../components/CommonWords.qml" line="62"/>
-      <source>Alarm status</source>
-      <translation>报警状态</translation>
+        <location filename="../components/CommonWords.qml" line="62"/>
+        <source>Alarm status</source>
+        <translation>报警状态</translation>
     </message>
     <message id="common_words_alarms">
-      <location filename="../../components/CommonWords.qml" line="65"/>
-      <source>Alarms</source>
-      <translation>报警</translation>
+        <location filename="../components/CommonWords.qml" line="65"/>
+        <source>Alarms</source>
+        <translation>报警</translation>
     </message>
     <message id="common_words_allow_to_charge">
-      <location filename="../../components/CommonWords.qml" line="68"/>
-      <source>Allow to charge</source>
-      <translation>允许充电</translation>
+        <location filename="../components/CommonWords.qml" line="68"/>
+        <source>Allow to charge</source>
+        <translation>允许充电</translation>
     </message>
     <message id="common_words_allow_to_discharge">
-      <location filename="../../components/CommonWords.qml" line="71"/>
-      <source>Allow to discharge</source>
-      <translation>允许放电</translation>
+        <location filename="../components/CommonWords.qml" line="71"/>
+        <source>Allow to discharge</source>
+        <translation>允许放电</translation>
     </message>
     <message id="common_words_automatic_scanning">
-      <location filename="../../components/CommonWords.qml" line="77"/>
-      <source>Automatic scanning</source>
-      <translation>正在自动扫描</translation>
+        <location filename="../components/CommonWords.qml" line="77"/>
+        <source>Automatic scanning</source>
+        <translation>正在自动扫描</translation>
     </message>
     <message id="gauges_battery">
-      <location filename="../../components/Gauges.js" line="19"/>
-      <source>Battery</source>
-      <translation>电池</translation>
+        <location filename="../components/Gauges.js" line="19"/>
+        <source>Battery</source>
+        <translation>电池</translation>
     </message>
     <message id="common_words_battery_current">
-      <location filename="../../components/CommonWords.qml" line="86"/>
-      <source>Battery current</source>
-      <translation>电池电流</translation>
+        <location filename="../components/CommonWords.qml" line="86"/>
+        <source>Battery current</source>
+        <translation>电池电流</translation>
     </message>
     <message id="common_words_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="92"/>
-      <source>Battery voltage</source>
-      <translation>电池电压</translation>
+        <location filename="../components/CommonWords.qml" line="92"/>
+        <source>Battery voltage</source>
+        <translation>电池电压</translation>
     </message>
     <message id="common_words_charge_current">
-      <location filename="../../components/CommonWords.qml" line="98"/>
-      <source>Charge current</source>
-      <translation>充电电流</translation>
+        <location filename="../components/CommonWords.qml" line="98"/>
+        <source>Charge current</source>
+        <translation>充电电流</translation>
     </message>
     <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="102"/>
-      <source>Charging</source>
-      <extracomment>"Charging" state</extracomment>
-      <translation>充电</translation>
+        <location filename="../components/CommonWords.qml" line="102"/>
+        <source>Charging</source>
+        <extracomment>&quot;Charging&quot; state</extracomment>
+        <translation>充电</translation>
     </message>
     <message id="common_words_clear_error_action">
-      <location filename="../../components/CommonWords.qml" line="106"/>
-      <source>Clear error</source>
-      <extracomment>Action to clear an error state</extracomment>
-      <translation>清除错误</translation>
+        <location filename="../components/CommonWords.qml" line="106"/>
+        <source>Clear error</source>
+        <extracomment>Action to clear an error state</extracomment>
+        <translation>清除错误</translation>
     </message>
     <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="110"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation>已关闭</translation>
+        <location filename="../components/CommonWords.qml" line="110"/>
+        <source>Closed</source>
+        <extracomment>Status is &apos;closed&apos;</extracomment>
+        <translation>已关闭</translation>
     </message>
     <message id="evchargers_status_connected">
-      <location filename="../../data/EvChargers.qml" line="89"/>
-      <source>Connected</source>
-      <translation>已连接</translation>
+        <location filename="../data/EvChargers.qml" line="89"/>
+        <source>Connected</source>
+        <translation>已连接</translation>
     </message>
     <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="117"/>
-      <source>Current</source>
-      <extracomment>Electric current, as measured in Amps</extracomment>
-      <translation>电流</translation>
+        <location filename="../components/CommonWords.qml" line="117"/>
+        <source>Current</source>
+        <extracomment>Electric current, as measured in Amps</extracomment>
+        <translation>电流</translation>
     </message>
     <message id="common_words_current_transformers">
-      <location filename="../../components/CommonWords.qml" line="120"/>
-      <source>Current transformers</source>
-      <translation>电流互感器</translation>
+        <location filename="../components/CommonWords.qml" line="120"/>
+        <source>Current transformers</source>
+        <translation>电流互感器</translation>
     </message>
     <message id="common_words_custom_name">
-      <location filename="../../components/CommonWords.qml" line="123"/>
-      <source>Custom name</source>
-      <translation>自定义名称</translation>
+        <location filename="../components/CommonWords.qml" line="123"/>
+        <source>Custom name</source>
+        <translation>自定义名称</translation>
     </message>
     <message id="common_words_debug">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Debug</source>
-      <extracomment>Title for a menu item which displays debugging information</extracomment>
-      <translation>调试</translation>
+        <location filename="../components/CommonWords.qml" line="133"/>
+        <source>Debug</source>
+        <extracomment>Title for a menu item which displays debugging information</extracomment>
+        <translation>调试</translation>
     </message>
     <message id="common_words_device">
-      <location filename="../../components/CommonWords.qml" line="137"/>
-      <source>Device</source>
-      <extracomment>Title for device information</extracomment>
-      <translation>设备</translation>
+        <location filename="../components/CommonWords.qml" line="137"/>
+        <source>Device</source>
+        <extracomment>Title for device information</extracomment>
+        <translation>设备</translation>
+    </message>
+    <message id="common_words_disabled">
+        <location filename="../components/CommonWords.qml" line="140"/>
+        <source>Disabled</source>
+        <translation type="unfinished">已禁用</translation>
     </message>
     <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="143"/>
-      <source>Discharging</source>
-      <translation>放电</translation>
+        <location filename="../components/CommonWords.qml" line="143"/>
+        <source>Discharging</source>
+        <translation>放电</translation>
     </message>
     <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="86"/>
-      <source>Disconnected</source>
-      <oldsource>Unplugged</oldsource>
-      <translation>已断开连接</translation>
+        <location filename="../data/EvChargers.qml" line="86"/>
+        <source>Disconnected</source>
+        <oldsource>Unplugged</oldsource>
+        <translation>已断开连接</translation>
     </message>
     <message id="common_words_enable">
-      <location filename="../../components/CommonWords.qml" line="149"/>
-      <source>Enable</source>
-      <translation>启用</translation>
+        <location filename="../components/CommonWords.qml" line="149"/>
+        <source>Enable</source>
+        <translation>启用</translation>
     </message>
     <message id="common_words_enabled">
-      <location filename="../../components/CommonWords.qml" line="152"/>
-      <source>Enabled</source>
-      <translation>已启用</translation>
+        <location filename="../components/CommonWords.qml" line="152"/>
+        <source>Enabled</source>
+        <translation>已启用</translation>
     </message>
     <message id="common_words_energy">
-      <location filename="../../components/CommonWords.qml" line="156"/>
-      <source>Energy</source>
-      <extracomment>Amount of charged energy</extracomment>
-      <translation>能源</translation>
+        <location filename="../components/CommonWords.qml" line="156"/>
+        <source>Energy</source>
+        <extracomment>Amount of charged energy</extracomment>
+        <translation>能源</translation>
     </message>
     <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="159"/>
-      <source>Error</source>
-      <translation>错误</translation>
+        <location filename="../components/CommonWords.qml" line="159"/>
+        <source>Error</source>
+        <translation>错误</translation>
     </message>
     <message id="common_words_error_colon">
-      <location filename="../../components/CommonWords.qml" line="162"/>
-      <source>Error:</source>
-      <translation>错误：</translation>
+        <location filename="../components/CommonWords.qml" line="162"/>
+        <source>Error:</source>
+        <translation>错误：</translation>
     </message>
     <message id="common_words_error_code">
-      <location filename="../../components/CommonWords.qml" line="165"/>
-      <source>Error code</source>
-      <translation>错误代码</translation>
+        <location filename="../components/CommonWords.qml" line="165"/>
+        <source>Error code</source>
+        <translation>错误代码</translation>
     </message>
     <message id="common_words_firmware_version">
-      <location filename="../../components/CommonWords.qml" line="174"/>
-      <source>Firmware version</source>
-      <translation>固件版本</translation>
+        <location filename="../components/CommonWords.qml" line="174"/>
+        <source>Firmware version</source>
+        <translation>固件版本</translation>
     </message>
     <message id="digitalinputs_type_generator">
-      <location filename="../../data/DigitalInputs.qml" line="46"/>
-      <source>Generator</source>
-      <translation>发电机</translation>
+        <location filename="../data/DigitalInputs.qml" line="46"/>
+        <source>Generator</source>
+        <translation>发电机</translation>
     </message>
     <message id="common_words_high_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="183"/>
-      <source>High battery temperature</source>
-      <translation>电池温度高</translation>
+        <location filename="../components/CommonWords.qml" line="183"/>
+        <source>High battery temperature</source>
+        <translation>电池温度高</translation>
     </message>
     <message id="common_words_high_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="190"/>
-      <source>High level alarm</source>
-      <extracomment>An alarm that triggers when the level is too high</extracomment>
-      <translation>高液位报警</translation>
+        <location filename="../components/CommonWords.qml" line="190"/>
+        <source>High level alarm</source>
+        <extracomment>An alarm that triggers when the level is too high</extracomment>
+        <translation>高液位报警</translation>
     </message>
     <message id="common_words_high_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="193"/>
-      <source>High starter battery voltage</source>
-      <translation>启动电池电压高</translation>
+        <location filename="../components/CommonWords.qml" line="193"/>
+        <source>High starter battery voltage</source>
+        <translation>启动电池电压高</translation>
     </message>
     <message id="common_words_high_temperature">
-      <location filename="../../components/CommonWords.qml" line="196"/>
-      <source>High temperature</source>
-      <translation>温度高</translation>
+        <location filename="../components/CommonWords.qml" line="196"/>
+        <source>High temperature</source>
+        <translation>温度高</translation>
     </message>
     <message id="common_words_high_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="199"/>
-      <source>High voltage alarms</source>
-      <translation>高电压报警</translation>
+        <location filename="../components/CommonWords.qml" line="199"/>
+        <source>High voltage alarms</source>
+        <translation>高电压报警</translation>
     </message>
     <message id="common_words_history">
-      <location filename="../../components/CommonWords.qml" line="202"/>
-      <source>History</source>
-      <translation>历史</translation>
+        <location filename="../components/CommonWords.qml" line="202"/>
+        <source>History</source>
+        <translation>历史</translation>
     </message>
     <message id="common_words_x_hours">
-      <location filename="../../components/CommonWords.qml" line="205"/>
-      <source>%1 Hour(s)</source>
-      <translation>%1 小时</translation>
+        <location filename="../components/CommonWords.qml" line="205"/>
+        <source>%1 Hour(s)</source>
+        <translation>%1 小时</translation>
     </message>
     <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="208"/>
-      <source>Idle</source>
-      <translation>空闲</translation>
+        <location filename="../components/CommonWords.qml" line="208"/>
+        <source>Idle</source>
+        <translation>空闲</translation>
     </message>
     <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="212"/>
-      <source>Inactive</source>
-      <extracomment>Status is 'inactive'</extracomment>
-      <translation>不激活</translation>
+        <location filename="../components/CommonWords.qml" line="212"/>
+        <source>Inactive</source>
+        <extracomment>Status is &apos;inactive&apos;</extracomment>
+        <translation>不激活</translation>
+    </message>
+    <message id="common_words_inverter_charger">
+        <location filename="../components/CommonWords.qml" line="218"/>
+        <source>Inverter / Charger</source>
+        <translation type="unfinished">逆变器/充电器</translation>
     </message>
     <message id="common_words_ip_address">
-      <location filename="../../components/CommonWords.qml" line="228"/>
-      <source>IP address</source>
-      <translation>IP地址</translation>
+        <location filename="../components/CommonWords.qml" line="228"/>
+        <source>IP address</source>
+        <translation>IP地址</translation>
     </message>
     <message id="common_words_low_battery_temperature">
-      <location filename="../../components/CommonWords.qml" line="231"/>
-      <source>Low battery temperature</source>
-      <translation>电池温度低</translation>
+        <location filename="../components/CommonWords.qml" line="231"/>
+        <source>Low battery temperature</source>
+        <translation>电池温度低</translation>
     </message>
     <message id="common_words_low_level_alarm">
-      <location filename="../../components/CommonWords.qml" line="238"/>
-      <source>Low level alarm</source>
-      <extracomment>An alarm that triggers when the level is too low</extracomment>
-      <translation>低液位报警</translation>
+        <location filename="../components/CommonWords.qml" line="238"/>
+        <source>Low level alarm</source>
+        <extracomment>An alarm that triggers when the level is too low</extracomment>
+        <translation>低液位报警</translation>
     </message>
     <message id="common_words_low_starter_battery_voltage">
-      <location filename="../../components/CommonWords.qml" line="241"/>
-      <source>Low starter battery voltage</source>
-      <translation>启动电池电压低</translation>
+        <location filename="../components/CommonWords.qml" line="241"/>
+        <source>Low starter battery voltage</source>
+        <translation>启动电池电压低</translation>
     </message>
     <message id="common_words_low_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="244"/>
-      <source>Low state-of-charge</source>
-      <translation>电量低</translation>
+        <location filename="../components/CommonWords.qml" line="244"/>
+        <source>Low state-of-charge</source>
+        <translation>电量低</translation>
     </message>
     <message id="common_words_low_temperature">
-      <location filename="../../components/CommonWords.qml" line="247"/>
-      <source>Low temperature</source>
-      <translation>温度低</translation>
+        <location filename="../components/CommonWords.qml" line="247"/>
+        <source>Low temperature</source>
+        <translation>温度低</translation>
     </message>
     <message id="common_words_low_voltage_alarms">
-      <location filename="../../components/CommonWords.qml" line="250"/>
-      <source>Low voltage alarms</source>
-      <translation>低电压报警</translation>
+        <location filename="../components/CommonWords.qml" line="250"/>
+        <source>Low voltage alarms</source>
+        <translation>低电压报警</translation>
     </message>
     <message id="common_words_manufacturer">
-      <location filename="../../components/CommonWords.qml" line="265"/>
-      <source>Manufacturer</source>
-      <translation>制造商</translation>
+        <location filename="../components/CommonWords.qml" line="265"/>
+        <source>Manufacturer</source>
+        <translation>制造商</translation>
     </message>
     <message id="common_words_maximum_temperature">
-      <location filename="../../components/CommonWords.qml" line="274"/>
-      <source>Maximum temperature</source>
-      <translation>最高温度</translation>
+        <location filename="../components/CommonWords.qml" line="274"/>
+        <source>Maximum temperature</source>
+        <translation>最高温度</translation>
     </message>
     <message id="common_words_maximum_voltage">
-      <location filename="../../components/CommonWords.qml" line="277"/>
-      <source>Maximum voltage</source>
-      <translation>最高电压</translation>
+        <location filename="../components/CommonWords.qml" line="277"/>
+        <source>Maximum voltage</source>
+        <translation>最高电压</translation>
     </message>
     <message id="common_words_minimum_temperature">
-      <location filename="../../components/CommonWords.qml" line="283"/>
-      <source>Minimum temperature</source>
-      <translation>最低温度</translation>
+        <location filename="../components/CommonWords.qml" line="283"/>
+        <source>Minimum temperature</source>
+        <translation>最低温度</translation>
     </message>
     <message id="common_words_minimum_voltage">
-      <location filename="../../components/CommonWords.qml" line="286"/>
-      <source>Minimum voltage</source>
-      <translation>最低电压</translation>
+        <location filename="../components/CommonWords.qml" line="286"/>
+        <source>Minimum voltage</source>
+        <translation>最低电压</translation>
     </message>
     <message id="common_words_mode">
-      <location filename="../../components/CommonWords.qml" line="289"/>
-      <source>Mode</source>
-      <translation>模式</translation>
+        <location filename="../components/CommonWords.qml" line="289"/>
+        <source>Mode</source>
+        <translation>模式</translation>
     </message>
     <message id="common_words_model_name">
-      <location filename="../../components/CommonWords.qml" line="292"/>
-      <source>Model name</source>
-      <translation>型号名称</translation>
+        <location filename="../components/CommonWords.qml" line="292"/>
+        <source>Model name</source>
+        <translation>型号名称</translation>
     </message>
     <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="298"/>
-      <source>No</source>
-      <translation>不</translation>
+        <location filename="../components/CommonWords.qml" line="298"/>
+        <source>No</source>
+        <translation>不</translation>
     </message>
     <message id="common_words_no_error">
-      <location filename="../../components/CommonWords.qml" line="307"/>
-      <source>No error</source>
-      <translation>无错误</translation>
+        <location filename="../components/CommonWords.qml" line="307"/>
+        <source>No error</source>
+        <translation>无错误</translation>
     </message>
     <message id="acInputs_not_available">
-      <location filename="../../data/AcInputs.qml" line="91"/>
-      <source>Not available</source>
-      <translation>不可用</translation>
+        <location filename="../data/AcInputs.qml" line="108"/>
+        <source>Not available</source>
+        <translation>不可用</translation>
     </message>
     <message id="common_words_not_connected">
-      <location filename="../../components/CommonWords.qml" line="317"/>
-      <source>Not connected</source>
-      <translation>未连接</translation>
+        <location filename="../components/CommonWords.qml" line="317"/>
+        <source>Not connected</source>
+        <translation>未连接</translation>
     </message>
     <message id="common_words_offline">
-      <location filename="../../components/CommonWords.qml" line="323"/>
-      <source>Offline</source>
-      <translation>离线</translation>
+        <location filename="../components/CommonWords.qml" line="323"/>
+        <source>Offline</source>
+        <translation>离线</translation>
     </message>
     <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/ListAlarm.qml" line="17"/>
-      <source>OK</source>
-      <extracomment>Voltage alarm is at "OK" level</extracomment>
-      <translation>确认</translation>
+        <location filename="../components/listitems/ListAlarm.qml" line="17"/>
+        <source>OK</source>
+        <extracomment>Voltage alarm is at &quot;OK&quot; level</extracomment>
+        <translation>确认</translation>
     </message>
     <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="329"/>
-      <source>On</source>
-      <translation>开</translation>
+        <location filename="../components/CommonWords.qml" line="329"/>
+        <source>On</source>
+        <translation>开</translation>
     </message>
     <message id="common_words_online">
-      <location filename="../../components/CommonWords.qml" line="332"/>
-      <source>Online</source>
-      <translation>在线</translation>
+        <location filename="../components/CommonWords.qml" line="332"/>
+        <source>Online</source>
+        <translation>在线</translation>
     </message>
     <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="336"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation>打开</translation>
+        <location filename="../components/CommonWords.qml" line="336"/>
+        <source>Open</source>
+        <extracomment>Status is &apos;open&apos;</extracomment>
+        <translation>打开</translation>
     </message>
     <message id="common_words_password">
-      <location filename="../../components/CommonWords.qml" line="348"/>
-      <source>Password</source>
-      <translation>密码</translation>
+        <location filename="../components/CommonWords.qml" line="348"/>
+        <source>Password</source>
+        <translation>密码</translation>
     </message>
     <message id="common_words_phase">
-      <location filename="../../components/CommonWords.qml" line="355"/>
-      <source>Phase</source>
-      <translation>相位</translation>
+        <location filename="../components/CommonWords.qml" line="355"/>
+        <source>Phase</source>
+        <translation>相位</translation>
     </message>
     <message id="common_words_press_to_clear">
-      <location filename="../../components/CommonWords.qml" line="362"/>
-      <source>Press to clear</source>
-      <translation>按下清除</translation>
+        <location filename="../components/CommonWords.qml" line="362"/>
+        <source>Press to clear</source>
+        <translation>按下清除</translation>
     </message>
     <message id="common_words_press_to_reset">
-      <location filename="../../components/CommonWords.qml" line="365"/>
-      <source>Press to reset</source>
-      <translation>按下复位</translation>
+        <location filename="../components/CommonWords.qml" line="365"/>
+        <source>Press to reset</source>
+        <translation>按下复位</translation>
     </message>
     <message id="common_words_press_to_scan">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>Press to scan</source>
-      <translation>按下即可扫描</translation>
+        <location filename="../components/CommonWords.qml" line="368"/>
+        <source>Press to scan</source>
+        <translation>按下即可扫描</translation>
     </message>
     <message id="common_words_pv_inverter">
-      <location filename="../../components/CommonWords.qml" line="374"/>
-      <source>PV Inverter</source>
-      <translation>光伏逆变器</translation>
+        <location filename="../components/CommonWords.qml" line="374"/>
+        <source>PV Inverter</source>
+        <translation>光伏逆变器</translation>
     </message>
     <message id="common_words_pv_power">
-      <location filename="../../components/CommonWords.qml" line="378"/>
-      <source>PV Power</source>
-      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
-      <translation>PV功率</translation>
+        <location filename="../components/CommonWords.qml" line="378"/>
+        <source>PV Power</source>
+        <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+        <translation>PV功率</translation>
     </message>
     <message id="common_words_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="381"/>
-      <source>Quiet hours</source>
-      <translation>安静时间</translation>
+        <location filename="../components/CommonWords.qml" line="381"/>
+        <source>Quiet hours</source>
+        <translation>安静时间</translation>
     </message>
     <message id="common_words_relay">
-      <location filename="../../components/CommonWords.qml" line="385"/>
-      <source>Relay</source>
-      <extracomment>Relay switch</extracomment>
-      <translation>继电器</translation>
+        <location filename="../components/CommonWords.qml" line="385"/>
+        <source>Relay</source>
+        <extracomment>Relay switch</extracomment>
+        <translation>继电器</translation>
     </message>
     <message id="common_words_reboot">
-      <location filename="../../components/CommonWords.qml" line="391"/>
-      <source>Reboot</source>
-      <translation>重启</translation>
+        <location filename="../components/CommonWords.qml" line="391"/>
+        <source>Reboot</source>
+        <translation>重启</translation>
     </message>
     <message id="common_words_remove">
-      <location filename="../../components/CommonWords.qml" line="394"/>
-      <source>Remove</source>
-      <translation>删除</translation>
+        <location filename="../components/CommonWords.qml" line="394"/>
+        <source>Remove</source>
+        <translation>删除</translation>
     </message>
     <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="398"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation>运行</translation>
+        <location filename="../components/CommonWords.qml" line="398"/>
+        <source>Running</source>
+        <extracomment>Status = &quot;running&quot;</extracomment>
+        <translation>运行</translation>
     </message>
     <message id="common_words_scanning">
-      <location filename="../../components/CommonWords.qml" line="401"/>
-      <source>Scanning %1%</source>
-      <translation>正在扫描%1%</translation>
+        <location filename="../components/CommonWords.qml" line="401"/>
+        <source>Scanning %1%</source>
+        <translation>正在扫描%1%</translation>
     </message>
     <message id="common_words_serial_number">
-      <location filename="../../components/CommonWords.qml" line="404"/>
-      <source>Serial number</source>
-      <translation>序列号</translation>
+        <location filename="../components/CommonWords.qml" line="404"/>
+        <source>Serial number</source>
+        <translation>序列号</translation>
     </message>
     <message id="nav_settings">
-      <location filename="../../pages/SettingsPage.qml" line="18"/>
-      <source>Settings</source>
-      <translation>设置</translation>
+        <location filename="../pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>设置</translation>
     </message>
     <message id="common_words_setup">
-      <location filename="../../components/CommonWords.qml" line="410"/>
-      <source>Setup</source>
-      <translation>设置</translation>
+        <location filename="../components/CommonWords.qml" line="410"/>
+        <source>Setup</source>
+        <translation>设置</translation>
     </message>
     <message id="common_words_signal_strength">
-      <location filename="../../components/CommonWords.qml" line="413"/>
-      <source>Signal strength</source>
-      <translation>信号强度</translation>
+        <location filename="../components/CommonWords.qml" line="413"/>
+        <source>Signal strength</source>
+        <translation>信号强度</translation>
     </message>
     <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="424"/>
-      <source>Standby</source>
-      <translation>待机</translation>
+        <location filename="../components/CommonWords.qml" line="424"/>
+        <source>Standby</source>
+        <translation>待机</translation>
     </message>
     <message id="common_words_start_after_condition_reached_for">
-      <location filename="../../components/CommonWords.qml" line="427"/>
-      <source>Start after the condition is reached for</source>
-      <translation>在达到条件后启动</translation>
+        <location filename="../components/CommonWords.qml" line="427"/>
+        <source>Start after the condition is reached for</source>
+        <translation>在达到条件后启动</translation>
     </message>
     <message id="common_words_start_time">
-      <location filename="../../components/CommonWords.qml" line="430"/>
-      <source>Start time</source>
-      <translation>启动时间</translation>
+        <location filename="../components/CommonWords.qml" line="430"/>
+        <source>Start time</source>
+        <translation>启动时间</translation>
     </message>
     <message id="common_words_start_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="433"/>
-      <source>Start value during quiet hours</source>
-      <translation>安静时间内的启动值</translation>
+        <location filename="../components/CommonWords.qml" line="433"/>
+        <source>Start value during quiet hours</source>
+        <translation>安静时间内的启动值</translation>
     </message>
     <message id="common_words_start_when_warning_is_active_for">
-      <location filename="../../components/CommonWords.qml" line="436"/>
-      <source>Start when warning is active for</source>
-      <translation>在警报下启动</translation>
+        <location filename="../components/CommonWords.qml" line="436"/>
+        <source>Start when warning is active for</source>
+        <translation>在警报下启动</translation>
     </message>
     <message id="common_words_state_of_charge">
-      <location filename="../../components/CommonWords.qml" line="442"/>
-      <source>State of charge</source>
-      <translation>充电状态</translation>
+        <location filename="../components/CommonWords.qml" line="442"/>
+        <source>State of charge</source>
+        <translation>充电状态</translation>
     </message>
     <message id="common_words_status">
-      <location filename="../../components/CommonWords.qml" line="445"/>
-      <source>Status</source>
-      <translation>状态</translation>
+        <location filename="../components/CommonWords.qml" line="445"/>
+        <source>Status</source>
+        <translation>状态</translation>
     </message>
     <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="449"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation>启动（%1）</translation>
+        <location filename="../components/CommonWords.qml" line="449"/>
+        <source>Startup (%1)</source>
+        <extracomment>Status = &quot;start up&quot;. %1 = the startup status number</extracomment>
+        <translation>启动（%1）</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
-      <location filename="../../components/CommonWords.qml" line="452"/>
-      <source>Stop value during quiet hours</source>
-      <translation>安静时间内的停止值</translation>
+        <location filename="../components/CommonWords.qml" line="452"/>
+        <source>Stop value during quiet hours</source>
+        <translation>安静时间内的停止值</translation>
     </message>
     <message id="common_words_stop_after_the_condition_is_reached_for">
-      <location filename="../../components/CommonWords.qml" line="455"/>
-      <source>Stop after the condition is reached for</source>
-      <translation>在达到条件后停止</translation>
+        <location filename="../components/CommonWords.qml" line="455"/>
+        <source>Stop after the condition is reached for</source>
+        <translation>在达到条件后停止</translation>
     </message>
     <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Stopped</source>
-      <translation>已停止</translation>
+        <location filename="../components/CommonWords.qml" line="458"/>
+        <source>Stopped</source>
+        <translation>已停止</translation>
     </message>
     <message id="common_words_temperature">
-      <location filename="../../components/CommonWords.qml" line="465"/>
-      <source>Temperature</source>
-      <translation>温度</translation>
+        <location filename="../components/CommonWords.qml" line="465"/>
+        <source>Temperature</source>
+        <translation>温度</translation>
     </message>
     <message id="common_words_temperature_sensor">
-      <location filename="../../components/CommonWords.qml" line="468"/>
-      <source>Temperature sensor</source>
-      <translation>温度传感器</translation>
+        <location filename="../components/CommonWords.qml" line="468"/>
+        <source>Temperature sensor</source>
+        <translation>温度传感器</translation>
     </message>
     <message id="common_words_today">
-      <location filename="../../components/CommonWords.qml" line="471"/>
-      <source>Today</source>
-      <translation>今天</translation>
+        <location filename="../components/CommonWords.qml" line="471"/>
+        <source>Today</source>
+        <translation>今天</translation>
     </message>
     <message id="common_words_total">
-      <location filename="../../components/CommonWords.qml" line="474"/>
-      <source>Total</source>
-      <translation>合计</translation>
+        <location filename="../components/CommonWords.qml" line="474"/>
+        <source>Total</source>
+        <translation>合计</translation>
     </message>
     <message id="common_words_tracker">
-      <location filename="../../components/CommonWords.qml" line="478"/>
-      <source>Tracker</source>
-      <extracomment>Solar tracker</extracomment>
-      <translation>跟踪器</translation>
+        <location filename="../components/CommonWords.qml" line="478"/>
+        <source>Tracker</source>
+        <extracomment>Solar tracker</extracomment>
+        <translation>跟踪器</translation>
     </message>
     <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="481"/>
-      <source>Type</source>
-      <translation>类型</translation>
+        <location filename="../components/CommonWords.qml" line="481"/>
+        <source>Type</source>
+        <translation>类型</translation>
     </message>
     <message id="common_words_unique_id_number">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Unique Identity Number</source>
-      <translation>唯一身份号码</translation>
+        <location filename="../components/CommonWords.qml" line="484"/>
+        <source>Unique Identity Number</source>
+        <translation>唯一身份号码</translation>
     </message>
     <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="149"/>
-      <source>Unknown</source>
-      <translation>未知</translation>
+        <location filename="../data/EvChargers.qml" line="149"/>
+        <source>Unknown</source>
+        <translation>未知</translation>
     </message>
     <message id="common_words_vebus_error">
-      <location filename="../../components/CommonWords.qml" line="491"/>
-      <source>VE.Bus Error</source>
-      <translation>VE.Bus错误</translation>
+        <location filename="../components/CommonWords.qml" line="491"/>
+        <source>VE.Bus Error</source>
+        <translation>VE.Bus错误</translation>
     </message>
     <message id="common_words_voltage">
-      <location filename="../../components/CommonWords.qml" line="494"/>
-      <source>Voltage</source>
-      <translation>电压</translation>
+        <location filename="../components/CommonWords.qml" line="494"/>
+        <source>Voltage</source>
+        <translation>电压</translation>
     </message>
     <message id="common_words_vrm_instance">
-      <location filename="../../components/CommonWords.qml" line="497"/>
-      <source>VRM instance</source>
-      <translation>VRM实例</translation>
+        <location filename="../components/CommonWords.qml" line="497"/>
+        <source>VRM instance</source>
+        <translation>VRM实例</translation>
     </message>
     <message id="common_words_when_warning_is_cleared_stop_after">
-      <location filename="../../components/CommonWords.qml" line="500"/>
-      <source>When warning is cleared stop after</source>
-      <translation>当警报清除，之后停止</translation>
+        <location filename="../components/CommonWords.qml" line="500"/>
+        <source>When warning is cleared stop after</source>
+        <translation>当警报清除，之后停止</translation>
     </message>
     <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="503"/>
-      <source>Yes</source>
-      <translation>是</translation>
+        <location filename="../components/CommonWords.qml" line="503"/>
+        <source>Yes</source>
+        <translation>是</translation>
     </message>
     <message id="common_words_yesterday">
-      <location filename="../../components/CommonWords.qml" line="506"/>
-      <source>Yesterday</source>
-      <translation>昨天</translation>
+        <location filename="../components/CommonWords.qml" line="506"/>
+        <source>Yesterday</source>
+        <translation>昨天</translation>
     </message>
     <message id="common_words_yield_kwh">
-      <location filename="../../components/CommonWords.qml" line="510"/>
-      <source>Yield</source>
-      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
-      <translation>发电</translation>
+        <location filename="../components/CommonWords.qml" line="510"/>
+        <source>Yield</source>
+        <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+        <translation>发电</translation>
     </message>
     <message id="common_words_zero_feed_in_power_limit">
-      <location filename="../../components/CommonWords.qml" line="517"/>
-      <source>Zero feed-in power limit</source>
-      <translation>零馈入功率限制</translation>
+        <location filename="../components/CommonWords.qml" line="517"/>
+        <source>Zero feed-in power limit</source>
+        <translation>零馈入功率限制</translation>
     </message>
     <message id="dateselectordialog_set_date">
-      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
-      <source>Set date</source>
-      <translation>设置日期</translation>
+        <location filename="../components/dialogs/DateSelectorDialog.qml" line="17"/>
+        <source>Set date</source>
+        <translation>设置日期</translation>
     </message>
     <message id="controlcard_generator_startdialog_start_now">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
-      <source>Start Now</source>
-      <translation>现在开始</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+        <source>Start Now</source>
+        <translation>现在开始</translation>
     </message>
     <message id="controlcard_generator_startdialog_timed_run">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
-      <source>Timed run</source>
-      <translation>定时运行</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+        <source>Timed run</source>
+        <translation>定时运行</translation>
     </message>
     <message id="controlcard_generator_stopdialog_stop_now">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
-      <source>Stop Now</source>
-      <translation>立即停止</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+        <source>Stop Now</source>
+        <translation>立即停止</translation>
     </message>
     <message id="controlcard_generator_stopdialog_total_run_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
-      <source>Total Run Time</source>
-      <translation>总运行时间</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+        <source>Total Run Time</source>
+        <translation>总运行时间</translation>
     </message>
     <message id="controlcard_generator_stopdialog_set_time">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
-      <source>Set Time %1</source>
-      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
-      <translation>设置时间%1</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+        <source>Set Time %1</source>
+        <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+        <translation>设置时间%1</translation>
     </message>
     <message id="controlcard_generator_stopdialog_description">
-      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
-      <source>Generator will keep running if an autostart condition is met.</source>
-      <translation>如果满足自动启动条件，发电机将继续运行。</translation>
+        <location filename="../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+        <source>Generator will keep running if an autostart condition is met.</source>
+        <translation>如果满足自动启动条件，发电机将继续运行。</translation>
     </message>
     <message id="controlcard_inverter_charger_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
-      <source>Inverter / Charger mode</source>
-      <translation>逆变/充电模式</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+        <source>Inverter / Charger mode</source>
+        <translation>逆变/充电模式</translation>
     </message>
     <message id="modaldialog_set">
-      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
-      <source>Set</source>
-      <translation>设置</translation>
+        <location filename="../components/dialogs/ModalDialog.qml" line="25"/>
+        <source>Set</source>
+        <translation>设置</translation>
     </message>
     <message id="common_words_cancel">
-      <location filename="../../components/CommonWords.qml" line="95"/>
-      <source>Cancel</source>
-      <translation>取消</translation>
+        <location filename="../components/CommonWords.qml" line="95"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
     </message>
     <message id="settings_vrm_device_instances_close">
-      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
-      <source>Close</source>
-      <translation>关闭</translation>
+        <location filename="../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+        <source>Close</source>
+        <translation>关闭</translation>
     </message>
     <message id="timeselectordialog_set_time">
-      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
-      <source>Set time</source>
-      <translation>设置时间</translation>
+        <location filename="../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+        <source>Set time</source>
+        <translation>设置时间</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
-      <source>Already in use</source>
-      <translation>已在使用中</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+        <source>Already in use</source>
+        <translation>已在使用中</translation>
     </message>
     <message id="deviceinstanceswap_swap_error">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
-      <source>Swap error</source>
-      <translation>交换错误</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+        <source>Swap error</source>
+        <translation>交换错误</translation>
     </message>
     <message id="deviceinstanceswap_swap_completed">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
-      <source>Swap complete</source>
-      <translation>交换完成</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+        <source>Swap complete</source>
+        <translation>交换完成</translation>
     </message>
     <message id="deviceinstanceswap_busy">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
-      <source>Swapping device instances...</source>
-      <translation>交换设备实例...</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+        <source>Swapping device instances...</source>
+        <translation>交换设备实例...</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description_with_name">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
-      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
-      <translation>设备实例 %1 已被“%3”使用。交换设备实例并将其分配给 %2？</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+        <source>Device instance %1 is already used by &apos;%3&apos;. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers, %3 = another device&apos;s name</extracomment>
+        <translation>设备实例 %1 已被“%3”使用。交换设备实例并将其分配给 %2？</translation>
     </message>
     <message id="deviceinstanceswap_already_assigned_description">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
-      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
-      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
-      <translation>设备实例 %1 已被另一个相同类型的设备使用。交换设备实例并将其分配给 %2？</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+        <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+        <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+        <translation>设备实例 %1 已被另一个相同类型的设备使用。交换设备实例并将其分配给 %2？</translation>
     </message>
     <message id="deviceinstanceswap_timed_out">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
-      <source>Cannot swap device instances: operation timed out.</source>
-      <translation>无法交换设备实例：操作超时。</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+        <source>Cannot swap device instances: operation timed out.</source>
+        <translation>无法交换设备实例：操作超时。</translation>
     </message>
     <message id="deviceinstanceswap_active_on_reboot">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
-      <source>New device instances will be active on reboot.</source>
-      <translation>新设备实例将在重新启动时处于活动状态。</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+        <source>New device instances will be active on reboot.</source>
+        <translation>新设备实例将在重新启动时处于活动状态。</translation>
     </message>
     <message id="deviceinstanceswap_swap">
-      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
-      <source>Swap</source>
-      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
-      <translation>交换</translation>
+        <location filename="../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+        <source>Swap</source>
+        <extracomment>Confirm that the two devices&apos; instance number should be swapped.</extracomment>
+        <translation>交换</translation>
     </message>
     <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation>检查固件更新时出错</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="55"/>
+        <source>Error while checking for firmware updates</source>
+        <translation>检查固件更新时出错</translation>
     </message>
     <message id="settings_firmware_downloading_and_installing">
-      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
-      <source>Downloading and installing firmware %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation>正在下载和安装固件 %1...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="63"/>
+        <source>Downloading and installing firmware %1...</source>
+        <extracomment>%1 = firmware version</extracomment>
+        <translation>正在下载和安装固件 %1...</translation>
     </message>
     <message id="settings_firmware_installing_firmware">
-      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
-      <source>Installing firmware...</source>
-      <translation>正在安装固件...</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="70"/>
+        <source>Installing firmware...</source>
+        <translation>正在安装固件...</translation>
     </message>
     <message id="settings_firmware_error_during_installation">
-      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
-      <source>Error during firmware installation</source>
-      <translation>固件安装期间出错</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="75"/>
+        <source>Error during firmware installation</source>
+        <translation>固件安装期间出错</translation>
     </message>
     <message id="settings_firmware_no_newer_version_available">
-      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
-      <source>No newer version available</source>
-      <translation>无可用新版本</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="185"/>
+        <source>No newer version available</source>
+        <translation>无可用新版本</translation>
     </message>
     <message id="settings_firmware_no_firmware_found">
-      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
-      <source>No firmware found</source>
-      <translation>未找到固件</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="188"/>
+        <source>No firmware found</source>
+        <translation>未找到固件</translation>
     </message>
     <message id="gauges_fuel">
-      <location filename="../../components/Gauges.js" line="27"/>
-      <source>Fuel</source>
-      <translation>燃料</translation>
+        <location filename="../components/Gauges.js" line="27"/>
+        <source>Fuel</source>
+        <translation>燃料</translation>
     </message>
     <message id="gauges_fresh_water">
-      <location filename="../../components/Gauges.js" line="35"/>
-      <source>Fresh water</source>
-      <translation>清水</translation>
+        <location filename="../components/Gauges.js" line="35"/>
+        <source>Fresh water</source>
+        <translation>清水</translation>
     </message>
     <message id="gauges_waste_water">
-      <location filename="../../components/Gauges.js" line="43"/>
-      <source>Waste water</source>
-      <translation>废水</translation>
+        <location filename="../components/Gauges.js" line="43"/>
+        <source>Waste water</source>
+        <translation>废水</translation>
     </message>
     <message id="gauges_live_well">
-      <location filename="../../components/Gauges.js" line="51"/>
-      <source>Live well</source>
-      <translation>活鱼池</translation>
+        <location filename="../components/Gauges.js" line="51"/>
+        <source>Live well</source>
+        <translation>活鱼池</translation>
     </message>
     <message id="gauges_oil">
-      <location filename="../../components/Gauges.js" line="59"/>
-      <source>Oil</source>
-      <translation>石油</translation>
+        <location filename="../components/Gauges.js" line="59"/>
+        <source>Oil</source>
+        <translation>石油</translation>
     </message>
     <message id="gauges_black_water">
-      <location filename="../../components/Gauges.js" line="67"/>
-      <source>Black water</source>
-      <translation>黑水</translation>
+        <location filename="../components/Gauges.js" line="67"/>
+        <source>Black water</source>
+        <translation>黑水</translation>
     </message>
     <message id="gauges_gasoline">
-      <location filename="../../components/Gauges.js" line="75"/>
-      <source>Gasoline</source>
-      <translation>汽油</translation>
+        <location filename="../components/Gauges.js" line="75"/>
+        <source>Gasoline</source>
+        <translation>汽油</translation>
     </message>
     <message id="gauges_diesel">
-      <location filename="../../components/Gauges.js" line="83"/>
-      <source>Diesel</source>
-      <translation>柴油</translation>
+        <location filename="../components/Gauges.js" line="83"/>
+        <source>Diesel</source>
+        <translation>柴油</translation>
     </message>
     <message id="gauges_lpg">
-      <location filename="../../components/Gauges.js" line="91"/>
-      <source>LPG</source>
-      <translation>LPG</translation>
+        <location filename="../components/Gauges.js" line="91"/>
+        <source>LPG</source>
+        <translation>LPG</translation>
     </message>
     <message id="gauges_lng">
-      <location filename="../../components/Gauges.js" line="99"/>
-      <source>LNG</source>
-      <translation>LNG</translation>
+        <location filename="../components/Gauges.js" line="99"/>
+        <source>LNG</source>
+        <translation>LNG</translation>
     </message>
     <message id="gauges_hydraulic_oil">
-      <location filename="../../components/Gauges.js" line="107"/>
-      <source>Hydraulic oil</source>
-      <translation>液压油</translation>
+        <location filename="../components/Gauges.js" line="107"/>
+        <source>Hydraulic oil</source>
+        <translation>液压油</translation>
     </message>
     <message id="gauges_raw_water">
-      <location filename="../../components/Gauges.js" line="115"/>
-      <source>Raw water</source>
-      <translation>生水</translation>
+        <location filename="../components/Gauges.js" line="115"/>
+        <source>Raw water</source>
+        <translation>生水</translation>
     </message>
     <message id="settings_radio_button_group_no_access">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="62"/>
-      <source>Setting locked for access level</source>
-      <translation>设置锁定访问级别</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="62"/>
+        <source>Setting locked for access level</source>
+        <translation>设置锁定访问级别</translation>
     </message>
     <message id="settings_access_incorrect_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
-      <source>Incorrect password</source>
-      <translation>密码错误</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="93"/>
+        <source>Incorrect password</source>
+        <translation>密码错误</translation>
     </message>
     <message id="welcome_brief_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
-      <source>Brief</source>
-      <translation>概要</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="82"/>
+        <source>Brief</source>
+        <translation>概要</translation>
     </message>
     <message id="welcome_overview_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
-      <source>Overview</source>
-      <translation>总览</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="91"/>
+        <source>Overview</source>
+        <translation>总览</translation>
     </message>
     <message id="nav_levels">
-      <location filename="../../pages/LevelsPage.qml" line="19"/>
-      <source>Levels</source>
-      <translation>液位</translation>
+        <location filename="../pages/LevelsPage.qml" line="19"/>
+        <source>Levels</source>
+        <translation>液位</translation>
     </message>
     <message id="nav_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="14"/>
-      <source>Notifications</source>
-      <translation>通知</translation>
+        <location filename="../pages/NotificationsPage.qml" line="14"/>
+        <source>Notifications</source>
+        <translation>通知</translation>
     </message>
     <message id="utils_formatTimestamp_now">
-      <location filename="../../components/Utils.js" line="246"/>
-      <source>now</source>
-      <extracomment>Indicates an event happened very recently</extracomment>
-      <translation>现在</translation>
+        <location filename="../components/Utils.js" line="246"/>
+        <source>now</source>
+        <extracomment>Indicates an event happened very recently</extracomment>
+        <translation>现在</translation>
     </message>
     <message id="utils_formatTimestamp_min_ago">
-      <location filename="../../components/Utils.js" line="251"/>
-      <source>%1m ago</source>
-      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
-      <translation>%1分钟前</translation>
+        <location filename="../components/Utils.js" line="251"/>
+        <source>%1m ago</source>
+        <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+        <translation>%1分钟前</translation>
     </message>
     <message id="utils_formatTimestamp_hours_min_ago">
-      <location filename="../../components/Utils.js" line="258"/>
-      <source>%1h %2m ago</source>
-      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
-      <translation>%1 小时 %2 分钟前</translation>
+        <location filename="../components/Utils.js" line="258"/>
+        <source>%1h %2m ago</source>
+        <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+        <translation>%1 小时 %2 分钟前</translation>
     </message>
     <message id="cgwacs_battery_schedule_every_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="17"/>
-      <source>Every day</source>
-      <translation>每天</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="17"/>
+        <source>Every day</source>
+        <translation>每天</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekdays">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="19"/>
-      <source>Weekdays</source>
-      <translation>工作日</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="19"/>
+        <source>Weekdays</source>
+        <translation>工作日</translation>
     </message>
     <message id="cgwacs_battery_schedule_weekends">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="21"/>
-      <source>Weekends</source>
-      <translation>周末</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="21"/>
+        <source>Weekends</source>
+        <translation>周末</translation>
     </message>
     <message id="cgwacs_battery_schedule_monday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="25"/>
-      <source>Monday</source>
-      <translation>周一</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="25"/>
+        <source>Monday</source>
+        <translation>周一</translation>
     </message>
     <message id="cgwacs_battery_schedule_tuesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="27"/>
-      <source>Tuesday</source>
-      <translation>周二</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="27"/>
+        <source>Tuesday</source>
+        <translation>周二</translation>
     </message>
     <message id="cgwacs_battery_schedule_wednesday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="29"/>
-      <source>Wednesday</source>
-      <translation>周三</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="29"/>
+        <source>Wednesday</source>
+        <translation>周三</translation>
     </message>
     <message id="cgwacs_battery_schedule_thursday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="31"/>
-      <source>Thursday</source>
-      <translation>周四</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="31"/>
+        <source>Thursday</source>
+        <translation>周四</translation>
     </message>
     <message id="cgwacs_battery_schedule_friday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="33"/>
-      <source>Friday</source>
-      <translation>周五</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="33"/>
+        <source>Friday</source>
+        <translation>周五</translation>
     </message>
     <message id="cgwacs_battery_schedule_saturday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="35"/>
-      <source>Saturday</source>
-      <translation>周六</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="35"/>
+        <source>Saturday</source>
+        <translation>周六</translation>
     </message>
     <message id="cgwacs_battery_schedule_sunday">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="37"/>
-      <source>Sunday</source>
-      <translation>周日</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="37"/>
+        <source>Sunday</source>
+        <translation>周日</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_no_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="70"/>
-      <source>%1 %2 (%3)</source>
-      <translation>%1 %2 (%3)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="70"/>
+        <source>%1 %2 (%3)</source>
+        <translation>%1 %2 (%3)</translation>
     </message>
     <message id="cgwacs_battery_schedule_format_soc">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="73"/>
-      <source>%1 %2 (%3 or %4%)</source>
-      <translation>%1 %2 (%3 或 %4%)</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="73"/>
+        <source>%1 %2 (%3 or %4%)</source>
+        <translation>%1 %2 (%3 或 %4%)</translation>
     </message>
     <message id="cgwacs_battery_schedule_name">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="79"/>
-      <source>Schedule %1</source>
-      <translation>调度%1</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="79"/>
+        <source>Schedule %1</source>
+        <translation>调度%1</translation>
     </message>
     <message id="cgwacs_battery_schedule_day">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="127"/>
-      <source>Day</source>
-      <translation>天</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="127"/>
+        <source>Day</source>
+        <translation>天</translation>
     </message>
     <message id="cgwacs_battery_schedule_day_not_set">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="131"/>
-      <source>Not set</source>
-      <translation>未设定</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="131"/>
+        <source>Not set</source>
+        <translation>未设定</translation>
     </message>
     <message id="cgwacs_battery_schedule_soc_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="154"/>
-      <source>SOC limit</source>
-      <translation>SOC限制</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="154"/>
+        <source>SOC limit</source>
+        <translation>SOC限制</translation>
     </message>
     <message id="cgwacs_battery_schedule_self_consumption_above_limit">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="165"/>
-      <source>Self-consumption above limit</source>
-      <translation>自耗超限</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="165"/>
+        <source>Self-consumption above limit</source>
+        <translation>自耗超限</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv">
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="170"/>
+        <source>PV</source>
+        <translation type="unfinished">光伏</translation>
     </message>
     <message id="settings_multirs_pv">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
-      <source>PV</source>
-      <translation>光伏</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="198"/>
+        <source>PV</source>
+        <translation>光伏</translation>
     </message>
     <message id="cgwacs_battery_schedule_pv_and_battery">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="172"/>
-      <source>PV &amp; Battery</source>
-      <translation>光伏&amp;电池</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="172"/>
+        <source>PV &amp; Battery</source>
+        <translation>光伏&amp;电池</translation>
     </message>
     <message id="settings_firmware_checking">
-      <location filename="../../components/settings/FirmwareCheckListButton.qml" line="16"/>
-      <source>Checking...</source>
-      <translation>检查...</translation>
+        <location filename="../components/settings/FirmwareCheckListButton.qml" line="16"/>
+        <source>Checking...</source>
+        <translation>检查...</translation>
     </message>
     <message id="list_alarm_state">
-      <location filename="../../components/settings/ListAlarmState.qml" line="11"/>
-      <source>Alarm state</source>
-      <translation>报警状态</translation>
+        <location filename="../components/settings/ListAlarmState.qml" line="11"/>
+        <source>Alarm state</source>
+        <translation>报警状态</translation>
+    </message>
+    <message id="devicelist_battery_alarm_state">
+        <location filename="../components/settings/ListAlarmState.qml" line="19"/>
+        <source>Alarm</source>
+        <extracomment>Alarm state is active</extracomment>
+        <translation type="unfinished">报警</translation>
     </message>
     <message id="clear_history_button_clear_history">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="15"/>
-      <source>Clear History</source>
-      <translation>清除历史记录</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="15"/>
+        <source>Clear History</source>
+        <translation>清除历史记录</translation>
     </message>
     <message id="clear_history_button_clearing">
-      <location filename="../../components/settings/ListClearHistoryButton.qml" line="19"/>
-      <source>Clearing</source>
-      <translation>正在清除</translation>
+        <location filename="../components/settings/ListClearHistoryButton.qml" line="19"/>
+        <source>Clearing</source>
+        <translation>正在清除</translation>
     </message>
     <message id="settings_dvcc_switch_forced_on">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="19"/>
-      <source>Forced on</source>
-      <translation>强制打开</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="19"/>
+        <source>Forced on</source>
+        <translation>强制打开</translation>
     </message>
     <message id="settings_dvcc_switch_forced_off">
-      <location filename="../../components/listitems/ListSwitchForced.qml" line="22"/>
-      <source>Forced off</source>
-      <translation>强制关闭</translation>
+        <location filename="../components/listitems/ListSwitchForced.qml" line="22"/>
+        <source>Forced off</source>
+        <translation>强制关闭</translation>
     </message>
     <message id="list_relay_state">
-      <location filename="../../components/settings/ListRelayState.qml" line="11"/>
-      <source>Relay state</source>
-      <translation>继电器状态</translation>
+        <location filename="../components/settings/ListRelayState.qml" line="11"/>
+        <source>Relay state</source>
+        <translation>继电器状态</translation>
     </message>
     <message id="batteryhistory_reset_history_on_the_monitor_itself">
-      <location filename="../../components/settings/ListResetHistoryLabel.qml" line="29"/>
-      <source>Reset history on the monitor itself</source>
-      <translation>重置显示器本身的历史记录</translation>
+        <location filename="../components/settings/ListResetHistoryLabel.qml" line="29"/>
+        <source>Reset history on the monitor itself</source>
+        <translation>重置显示器本身的历史记录</translation>
     </message>
     <message id="components_mount_state_press_to_eject">
-      <location filename="../../components/settings/MountStateListButton.qml" line="17"/>
-      <source>Press to eject</source>
-      <translation>按下弹出</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="17"/>
+        <source>Press to eject</source>
+        <translation>按下弹出</translation>
     </message>
     <message id="components_mount_state_ejecting">
-      <location filename="../../components/settings/MountStateListButton.qml" line="21"/>
-      <source>Ejecting, please wait</source>
-      <translation>正在弹出，请等待</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="21"/>
+        <source>Ejecting, please wait</source>
+        <translation>正在弹出，请等待</translation>
     </message>
     <message id="components_mount_state_no_storage_found">
-      <location filename="../../components/settings/MountStateListButton.qml" line="24"/>
-      <source>No storage found</source>
-      <translation>未找到存储器</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="24"/>
+        <source>No storage found</source>
+        <translation>未找到存储器</translation>
     </message>
     <message id="components_mount_state_microsd_usb">
-      <location filename="../../components/settings/MountStateListButton.qml" line="29"/>
-      <source>microSD / USB</source>
-      <translation>microSD / USB</translation>
+        <location filename="../components/settings/MountStateListButton.qml" line="29"/>
+        <source>microSD / USB</source>
+        <translation>microSD / USB</translation>
     </message>
     <message id="settings_relay_title_type_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
-      <source>%1 temperature sensor</source>
-      <extracomment>%1 = temperature sensor type</extracomment>
-      <translation>%1温度传感器</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="28"/>
+        <source>%1 temperature sensor</source>
+        <extracomment>%1 = temperature sensor type</extracomment>
+        <translation>%1温度传感器</translation>
     </message>
     <message id="settings_relay_title_type_and_number">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
-      <source>%1 temperature sensor (%2)</source>
-      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
-      <translation>%1 温度传感器 (%2)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="32"/>
+        <source>%1 temperature sensor (%2)</source>
+        <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+        <translation>%1 温度传感器 (%2)</translation>
     </message>
     <message id="settings_relay_title_number_only">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
-      <source>Temperature sensor (%1)</source>
-      <extracomment>%1 = input number of the sensor</extracomment>
-      <translation>温度传感器(%1)</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="41"/>
+        <source>Temperature sensor (%1)</source>
+        <extracomment>%1 = input number of the sensor</extracomment>
+        <translation>温度传感器(%1)</translation>
     </message>
     <message id="settings_relay_no_actions">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
-      <source>No actions</source>
-      <translation>无动作</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="52"/>
+        <source>No actions</source>
+        <translation>无动作</translation>
     </message>
     <message id="settings_relay_c0_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
-      <source>C1: %1, %2</source>
-      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
-      <translation>C1: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="57"/>
+        <source>C1: %1, %2</source>
+        <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+        <translation>C1: %1, %2</translation>
     </message>
     <message id="settings_relay_c1_desc">
-      <location filename="../../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
-      <source>C2: %1, %2</source>
-      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
-      <translation>C2: %1, %2</translation>
+        <location filename="../components/settings/TemperatureRelayNavigationItem.qml" line="62"/>
+        <source>C2: %1, %2</source>
+        <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+        <translation>C2: %1, %2</translation>
     </message>
     <message id="settings_relay_equal_values_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="23"/>
-      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
-      <translation>警告：激活和停用温度设置为相同的值。这将导致该条件被忽略。</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="23"/>
+        <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+        <translation>警告：激活和停用温度设置为相同的值。这将导致该条件被忽略。</translation>
     </message>
     <message id="settings_relay_condition">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="35"/>
-      <source>Condition %1</source>
-      <translation>条件%1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="35"/>
+        <source>Condition %1</source>
+        <translation>条件%1</translation>
     </message>
     <message id="settings_relay_function_disabled">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="41"/>
-      <source>Function disabled</source>
-      <translation>功能已禁用</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="41"/>
+        <source>Function disabled</source>
+        <translation>功能已禁用</translation>
     </message>
     <message id="settings_relay_none">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="52"/>
-      <source>None (Disable)</source>
-      <translation>无（禁用）</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="52"/>
+        <source>None (Disable)</source>
+        <translation>无（禁用）</translation>
     </message>
     <message id="settings_relay1">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="54"/>
-      <source>Relay 1</source>
-      <translation>继电器1</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="54"/>
+        <source>Relay 1</source>
+        <translation>继电器1</translation>
     </message>
     <message id="settings_relay2">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="56"/>
-      <source>Relay 2</source>
-      <translation>继电器2</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="56"/>
+        <source>Relay 2</source>
+        <translation>继电器2</translation>
     </message>
     <message id="settings_relay_invalid_temp_config_warning">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="61"/>
-      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
-      <translation>警告：上述选择的继电器未配置温度，此条件将被忽略。</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="61"/>
+        <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+        <translation>警告：上述选择的继电器未配置温度，此条件将被忽略。</translation>
     </message>
     <message id="settings_relay_activation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="70"/>
-      <source>Activation value</source>
-      <translation>启用值</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="70"/>
+        <source>Activation value</source>
+        <translation>启用值</translation>
     </message>
     <message id="components_volumeunit_title">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
-      <source>Volume unit</source>
-      <translation>容积单位</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="11"/>
+        <source>Volume unit</source>
+        <translation>容积单位</translation>
     </message>
     <message id="components_volumeunit_cubic_meters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
-      <source>Cubic meters</source>
-      <translation>立方米</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="15"/>
+        <source>Cubic meters</source>
+        <translation>立方米</translation>
     </message>
     <message id="components_volumeunit_liters">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
-      <source>Liters</source>
-      <translation>升（L）</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="17"/>
+        <source>Liters</source>
+        <translation>升（L）</translation>
     </message>
     <message id="components_volumeunit_gallons_us">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
-      <source>Gallons (US)</source>
-      <translation>加仑（美国）</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="19"/>
+        <source>Gallons (US)</source>
+        <translation>加仑（美国）</translation>
     </message>
     <message id="components_volumeunit_gallons_imperial">
-      <location filename="../../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
-      <source>Gallons (Imperial)</source>
-      <translation>加仑（英制）</translation>
+        <location filename="../components/settings/VolumeUnitRadioButtonGroup.qml" line="21"/>
+        <source>Gallons (Imperial)</source>
+        <translation>加仑（英制）</translation>
     </message>
     <message id="charger_history_box_min_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="58"/>
-      <source>Min Voltage</source>
-      <translation>最小电压</translation>
+        <location filename="../components/SolarDetailBox.qml" line="58"/>
+        <source>Min Voltage</source>
+        <translation>最小电压</translation>
     </message>
     <message id="charger_history_max_voltage">
-      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
-      <source>Max Voltage</source>
-      <translation>最大电压</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="87"/>
+        <source>Max Voltage</source>
+        <translation>最大电压</translation>
+    </message>
+    <message id="charger_history_box_max_voltage">
+        <location filename="../components/SolarDetailBox.qml" line="64"/>
+        <source>Max Voltage</source>
+        <translation type="unfinished">最大电压</translation>
     </message>
     <message id="charger_history_box_max_current">
-      <location filename="../../components/SolarDetailBox.qml" line="70"/>
-      <source>Max Current</source>
-      <translation>最大电流</translation>
+        <location filename="../components/SolarDetailBox.qml" line="70"/>
+        <source>Max Current</source>
+        <translation>最大电流</translation>
     </message>
     <message id="charger_history_charge_time">
-      <location filename="../../components/SolarDetailBox.qml" line="121"/>
-      <source>Charge time</source>
-      <extracomment>Statistics for battery charging time</extracomment>
-      <translation>充电时间</translation>
+        <location filename="../components/SolarDetailBox.qml" line="121"/>
+        <source>Charge time</source>
+        <extracomment>Statistics for battery charging time</extracomment>
+        <translation>充电时间</translation>
+    </message>
+    <message id="charger_history_box_bulk">
+        <location filename="../components/SolarDetailBox.qml" line="136"/>
+        <source>Bulk</source>
+        <extracomment>Battery: time spent in &apos;Bulk&apos; mode</extracomment>
+        <translation type="unfinished">快充</translation>
+    </message>
+    <message id="charger_history_box_float">
+        <location filename="../components/SolarDetailBox.qml" line="148"/>
+        <source>Float</source>
+        <extracomment>Battery: time spent in &apos;Float&apos; mode</extracomment>
+        <translation type="unfinished">浮充</translation>
+    </message>
+    <message id="charger_history_hr">
+        <location filename="../components/SolarDetailBox.qml" line="174"/>
+        <source>hr</source>
+        <extracomment>Abbreviation of &quot;hour&quot;</extracomment>
+        <translation type="unfinished">小时</translation>
     </message>
     <message id="solarchargers_state_bulk">
-      <location filename="../../data/SolarChargers.qml" line="57"/>
-      <source>Bulk</source>
-      <translation>快充</translation>
+        <location filename="../data/SolarChargers.qml" line="57"/>
+        <source>Bulk</source>
+        <translation>快充</translation>
     </message>
     <message id="charger_history_box_abs">
-      <location filename="../../components/SolarDetailBox.qml" line="142"/>
-      <source>Abs</source>
-      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
-      <translation>均充</translation>
+        <location filename="../components/SolarDetailBox.qml" line="142"/>
+        <source>Abs</source>
+        <extracomment>Battery: time spent in &apos;Absorption&apos; mode</extracomment>
+        <translation>均充</translation>
     </message>
     <message id="solarchargers_state_float">
-      <location filename="../../data/SolarChargers.qml" line="63"/>
-      <source>Float</source>
-      <translation>浮充</translation>
+        <location filename="../data/SolarChargers.qml" line="63"/>
+        <source>Float</source>
+        <translation>浮充</translation>
     </message>
     <message id="timeselector_hr">
-      <location filename="../../components/TimeSelector.qml" line="34"/>
-      <source>hr</source>
-      <translation>小时</translation>
+        <location filename="../components/TimeSelector.qml" line="34"/>
+        <source>hr</source>
+        <translation>小时</translation>
     </message>
     <message id="charger_history_errors_occurred">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
-      <source>%1 error(s) occurred</source>
-      <translation>发生 %1 个错误</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="96"/>
+        <source>%1 error(s) occurred</source>
+        <translation>发生 %1 个错误</translation>
     </message>
     <message id="charger_history_errors_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
-      <source>Last</source>
-      <extracomment>Details of last error</extracomment>
-      <translation>最后一个</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="120"/>
+        <source>Last</source>
+        <extracomment>Details of last error</extracomment>
+        <translation>最后一个</translation>
     </message>
     <message id="charger_history_errors_2nd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
-      <source>2nd last</source>
-      <extracomment>Details of 2nd last error</extracomment>
-      <translation>最后第二个</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="123"/>
+        <source>2nd last</source>
+        <extracomment>Details of 2nd last error</extracomment>
+        <translation>最后第二个</translation>
     </message>
     <message id="charger_history_errors_3rd_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
-      <source>3rd last</source>
-      <extracomment>Details of 3rd last error</extracomment>
-      <translation>最后第三个</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="126"/>
+        <source>3rd last</source>
+        <extracomment>Details of 3rd last error</extracomment>
+        <translation>最后第三个</translation>
     </message>
     <message id="charger_history_errors_4th_last">
-      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
-      <source>4th last</source>
-      <extracomment>Details of 4th last error</extracomment>
-      <translation>最后第四个</translation>
+        <location filename="../components/SolarHistoryErrorView.qml" line="129"/>
+        <source>4th last</source>
+        <extracomment>Details of 4th last error</extracomment>
+        <translation>最后第四个</translation>
     </message>
     <message id="charger_history_max_power">
-      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
-      <source>Max Power</source>
-      <translation>最大功率</translation>
+        <location filename="../components/SolarHistoryTableView.qml" line="93"/>
+        <source>Max Power</source>
+        <translation>最大功率</translation>
     </message>
     <message id="splash_view_unable_to_connect">
-      <location filename="../../components/SplashView.qml" line="231"/>
-      <source>Unable to connect</source>
-      <translation>无法连接</translation>
+        <location filename="../components/SplashView.qml" line="231"/>
+        <source>Unable to connect</source>
+        <translation>无法连接</translation>
     </message>
     <message id="splash_view_reconnecting">
-      <location filename="../../components/SplashView.qml" line="233"/>
-      <source>Disconnected, attempting to reconnect</source>
-      <translation>已断开连接，正在尝试重新连接</translation>
+        <location filename="../components/SplashView.qml" line="233"/>
+        <source>Disconnected, attempting to reconnect</source>
+        <translation>已断开连接，正在尝试重新连接</translation>
     </message>
     <message id="utils_connman_connecting">
-      <location filename="../../components/Utils.js" line="273"/>
-      <source>Connecting</source>
-      <translation>正在连接</translation>
+        <location filename="../components/Utils.js" line="273"/>
+        <source>Connecting</source>
+        <translation>正在连接</translation>
+    </message>
+    <message id="splash_view_connecting">
+        <location filename="../components/SplashView.qml" line="236"/>
+        <source>Connecting</source>
+        <translation type="unfinished">正在连接</translation>
     </message>
     <message id="splash_view_connected">
-      <location filename="../../components/SplashView.qml" line="238"/>
-      <source>Connected, awaiting broker messages</source>
-      <translation>已连接，等待代理消息</translation>
+        <location filename="../components/SplashView.qml" line="238"/>
+        <source>Connected, awaiting broker messages</source>
+        <translation>已连接，等待代理消息</translation>
     </message>
     <message id="splash_view_initializing">
-      <location filename="../../components/SplashView.qml" line="240"/>
-      <source>Connected, receiving broker messages</source>
-      <translation>已连接，正在接收代理消息</translation>
+        <location filename="../components/SplashView.qml" line="240"/>
+        <source>Connected, receiving broker messages</source>
+        <translation>已连接，正在接收代理消息</translation>
     </message>
     <message id="splash_view_ready">
-      <location filename="../../components/SplashView.qml" line="242"/>
-      <source>Connected, loading user interface</source>
-      <translation>已连接，正在加载用户界面</translation>
+        <location filename="../components/SplashView.qml" line="242"/>
+        <source>Connected, loading user interface</source>
+        <translation>已连接，正在加载用户界面</translation>
     </message>
     <message id="splash_view_invalid_protocol_version">
-      <location filename="../../components/SplashView.qml" line="257"/>
-      <source>Invalid protocol version</source>
-      <translation>协议版本无效</translation>
+        <location filename="../components/SplashView.qml" line="257"/>
+        <source>Invalid protocol version</source>
+        <translation>协议版本无效</translation>
     </message>
     <message id="splash_view_client_id_rejected">
-      <location filename="../../components/SplashView.qml" line="259"/>
-      <source>Client ID rejected</source>
-      <translation>客户 ID 被拒绝</translation>
+        <location filename="../components/SplashView.qml" line="259"/>
+        <source>Client ID rejected</source>
+        <translation>客户 ID 被拒绝</translation>
     </message>
     <message id="splash_view_server_unavailable">
-      <location filename="../../components/SplashView.qml" line="261"/>
-      <source>Broker service not available</source>
-      <translation>代理服务不可用</translation>
+        <location filename="../components/SplashView.qml" line="261"/>
+        <source>Broker service not available</source>
+        <translation>代理服务不可用</translation>
     </message>
     <message id="splash_view_bad_username_or_password">
-      <location filename="../../components/SplashView.qml" line="263"/>
-      <source>Bad username or password</source>
-      <translation>用户名或密码错误</translation>
+        <location filename="../components/SplashView.qml" line="263"/>
+        <source>Bad username or password</source>
+        <translation>用户名或密码错误</translation>
     </message>
     <message id="splash_view_not_authorized">
-      <location filename="../../components/SplashView.qml" line="265"/>
-      <source>Client not authorized</source>
-      <translation>客户端未授权</translation>
+        <location filename="../components/SplashView.qml" line="265"/>
+        <source>Client not authorized</source>
+        <translation>客户端未授权</translation>
     </message>
     <message id="splash_view_transport_invalid">
-      <location filename="../../components/SplashView.qml" line="267"/>
-      <source>Transport connection error</source>
-      <translation>传输连接错误</translation>
+        <location filename="../components/SplashView.qml" line="267"/>
+        <source>Transport connection error</source>
+        <translation>传输连接错误</translation>
     </message>
     <message id="splash_view_protocol_violation">
-      <location filename="../../components/SplashView.qml" line="269"/>
-      <source>Protocol violation error</source>
-      <translation>协议违规错误</translation>
+        <location filename="../components/SplashView.qml" line="269"/>
+        <source>Protocol violation error</source>
+        <translation>协议违规错误</translation>
     </message>
     <message id="splash_view_mqtt5_error">
-      <location filename="../../components/SplashView.qml" line="273"/>
-      <source>MQTT protocol level 5 error</source>
-      <translation>MQTT 协议 5 级错误</translation>
+        <location filename="../components/SplashView.qml" line="273"/>
+        <source>MQTT protocol level 5 error</source>
+        <translation>MQTT 协议 5 级错误</translation>
     </message>
     <message id="notifications_silence_alarm">
-      <location filename="../../components/StatusBar.qml" line="142"/>
-      <source>Silence alarm</source>
-      <translation>静音警报</translation>
+        <location filename="../components/StatusBar.qml" line="142"/>
+        <source>Silence alarm</source>
+        <translation>静音警报</translation>
     </message>
     <message id="vebus_device_page_total_power">
-      <location filename="../../components/ThreePhaseQuantityTable.qml" line="76"/>
-      <source>Total Power</source>
-      <translation>总电力</translation>
+        <location filename="../components/ThreePhaseQuantityTable.qml" line="77"/>
+        <source>Total Power</source>
+        <translation>总电力</translation>
     </message>
     <message id="timeselector_min">
-      <location filename="../../components/TimeSelector.qml" line="62"/>
-      <source>min</source>
-      <translation>最小</translation>
+        <location filename="../components/TimeSelector.qml" line="62"/>
+        <source>min</source>
+        <translation>最小</translation>
     </message>
     <message id="utils_format_days_hours">
-      <location filename="../../components/Utils.js" line="186"/>
-      <source>%1d %2h</source>
-      <translation>%1天 %2小时</translation>
+        <location filename="../components/Utils.js" line="186"/>
+        <source>%1d %2h</source>
+        <translation>%1天 %2小时</translation>
     </message>
     <message id="utils_format_hours_min">
-      <location filename="../../components/Utils.js" line="191"/>
-      <source>%1h %2m</source>
-      <translation>%1天 %2小时</translation>
+        <location filename="../components/Utils.js" line="191"/>
+        <source>%1h %2m</source>
+        <translation>%1天 %2小时</translation>
     </message>
     <message id="utils_format_min_sec">
-      <location filename="../../components/Utils.js" line="212"/>
-      <source>%1m %2s</source>
-      <translation>%1分 %2秒</translation>
+        <location filename="../components/Utils.js" line="212"/>
+        <source>%1m %2s</source>
+        <translation>%1分 %2秒</translation>
     </message>
     <message id="utils_format_min">
-      <location filename="../../components/Utils.js" line="214"/>
-      <source>%1m</source>
-      <translation>%1分</translation>
+        <location filename="../components/Utils.js" line="214"/>
+        <source>%1m</source>
+        <translation>%1分</translation>
     </message>
     <message id="utils_format_sec">
-      <location filename="../../components/Utils.js" line="218"/>
-      <source>%1s</source>
-      <translation>%1秒</translation>
+        <location filename="../components/Utils.js" line="218"/>
+        <source>%1s</source>
+        <translation>%1秒</translation>
     </message>
     <message id="utils_zero_minutes">
-      <location filename="../../components/Utils.js" line="220"/>
-      <source>0m</source>
-      <translation>0分</translation>
+        <location filename="../components/Utils.js" line="220"/>
+        <source>0m</source>
+        <translation>0分</translation>
     </message>
     <message id="utils_connman_failure">
-      <location filename="../../components/Utils.js" line="270"/>
-      <source>Failure</source>
-      <translation>故障</translation>
+        <location filename="../components/Utils.js" line="270"/>
+        <source>Failure</source>
+        <translation>故障</translation>
     </message>
     <message id="utils_connman_retrieving_ip_address">
-      <location filename="../../components/Utils.js" line="276"/>
-      <source>Retrieving IP address</source>
-      <translation>检索IP地址</translation>
+        <location filename="../components/Utils.js" line="276"/>
+        <source>Retrieving IP address</source>
+        <translation>检索IP地址</translation>
+    </message>
+    <message id="utils_connman_connected">
+        <location filename="../components/Utils.js" line="280"/>
+        <source>Connected</source>
+        <translation type="unfinished">已连接</translation>
     </message>
     <message id="utils_connman_disconnect">
-      <location filename="../../components/Utils.js" line="283"/>
-      <source>Disconnect</source>
-      <translation>断开</translation>
+        <location filename="../components/Utils.js" line="283"/>
+        <source>Disconnect</source>
+        <translation>断开</translation>
+    </message>
+    <message id="utils_connman_disconnected">
+        <location filename="../components/Utils.js" line="287"/>
+        <source>Disconnected</source>
+        <translation type="unfinished">已断开连接</translation>
     </message>
     <message id="overview_widget_acloads_title">
-      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
-      <source>AC Loads</source>
-      <translation>交流负载</translation>
+        <location filename="../components/widgets/AcLoadsWidget.qml" line="17"/>
+        <source>AC Loads</source>
+        <translation>交流负载</translation>
     </message>
     <message id="overview_widget_dcloads_title">
-      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
-      <source>DC Loads</source>
-      <translation>直流负载</translation>
+        <location filename="../components/widgets/DcLoadsWidget.qml" line="24"/>
+        <source>DC Loads</source>
+        <translation>直流负载</translation>
     </message>
     <message id="overview_widget_evcs_title">
-      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
-      <source>EVCS</source>
-      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
-      <translation>电动汽车充电器</translation>
+        <location filename="../components/widgets/EvcsWidget.qml" line="23"/>
+        <source>EVCS</source>
+        <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+        <translation>电动汽车充电器</translation>
     </message>
     <message id="overview_widget_wind_title">
-      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
-      <source>Wind</source>
-      <translation>风</translation>
+        <location filename="../components/widgets/WindWidget.qml" line="13"/>
+        <source>Wind</source>
+        <translation>风</translation>
     </message>
     <message id="acInputs_shore">
-      <location filename="../../data/AcInputs.qml" line="98"/>
-      <source>Shore</source>
-      <translation>岸电</translation>
+        <location filename="../data/AcInputs.qml" line="115"/>
+        <source>Shore</source>
+        <translation>岸电</translation>
     </message>
     <message id="acInputs_current_limit_grid">
-      <location filename="../../data/AcInputs.qml" line="124"/>
-      <source>Grid current limit</source>
-      <translation>电网电流限制</translation>
+        <location filename="../data/AcInputs.qml" line="141"/>
+        <source>Grid current limit</source>
+        <translation>电网电流限制</translation>
     </message>
     <message id="acInputs_current_limit_generator">
-      <location filename="../../data/AcInputs.qml" line="127"/>
-      <source>Generator current limit</source>
-      <translation>发电机电流限制</translation>
+        <location filename="../data/AcInputs.qml" line="144"/>
+        <source>Generator current limit</source>
+        <translation>发电机电流限制</translation>
     </message>
     <message id="acInputs_current_limit_shore">
-      <location filename="../../data/AcInputs.qml" line="130"/>
-      <source>Shore current limit</source>
-      <translation>岸电电流限制</translation>
+        <location filename="../data/AcInputs.qml" line="147"/>
+        <source>Shore current limit</source>
+        <translation>岸电电流限制</translation>
+    </message>
+    <message id="acInputs_statusCode_stopping">
+        <location filename="../data/AcInputs.qml" line="169"/>
+        <source>Stopping</source>
+        <translation type="unfinished">停止</translation>
     </message>
     <message id="page_generator_stopping">
-      <location filename="../../data/Generators.qml" line="55"/>
-      <source>Stopping</source>
-      <translation>停止</translation>
+        <location filename="../data/Generators.qml" line="55"/>
+        <source>Stopping</source>
+        <translation>停止</translation>
     </message>
     <message id="brief_battery_time_to_go">
-      <location filename="../../data/Batteries.qml" line="38"/>
-      <source>%1 to go</source>
-      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
-      <translation>还剩 %1 </translation>
+        <location filename="../data/Batteries.qml" line="38"/>
+        <source>%1 to go</source>
+        <extracomment>%1 = time remaining, e.g. &apos;3h 2m&apos;</extracomment>
+        <translation>还剩 %1 </translation>
     </message>
     <message id="tank_description">
-      <location filename="../../data/common/Tank.qml" line="96"/>
-      <source>%1 tank (%2)</source>
-      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
-      <translation>%1 箱 (%2)</translation>
+        <location filename="../data/common/Tank.qml" line="96"/>
+        <source>%1 tank (%2)</source>
+        <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+        <translation>%1 箱 (%2)</translation>
     </message>
     <message id="dcInputs_ac_charger">
-      <location filename="../../data/DcInputs.qml" line="112"/>
-      <source>AC charger</source>
-      <translation>交流充电器</translation>
+        <location filename="../data/DcInputs.qml" line="112"/>
+        <source>AC charger</source>
+        <translation>交流充电器</translation>
     </message>
     <message id="dcInputs_alternator">
-      <location filename="../../data/DcInputs.qml" line="115"/>
-      <source>Alternator</source>
-      <translation>底盘发电机</translation>
+        <location filename="../data/DcInputs.qml" line="115"/>
+        <source>Alternator</source>
+        <translation>底盘发电机</translation>
     </message>
     <message id="dcInputs_dccharger">
-      <location filename="../../data/DcInputs.qml" line="118"/>
-      <source>DC charger</source>
-      <translation>直流充电器</translation>
+        <location filename="../data/DcInputs.qml" line="118"/>
+        <source>DC charger</source>
+        <translation>直流充电器</translation>
     </message>
     <message id="dcInputs_dc_generator">
-      <location filename="../../data/DcInputs.qml" line="121"/>
-      <source>DC generator</source>
-      <translation>直流发电机</translation>
+        <location filename="../data/DcInputs.qml" line="121"/>
+        <source>DC generator</source>
+        <translation>直流发电机</translation>
     </message>
     <message id="dcInputs_dc_system">
-      <location filename="../../data/DcInputs.qml" line="124"/>
-      <source>DC system</source>
-      <translation>直流系统</translation>
+        <location filename="../data/DcInputs.qml" line="124"/>
+        <source>DC system</source>
+        <translation>直流系统</translation>
     </message>
     <message id="dcInputs_fuelcell">
-      <location filename="../../data/DcInputs.qml" line="127"/>
-      <source>Fuel cell</source>
-      <translation>燃料电池</translation>
+        <location filename="../data/DcInputs.qml" line="127"/>
+        <source>Fuel cell</source>
+        <translation>燃料电池</translation>
     </message>
     <message id="dcInputs_shaft_generator">
-      <location filename="../../data/DcInputs.qml" line="130"/>
-      <source>Shaft generator</source>
-      <translation>轴发电机</translation>
+        <location filename="../data/DcInputs.qml" line="130"/>
+        <source>Shaft generator</source>
+        <translation>轴发电机</translation>
     </message>
     <message id="dcInputs_water_generator">
-      <location filename="../../data/DcInputs.qml" line="133"/>
-      <source>Water generator</source>
-      <translation>水力发电机</translation>
+        <location filename="../data/DcInputs.qml" line="133"/>
+        <source>Water generator</source>
+        <translation>水力发电机</translation>
     </message>
     <message id="dcInputs_wind_charger">
-      <location filename="../../data/DcInputs.qml" line="136"/>
-      <source>Wind charger</source>
-      <translation>风能充电器</translation>
+        <location filename="../data/DcInputs.qml" line="136"/>
+        <source>Wind charger</source>
+        <translation>风能充电器</translation>
     </message>
     <message id="digitalinputs_state_low">
-      <location filename="../../data/DigitalInputs.qml" line="59"/>
-      <source>Low</source>
-      <translation>低</translation>
+        <location filename="../data/DigitalInputs.qml" line="59"/>
+        <source>Low</source>
+        <translation>低</translation>
     </message>
     <message id="digitalinputs_state_high">
-      <location filename="../../data/DigitalInputs.qml" line="62"/>
-      <source>High</source>
-      <translation>高</translation>
+        <location filename="../data/DigitalInputs.qml" line="62"/>
+        <source>High</source>
+        <translation>高</translation>
     </message>
     <message id="ess_state_keep_batteries_charged">
-      <location filename="../../data/Ess.qml" line="32"/>
-      <source>Keep batteries charged</source>
-      <translation>让电池保持在充电状态</translation>
+        <location filename="../data/Ess.qml" line="32"/>
+        <source>Keep batteries charged</source>
+        <translation>让电池保持在充电状态</translation>
     </message>
     <message id="ess_state_optimized_with_battery_life">
-      <location filename="../../data/Ess.qml" line="34"/>
-      <source>Optimized with battery life</source>
-      <translation>优化电池寿命</translation>
+        <location filename="../data/Ess.qml" line="34"/>
+        <source>Optimized with battery life</source>
+        <translation>优化电池寿命</translation>
     </message>
     <message id="ess_state_optimized_without_battery_life">
-      <location filename="../../data/Ess.qml" line="36"/>
-      <source>Optimized without battery life</source>
-      <translation>非电池长寿命优化</translation>
+        <location filename="../data/Ess.qml" line="36"/>
+        <source>Optimized without battery life</source>
+        <translation>非电池长寿命优化</translation>
+    </message>
+    <message id="ess_state_external_control">
+        <location filename="../data/Ess.qml" line="38"/>
+        <source>External control</source>
+        <translation type="unfinished">外部控制</translation>
     </message>
     <message id="evchargers_status_charged">
-      <location filename="../../data/EvChargers.qml" line="94"/>
-      <source>Charged</source>
-      <translation>已充电</translation>
+        <location filename="../data/EvChargers.qml" line="94"/>
+        <source>Charged</source>
+        <translation>已充电</translation>
     </message>
     <message id="evchargers_status_waiting_for_sun">
-      <location filename="../../data/EvChargers.qml" line="97"/>
-      <source>Waiting for sun</source>
-      <translation>等待太阳</translation>
+        <location filename="../data/EvChargers.qml" line="97"/>
+        <source>Waiting for sun</source>
+        <translation>等待太阳</translation>
     </message>
     <message id="evchargers_status_waiting_for_rfid">
-      <location filename="../../data/EvChargers.qml" line="100"/>
-      <source>Waiting for RFID</source>
-      <translation>等待RFID</translation>
+        <location filename="../data/EvChargers.qml" line="100"/>
+        <source>Waiting for RFID</source>
+        <translation>等待RFID</translation>
     </message>
     <message id="evchargers_status_waiting_for_start">
-      <location filename="../../data/EvChargers.qml" line="103"/>
-      <source>Waiting for start</source>
-      <translation>等待开始</translation>
+        <location filename="../data/EvChargers.qml" line="103"/>
+        <source>Waiting for start</source>
+        <translation>等待开始</translation>
     </message>
     <message id="evchargers_status_ground_test_error">
-      <location filename="../../data/EvChargers.qml" line="109"/>
-      <source>Ground test error</source>
-      <translation>接地测试误差</translation>
+        <location filename="../data/EvChargers.qml" line="109"/>
+        <source>Ground test error</source>
+        <translation>接地测试误差</translation>
     </message>
     <message id="evchargers_status_cp_input_test_error">
-      <location filename="../../data/EvChargers.qml" line="115"/>
-      <source>CP input test error</source>
-      <translation>CP输入测试错误</translation>
+        <location filename="../data/EvChargers.qml" line="115"/>
+        <source>CP input test error</source>
+        <translation>CP输入测试错误</translation>
     </message>
     <message id="evchargers_status_residual_current_detected">
-      <location filename="../../data/EvChargers.qml" line="118"/>
-      <source>Residual current detected</source>
-      <translation>检测到RCD</translation>
+        <location filename="../data/EvChargers.qml" line="118"/>
+        <source>Residual current detected</source>
+        <translation>检测到RCD</translation>
     </message>
     <message id="evchargers_status_undervoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="121"/>
-      <source>Undervoltage detected</source>
-      <translation>检测到欠压</translation>
+        <location filename="../data/EvChargers.qml" line="121"/>
+        <source>Undervoltage detected</source>
+        <translation>检测到欠压</translation>
     </message>
     <message id="evchargers_status_overvoltage_detected">
-      <location filename="../../data/EvChargers.qml" line="124"/>
-      <source>Overvoltage detected</source>
-      <translation>检测到高电压</translation>
+        <location filename="../data/EvChargers.qml" line="124"/>
+        <source>Overvoltage detected</source>
+        <translation>检测到高电压</translation>
     </message>
     <message id="evchargers_status_overheating_detected">
-      <location filename="../../data/EvChargers.qml" line="127"/>
-      <source>Overheating detected</source>
-      <translation>检测到过热</translation>
+        <location filename="../data/EvChargers.qml" line="127"/>
+        <source>Overheating detected</source>
+        <translation>检测到过热</translation>
     </message>
     <message id="evchargers_status_charging_limit">
-      <location filename="../../data/EvChargers.qml" line="130"/>
-      <source>Charging limit</source>
-      <translation>充电限制</translation>
+        <location filename="../data/EvChargers.qml" line="130"/>
+        <source>Charging limit</source>
+        <translation>充电限制</translation>
     </message>
     <message id="evchargers_status_start_charging">
-      <location filename="../../data/EvChargers.qml" line="133"/>
-      <source>Start charging</source>
-      <translation>开始充电</translation>
+        <location filename="../data/EvChargers.qml" line="133"/>
+        <source>Start charging</source>
+        <translation>开始充电</translation>
+    </message>
+    <message id="evchargers_mode_scheduled">
+        <location filename="../data/EvChargers.qml" line="162"/>
+        <source>Scheduled</source>
+        <translation type="unfinished">已定时</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
-      <location filename="../../data/System.qml" line="193"/>
-      <source>Scheduled</source>
-      <translation>已定时</translation>
+        <location filename="../data/System.qml" line="193"/>
+        <source>Scheduled</source>
+        <translation>已定时</translation>
     </message>
     <message id="page_generator_warm_up">
-      <location filename="../../data/Generators.qml" line="49"/>
-      <source>Warm-up</source>
-      <translation>预热</translation>
+        <location filename="../data/Generators.qml" line="49"/>
+        <source>Warm-up</source>
+        <translation>预热</translation>
     </message>
     <message id="page_generator_cool_down">
-      <location filename="../../data/Generators.qml" line="52"/>
-      <source>Cool-down</source>
-      <translation>冷却</translation>
+        <location filename="../data/Generators.qml" line="52"/>
+        <source>Cool-down</source>
+        <translation>冷却</translation>
     </message>
     <message id="generator_test_run">
-      <location filename="../../data/Generators.qml" line="73"/>
-      <source>Test run</source>
-      <translation>试运行</translation>
+        <location filename="../data/Generators.qml" line="73"/>
+        <source>Test run</source>
+        <translation>试运行</translation>
     </message>
     <message id="generator_manually_started">
-      <location filename="../../data/Generators.qml" line="70"/>
-      <source>Manually started</source>
-      <translation>手动启动</translation>
+        <location filename="../data/Generators.qml" line="70"/>
+        <source>Manually started</source>
+        <translation>手动启动</translation>
     </message>
     <message id="notifications_toast_short_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi。</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi。</translation>
     </message>
     <message id="notifications_toast_long_text">
-      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
-      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
-      <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi。 Voluptatem qui quia et consequuntur。</translation>
+        <location filename="../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+        <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+        <translation>Mollitia quis est quas deleniti quibusdam explicabo quasi。 Voluptatem qui quia et consequuntur。</translation>
     </message>
     <message id="pvinverters_statusCode_boot_loading">
-      <location filename="../../data/PvInverters.qml" line="44"/>
-      <source>Boot loading</source>
-      <translation>启动加载</translation>
+        <location filename="../data/PvInverters.qml" line="44"/>
+        <source>Boot loading</source>
+        <translation>启动加载</translation>
     </message>
     <message id="pvinverters_statusCode_running_mppt">
-      <location filename="../../data/PvInverters.qml" line="49"/>
-      <source>Running (MPPT)</source>
-      <translation>运行中(MPPT)</translation>
+        <location filename="../data/PvInverters.qml" line="49"/>
+        <source>Running (MPPT)</source>
+        <translation>运行中(MPPT)</translation>
     </message>
     <message id="pvinverters_statusCode_running_throttled">
-      <location filename="../../data/PvInverters.qml" line="52"/>
-      <source>Running (Throttled)</source>
-      <translation>运行中（限制）</translation>
+        <location filename="../data/PvInverters.qml" line="52"/>
+        <source>Running (Throttled)</source>
+        <translation>运行中（限制）</translation>
     </message>
     <message id="controlcard_switches_relay_name">
-      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
-      <source>Relay %1</source>
-      <extracomment>%1 = Relay number</extracomment>
-      <translation>继电器%1</translation>
+        <location filename="../pages/controlcards/SwitchesCard.qml" line="34"/>
+        <source>Relay %1</source>
+        <extracomment>%1 = Relay number</extracomment>
+        <translation>继电器%1</translation>
     </message>
     <message id="solarchargers_state_fault">
-      <location filename="../../data/SolarChargers.qml" line="54"/>
-      <source>Fault</source>
-      <translation>错误</translation>
+        <location filename="../data/SolarChargers.qml" line="54"/>
+        <source>Fault</source>
+        <translation>错误</translation>
     </message>
     <message id="solarchargers_state_absorption">
-      <location filename="../../data/SolarChargers.qml" line="60"/>
-      <source>Absorption</source>
-      <translation>均充</translation>
+        <location filename="../data/SolarChargers.qml" line="60"/>
+        <source>Absorption</source>
+        <translation>均充</translation>
     </message>
     <message id="solarchargers_state_storage">
-      <location filename="../../data/SolarChargers.qml" line="66"/>
-      <source>Storage</source>
-      <translation>存储</translation>
+        <location filename="../data/SolarChargers.qml" line="66"/>
+        <source>Storage</source>
+        <translation>存储</translation>
     </message>
     <message id="solarchargers_state_equalize">
-      <location filename="../../data/SolarChargers.qml" line="69"/>
-      <source>Equalize</source>
-      <translation>均衡</translation>
+        <location filename="../data/SolarChargers.qml" line="69"/>
+        <source>Equalize</source>
+        <translation>均衡</translation>
+    </message>
+    <message id="solarchargers_state_external control">
+        <location filename="../data/SolarChargers.qml" line="72"/>
+        <source>External control</source>
+        <translation type="unfinished">外部控制</translation>
     </message>
     <message id="inverters_state_aes_mode">
-      <location filename="../../data/System.qml" line="123"/>
-      <source>AES mode</source>
-      <translation>节能模式</translation>
+        <location filename="../data/System.qml" line="123"/>
+        <source>AES mode</source>
+        <translation>节能模式</translation>
     </message>
     <message id="inverters_state_faultcondition">
-      <location filename="../../data/System.qml" line="126"/>
-      <source>Fault condition</source>
-      <translation>故障情况</translation>
+        <location filename="../data/System.qml" line="126"/>
+        <source>Fault condition</source>
+        <translation>故障情况</translation>
     </message>
     <message id="inverters_state_bulkcharging">
-      <location filename="../../data/System.qml" line="129"/>
-      <source>Bulk charging</source>
-      <translation>快充</translation>
+        <location filename="../data/System.qml" line="129"/>
+        <source>Bulk charging</source>
+        <translation>快充</translation>
     </message>
     <message id="inverters_state_absorptioncharging">
-      <location filename="../../data/System.qml" line="132"/>
-      <source>Absorption charging</source>
-      <translation>均充</translation>
+        <location filename="../data/System.qml" line="132"/>
+        <source>Absorption charging</source>
+        <translation>均充</translation>
     </message>
     <message id="inverters_state_floatcharging">
-      <location filename="../../data/System.qml" line="135"/>
-      <source>Float charging</source>
-      <translation>浮充</translation>
+        <location filename="../data/System.qml" line="135"/>
+        <source>Float charging</source>
+        <translation>浮充</translation>
     </message>
     <message id="inverters_state_storagemode">
-      <location filename="../../data/System.qml" line="138"/>
-      <source>Storage mode</source>
-      <translation>存储模式</translation>
+        <location filename="../data/System.qml" line="138"/>
+        <source>Storage mode</source>
+        <translation>存储模式</translation>
     </message>
     <message id="inverters_state_equalisationcharging">
-      <location filename="../../data/System.qml" line="141"/>
-      <source>Equalization charging</source>
-      <translation>均衡充电</translation>
+        <location filename="../data/System.qml" line="141"/>
+        <source>Equalization charging</source>
+        <translation>均衡充电</translation>
     </message>
     <message id="inverters_state_passthru">
-      <location filename="../../data/System.qml" line="144"/>
-      <source>Pass-thru</source>
-      <translation>直通</translation>
+        <location filename="../data/System.qml" line="144"/>
+        <source>Pass-thru</source>
+        <translation>直通</translation>
     </message>
     <message id="inverters_state_inverting">
-      <location filename="../../data/System.qml" line="147"/>
-      <source>Inverting</source>
-      <translation>逆变</translation>
+        <location filename="../data/System.qml" line="147"/>
+        <source>Inverting</source>
+        <translation>逆变</translation>
     </message>
     <message id="inverters_state_assisting">
-      <location filename="../../data/System.qml" line="150"/>
-      <source>Assisting</source>
-      <translation>辅助供电</translation>
+        <location filename="../data/System.qml" line="150"/>
+        <source>Assisting</source>
+        <translation>辅助供电</translation>
     </message>
     <message id="inverters_state_powersupplymode">
-      <location filename="../../data/System.qml" line="153"/>
-      <source>Power supply mode</source>
-      <translation>电源模式</translation>
+        <location filename="../data/System.qml" line="153"/>
+        <source>Power supply mode</source>
+        <translation>电源模式</translation>
+    </message>
+    <message id="inverters_state_sustain">
+        <location filename="../data/System.qml" line="156"/>
+        <source>Sustain</source>
+        <translation type="unfinished">维持</translation>
     </message>
     <message id="inverters_state_wakeup">
-      <location filename="../../data/System.qml" line="160"/>
-      <source>Wake up</source>
-      <translation>唤醒</translation>
+        <location filename="../data/System.qml" line="160"/>
+        <source>Wake up</source>
+        <translation>唤醒</translation>
     </message>
     <message id="inverters_state_repeatedabsorption">
-      <location filename="../../data/System.qml" line="163"/>
-      <source>Repeated absorption</source>
-      <translation>重复均充</translation>
+        <location filename="../data/System.qml" line="163"/>
+        <source>Repeated absorption</source>
+        <translation>重复均充</translation>
     </message>
     <message id="inverters_state_autoequalize">
-      <location filename="../../data/System.qml" line="166"/>
-      <source>Auto equalize</source>
-      <translation>自动均衡</translation>
+        <location filename="../data/System.qml" line="166"/>
+        <source>Auto equalize</source>
+        <translation>自动均衡</translation>
     </message>
     <message id="inverters_state_battery_safe">
-      <location filename="../../data/System.qml" line="169"/>
-      <source>Battery safe</source>
-      <translation>电池保护模式</translation>
+        <location filename="../data/System.qml" line="169"/>
+        <source>Battery safe</source>
+        <translation>电池保护模式</translation>
     </message>
     <message id="inverters_state_loaddetect">
-      <location filename="../../data/System.qml" line="172"/>
-      <source>Load detect</source>
-      <translation>负载检测</translation>
+        <location filename="../data/System.qml" line="172"/>
+        <source>Load detect</source>
+        <translation>负载检测</translation>
     </message>
     <message id="inverters_state_blocked">
-      <location filename="../../data/System.qml" line="175"/>
-      <source>Blocked</source>
-      <translation>锁定</translation>
+        <location filename="../data/System.qml" line="175"/>
+        <source>Blocked</source>
+        <translation>锁定</translation>
     </message>
     <message id="inverters_state_test">
-      <location filename="../../data/System.qml" line="178"/>
-      <source>Test</source>
-      <translation>测试</translation>
+        <location filename="../data/System.qml" line="178"/>
+        <source>Test</source>
+        <translation>测试</translation>
+    </message>
+    <message id="inverters_state_dynamic_ess">
+        <location filename="../data/System.qml" line="196"/>
+        <source>Dynamic ESS</source>
+        <translation type="unfinished">动态ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
-      <source>Dynamic ESS</source>
-      <translation>动态ESS</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="41"/>
+        <source>Dynamic ESS</source>
+        <translation>动态ESS</translation>
     </message>
     <message id="systemsettings_networkstatus_group_master">
-      <location filename="../../data/SystemSettings.qml" line="89"/>
-      <source>Group Master</source>
-      <extracomment>Network status: Group Master</extracomment>
-      <translation>组主机</translation>
+        <location filename="../data/SystemSettings.qml" line="91"/>
+        <source>Group Master</source>
+        <extracomment>Network status: Group Master</extracomment>
+        <translation>组主机</translation>
     </message>
     <message id="systemsettings_networkstatus_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="93"/>
-      <source>Instance Master</source>
-      <extracomment>Network status: Instance Master</extracomment>
-      <translation>实例主机</translation>
+        <location filename="../data/SystemSettings.qml" line="95"/>
+        <source>Instance Master</source>
+        <extracomment>Network status: Instance Master</extracomment>
+        <translation>实例主机</translation>
     </message>
     <message id="systemsettings_networkstatus_group_and_instance_master">
-      <location filename="../../data/SystemSettings.qml" line="97"/>
-      <source>Group &amp; Instance Master</source>
-      <extracomment>Network status: Group &amp; Instance Master</extracomment>
-      <translation>组&amp;实例主机</translation>
+        <location filename="../data/SystemSettings.qml" line="99"/>
+        <source>Group &amp; Instance Master</source>
+        <extracomment>Network status: Group &amp; Instance Master</extracomment>
+        <translation>组&amp;实例主机</translation>
     </message>
     <message id="systemsettings_networkstatus_standalone_and_group_master">
-      <location filename="../../data/SystemSettings.qml" line="105"/>
-      <source>Standalone &amp; Group Master</source>
-      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
-      <translation>单机或主机</translation>
+        <location filename="../data/SystemSettings.qml" line="107"/>
+        <source>Standalone &amp; Group Master</source>
+        <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+        <translation>单机或主机</translation>
     </message>
     <message id="inverterCharger_mode_charger_only">
-      <location filename="../../data/InverterChargers.qml" line="85"/>
-      <source>Charger only</source>
-      <translation>只充电</translation>
+        <location filename="../data/InverterChargers.qml" line="85"/>
+        <source>Charger only</source>
+        <translation>只充电</translation>
     </message>
     <message id="inverterCharger_mode_inverter_only">
-      <location filename="../../data/InverterChargers.qml" line="88"/>
-      <source>Inverter only</source>
-      <translation>仅逆变</translation>
+        <location filename="../data/InverterChargers.qml" line="88"/>
+        <source>Inverter only</source>
+        <translation>仅逆变</translation>
+    </message>
+    <message id="charger_alarms_low_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="31"/>
+        <source>Low battery voltage alarm</source>
+        <translation type="unfinished">电池低压报警</translation>
+    </message>
+    <message id="charger_alarms_high_battery_voltage_alarm">
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="40"/>
+        <source>High battery voltage alarm</source>
+        <translation type="unfinished">高电池电压报警</translation>
     </message>
     <message id="charger_alarms_short_circuit_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
-      <source>Short circuit alarm</source>
-      <translation>短路报警</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+        <source>Short circuit alarm</source>
+        <translation>短路报警</translation>
     </message>
     <message id="settings_wifi_disable_ap">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="129"/>
-      <source>Disable Access Point</source>
-      <translation>取消连接热点</translation>
+        <location filename="../pages/settings/PageSettingsWifi.qml" line="129"/>
+        <source>Disable Access Point</source>
+        <translation>取消连接热点</translation>
     </message>
     <message id="settings_minmax_dc_input">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
-      <source>DC input</source>
-      <translation>直流输入</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+        <source>DC input</source>
+        <translation>直流输入</translation>
     </message>
     <message id="ess_recommended">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
-      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
-      <translation>对于锂电池，不建议充电低于 10%。对于其他类型的电池，请查看数据表，了解制造商建议的最低电量。</translation>
+        <location filename="../components/dialogs/ESSMinimumSOCDialog.qml" line="71"/>
+        <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+        <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+        <translation>对于锂电池，不建议充电低于 10%。对于其他类型的电池，请查看数据表，了解制造商建议的最低电量。</translation>
     </message>
     <message id="controlcard_generator_disableautostartdialog_title">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
-      <source>Disable autostart?</source>
-      <oldsource>Disable Autostart?</oldsource>
-      <translation>禁用自动启动？</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="91"/>
+        <source>Disable autostart?</source>
+        <oldsource>Disable Autostart?</oldsource>
+        <translation>禁用自动启动？</translation>
     </message>
     <message id="controlcard_inverter_charger">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
-      <source>Inverter / Charger (%1)</source>
-      <extracomment>%1 = the inverter/charger name</extracomment>
-      <oldsource>Inverter / Charger</oldsource>
-      <translation>逆变器/充电器 (%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="23"/>
+        <source>Inverter / Charger (%1)</source>
+        <oldsource>Inverter / Charger</oldsource>
+        <extracomment>%1 = the inverter/charger name</extracomment>
+        <translation>逆变器/充电器 (%1)</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
-      <source>Display CPU usage</source>
-      <translation>显示 CPU 使用率</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="57"/>
+        <source>Display CPU usage</source>
+        <translation>显示 CPU 使用率</translation>
     </message>
     <message id="settings_page_debug_quit_application">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
-      <source>Quit application</source>
-      <oldsource>Quit Application</oldsource>
-      <translation>退出应用程序</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="40"/>
+        <source>Quit application</source>
+        <oldsource>Quit Application</oldsource>
+        <translation>退出应用程序</translation>
     </message>
     <message id="settings_page_debug_quit">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
-      <source>Quit</source>
-      <translation>退出</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="43"/>
+        <source>Quit</source>
+        <translation>退出</translation>
     </message>
     <message id="settings_page_debug_application_version">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
-      <source>Application version</source>
-      <translation>应用版本</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="104"/>
+        <source>Application version</source>
+        <translation>应用版本</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="233"/>
-      <source>Oil temperature</source>
-      <translation>油温</translation>
+        <location filename="../components/PageGensetModel.qml" line="233"/>
+        <source>Oil temperature</source>
+        <translation>油温</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
-      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
-      <translation>请注意，更改放电下限时间设置也会更改继电器菜单中的低充电状态设置。</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+        <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+        <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+        <translation>请注意，更改放电下限时间设置也会更改继电器菜单中的低充电状态设置。</translation>
     </message>
     <message id="alternator_wakespeed_operation_time">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
-      <source>Operation time</source>
-      <translation>运行时间</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="113"/>
+        <source>Operation time</source>
+        <translation>运行时间</translation>
     </message>
     <message id="alternator_wakespeed_charged_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
-      <source>Charged Ah</source>
-      <translation>已充电Ah</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+        <source>Charged Ah</source>
+        <translation>已充电Ah</translation>
     </message>
     <message id="alternator_wakespeed_cycles_started">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
-      <source>Cycles started</source>
-      <translation>周期已启动</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="130"/>
+        <source>Cycles started</source>
+        <translation>周期已启动</translation>
     </message>
     <message id="alternator_wakespeed_cycles_completed">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
-      <source>Cycles completed</source>
-      <translation>周期已完成</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="137"/>
+        <source>Cycles completed</source>
+        <translation>周期已完成</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_power_ups">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
-      <source>Number of power-ups</source>
-      <translation>上电次数</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="144"/>
+        <source>Number of power-ups</source>
+        <translation>上电次数</translation>
     </message>
     <message id="alternator_wakespeed_nr_of_deep_discharges">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
-      <source>Number of deep discharges</source>
-      <translation>深放电次数</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="151"/>
+        <source>Number of deep discharges</source>
+        <translation>深放电次数</translation>
     </message>
     <message id="alternator_wakespeed_charge_cycle_history">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
-      <source>Charge cycle history</source>
-      <translation>充电周期历史记录</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="170"/>
+        <source>Charge cycle history</source>
+        <translation>充电周期历史记录</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
-      <source>Sensor value when full</source>
-      <translation>满时的传感器值</translation>
+        <location filename="../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+        <source>Sensor value when full</source>
+        <translation>满时的传感器值</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
-      <source>Time to service</source>
-      <translation>服务时间</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+        <source>Time to service</source>
+        <translation>服务时间</translation>
     </message>
     <message id="settings_page_relay_generator_auto_start_enabled">
-      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
-      <source>Autostart functionality</source>
-      <oldsource>Auto start functionality</oldsource>
-      <translation>自动启动功能</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="53"/>
+        <source>Autostart functionality</source>
+        <oldsource>Auto start functionality</oldsource>
+        <translation>自动启动功能</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="87"/>
-      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
-      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
-      <translation>使用此选项时，确保发电机未连接至交流输入 %1</translation>
+        <location filename="../pages/settings/PageGeneratorConditions.qml" line="87"/>
+        <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+        <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+        <translation>使用此选项时，确保发电机未连接至交流输入 %1</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
-      <source>The service timer has been reset</source>
-      <translation>服务计时器已重置</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+        <source>The service timer has been reset</source>
+        <translation>服务计时器已重置</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
-      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
-      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
-      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
-      <translation>连续扫描可能会干扰 Wi-Fi 操作。</translation>
+        <location filename="../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+        <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+        <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+        <translation>连续扫描可能会干扰 Wi-Fi 操作。</translation>
     </message>
     <message id="settings_display_minmax">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
-      <source>Minimum and maximum gauge ranges</source>
-      <translation>最小和最大量程</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="164"/>
+        <source>Minimum and maximum gauge ranges</source>
+        <translation>最小和最大量程</translation>
+    </message>
+    <message id="settings_brief_view_start_page">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="172"/>
+        <source>Start page</source>
+        <translation type="unfinished">启动页</translation>
     </message>
     <message id="settings_restarting_app">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
-      <source>Restarting application...</source>
-      <translation>正在重新启动应用程序...</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="231"/>
+        <source>Restarting application...</source>
+        <translation>正在重新启动应用程序...</translation>
     </message>
     <message id="settings_language_change_failed">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
-      <source>Failed to change language!</source>
-      <translation>更改语言失败！</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="139"/>
+        <source>Failed to change language!</source>
+        <translation>更改语言失败！</translation>
+    </message>
+    <message id="settings_displayoff_1min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="45"/>
+        <source>1 min</source>
+        <translation type="unfinished">1分钟</translation>
+    </message>
+    <message id="settings_displayoff_10min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="47"/>
+        <source>10 min</source>
+        <translation type="unfinished">10分钟</translation>
+    </message>
+    <message id="settings_displayoff_30min">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="49"/>
+        <source>30 min</source>
+        <translation type="unfinished">30分钟</translation>
+    </message>
+    <message id="settings_displayoff_never">
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="51"/>
+        <source>Never</source>
+        <translation type="unfinished">从不</translation>
     </message>
     <message id="settings_language_please_wait">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
-      <source>Please wait while the language is changed.</source>
-      <oldsource>Please wait while the language is changed</oldsource>
-      <translation>请稍候，语言正在更改。</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="144"/>
+        <source>Please wait while the language is changed.</source>
+        <oldsource>Please wait while the language is changed</oldsource>
+        <translation>请稍候，语言正在更改。</translation>
     </message>
     <message id="settings_briefview_unit">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
-      <source>Brief view unit</source>
-      <extracomment>Show percentage values in Brief view</extracomment>
-      <translation>简要视图单元</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+        <source>Brief view unit</source>
+        <extracomment>Show percentage values in Brief view</extracomment>
+        <translation>简要视图单元</translation>
     </message>
     <message id="settings_briefview_unit_none">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
-      <source>No labels</source>
-      <translation>无标签</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+        <source>No labels</source>
+        <translation>无标签</translation>
     </message>
     <message id="settings_briefview_unit_absolute">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
-      <source>Show tank volumes</source>
-      <translation>显示水箱容积</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+        <source>Show tank volumes</source>
+        <translation>显示水箱容积</translation>
     </message>
     <message id="settings_briefview_unit_percentages">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
-      <source>Show percentages</source>
-      <translation>显示百分比</translation>
+        <location filename="../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+        <source>Show percentages</source>
+        <translation>显示百分比</translation>
     </message>
     <message id="settings_units_amps_exceptions">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
-      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
-      <translation>注意： 如果无法显示电流（例如，当显示交流和直流电源的总和时），则将显示功率。</translation>
+        <location filename="../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+        <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+        <translation>注意： 如果无法显示电流（例如，当显示交流和直流电源的总和时），则将显示功率。</translation>
     </message>
     <message id="settings_dvcc_charge_current_limits">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
-      <source>Charge current limits</source>
-      <oldsource>Charge Current limits</oldsource>
-      <translation>充电电流限制</translation>
+        <location filename="../pages/settings/PageSettingsDvcc.qml" line="31"/>
+        <source>Charge current limits</source>
+        <oldsource>Charge Current limits</oldsource>
+        <translation>充电电流限制</translation>
     </message>
     <message id="settings_firmware_official_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
-      <source>Official release</source>
-      <translation>正式发布</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+        <source>Official release</source>
+        <translation>正式发布</translation>
     </message>
     <message id="settings_firmware_beta_release">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
-      <source>Beta release</source>
-      <translation>Beta版</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+        <source>Beta release</source>
+        <translation>Beta版</translation>
     </message>
     <message id="settings_firmware_testing_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
-      <source>Testing (Victron internal)</source>
-      <extracomment>Select the 'Testing' update feed</extracomment>
-      <translation>测试版本（Victron内部）</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+        <source>Testing (Victron internal)</source>
+        <extracomment>Select the &apos;Testing&apos; update feed</extracomment>
+        <translation>测试版本（Victron内部）</translation>
     </message>
     <message id="settings_firmware_develop_internal">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
-      <source>Develop (Victron internal)</source>
-      <extracomment>Select the 'Develop' update feed</extracomment>
-      <translation>开发版（Victron内部）</translation>
+        <location filename="../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+        <source>Develop (Victron internal)</source>
+        <extracomment>Select the &apos;Develop&apos; update feed</extracomment>
+        <translation>开发版（Victron内部）</translation>
     </message>
     <message id="dialoglayer_rebooting">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
-      <source>Rebooting...</source>
-      <translation>重新启动...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="326"/>
+        <source>Rebooting...</source>
+        <translation>重新启动...</translation>
     </message>
     <message id="settings_enable_status_leds">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
-      <source>Enable status LEDs</source>
-      <translation>启用状态 LED</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="352"/>
+        <source>Enable status LEDs</source>
+        <translation>启用状态 LED</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
-      <source>Warm-up &amp; cool-down</source>
-      <translation>预热和冷却</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="43"/>
+        <source>Warm-up &amp; cool-down</source>
+        <translation>预热和冷却</translation>
     </message>
     <message id="page_settings_generator_stop_time">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
-      <source>Generator stop time</source>
-      <translation>发电机停止时间</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="74"/>
+        <source>Generator stop time</source>
+        <translation>发电机停止时间</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
-      <source>Alarm when generator is not in autostart mode</source>
-      <oldsource>Alarm when generator is not in auto start mode</oldsource>
-      <translation>发电机未进入自动启动模式时报警</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="121"/>
+        <source>Alarm when generator is not in autostart mode</source>
+        <oldsource>Alarm when generator is not in auto start mode</oldsource>
+        <translation>发电机未进入自动启动模式时报警</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
-      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
-      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
-      <translation>如果自动启动功能被禁用超过 10 分钟，则会触发警报</translation>
+        <location filename="../pages/settings/PageSettingsGenerator.qml" line="127"/>
+        <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+        <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+        <translation>如果自动启动功能被禁用超过 10 分钟，则会触发警报</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="79"/>
-      <source>Self-consumption from battery</source>
-      <translation>从电池自消耗</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="79"/>
+        <source>Self-consumption from battery</source>
+        <translation>从电池自消耗</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
-      <source>All system loads</source>
-      <translation>所有系统负载</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="84"/>
+        <source>All system loads</source>
+        <translation>所有系统负载</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
-      <source>Only critical loads</source>
-      <translation>只限关键负载</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="86"/>
+        <source>Only critical loads</source>
+        <translation>只限关键负载</translation>
+    </message>
+    <message id="settings_ess_min_soc">
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="120"/>
+        <source>Minimum SOC (unless grid fails)</source>
+        <translation type="unfinished">最低放电量（除非电网故障）</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="148"/>
-      <source>Battery life state</source>
-      <oldsource>BatteryLife state</oldsource>
-      <translation>电池寿命状态</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="148"/>
+        <source>Battery life state</source>
+        <oldsource>BatteryLife state</oldsource>
+        <translation>电池寿命状态</translation>
     </message>
     <message id="settings_large_access_signal_k">
-      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
-      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
-      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
-      <translation>通过 http://venus.local:3000 和 VRM 访问Signal K。</translation>
+        <location filename="../pages/settings/PageSettingsLarge.qml" line="30"/>
+        <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+        <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+        <translation>通过 http://venus.local:3000 和 VRM 访问Signal K。</translation>
     </message>
     <message id="settings_large_access_node_red">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
-      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
-      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
-      <translation>通过 https://venus.local:1881 和 VRM 访问 Node-RED。</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+        <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+        <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+        <translation>通过 https://venus.local:1881 和 VRM 访问 Node-RED。</translation>
     </message>
     <message id="settings_system_battery_measurements">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="166"/>
-      <source>Battery measurements</source>
-      <oldsource>Battery Measurements</oldsource>
-      <translation>电池测量</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="166"/>
+        <source>Battery measurements</source>
+        <oldsource>Battery Measurements</oldsource>
+        <translation>电池测量</translation>
     </message>
     <message id="settings_system_system_status">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="172"/>
-      <source>System status</source>
-      <oldsource>System Status</oldsource>
-      <translation>系统状态</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="172"/>
+        <source>System status</source>
+        <oldsource>System Status</oldsource>
+        <translation>系统状态</translation>
     </message>
     <message id="settings_device_list">
-      <location filename="../../pages/SettingsPage.qml" line="29"/>
-      <source>Device list</source>
-      <oldsource>Device List</oldsource>
-      <translation>设备列表</translation>
+        <location filename="../pages/SettingsPage.qml" line="29"/>
+        <source>Device list</source>
+        <oldsource>Device List</oldsource>
+        <translation>设备列表</translation>
+    </message>
+    <message id="settings_ethernet">
+        <location filename="../pages/SettingsPage.qml" line="88"/>
+        <source>Ethernet</source>
+        <translation type="unfinished">以太网</translation>
     </message>
     <message id="settings_vrm_device_instances">
-      <location filename="../../pages/SettingsPage.qml" line="146"/>
-      <source>VRM device instances</source>
-      <oldsource>VRM Device Instances</oldsource>
-      <translation>VRM 设备实例</translation>
+        <location filename="../pages/SettingsPage.qml" line="146"/>
+        <source>VRM device instances</source>
+        <oldsource>VRM Device Instances</oldsource>
+        <translation>VRM 设备实例</translation>
     </message>
     <message id="charger_alarms_high_temperature_alarm">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
-      <source>High temperature alarm</source>
-      <translation>高温报警</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+        <source>High temperature alarm</source>
+        <translation>高温报警</translation>
     </message>
     <message id="charger_network_bms_controlled">
-      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
-      <source>BMS controlled</source>
-      <oldsource>BMS Controlled</oldsource>
-      <translation>BMS控制</translation>
+        <location filename="../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+        <source>BMS controlled</source>
+        <oldsource>BMS Controlled</oldsource>
+        <translation>BMS控制</translation>
     </message>
     <message id="charger_alarms_alarms_and_errors">
-      <location filename="../../pages/solar/SolarChargerPage.qml" line="146"/>
-      <source>Alarms &amp; Errors</source>
-      <oldsource>Alarms and Errors</oldsource>
-      <translation>警报和错误</translation>
+        <location filename="../pages/solar/SolarChargerPage.qml" line="146"/>
+        <source>Alarms &amp; Errors</source>
+        <oldsource>Alarms and Errors</oldsource>
+        <translation>警报和错误</translation>
     </message>
     <message id="vebus_device_update_firmware">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
-      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
-      <translation>该功能需要 400 或更高版本的固件。请联系安装人员更新 Multi/Quattro。</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+        <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+        <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+        <translation>该功能需要 400 或更高版本的固件。请联系安装人员更新 Multi/Quattro。</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
-      <source>Charger not ready, equalization cannot be started</source>
-      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
-      <translation>充电器未准备就绪，均衡无法启动</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+        <source>Charger not ready, equalization cannot be started</source>
+        <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+        <translation>充电器未准备就绪，均衡无法启动</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
-      <source>Equalization cannot be triggered during bulk charge state</source>
-      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
-      <translation>在快充状态下无法触发均衡功能</translation>
+        <location filename="../pages/vebusdevice/PageVeBusAdvanced.qml" line="129"/>
+        <source>Equalization cannot be triggered during bulk charge state</source>
+        <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+        <translation>在快充状态下无法触发均衡功能</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
-      <location filename="../../components/CommonWords.qml" line="222"/>
-      <source>Eco</source>
-      <extracomment>Inverter 'Eco' mode</extracomment>
-      <translation>节能</translation>
+        <location filename="../components/CommonWords.qml" line="222"/>
+        <source>Eco</source>
+        <extracomment>Inverter &apos;Eco&apos; mode</extracomment>
+        <translation>节能</translation>
     </message>
     <message id="common_words_maximum_current">
-      <location filename="../../components/CommonWords.qml" line="268"/>
-      <source>Maximum current</source>
-      <translation>最大电流</translation>
+        <location filename="../components/CommonWords.qml" line="268"/>
+        <source>Maximum current</source>
+        <translation>最大电流</translation>
     </message>
     <message id="common_words_maximum_power">
-      <location filename="../../components/CommonWords.qml" line="271"/>
-      <source>Maximum power</source>
-      <translation>最大功率</translation>
+        <location filename="../components/CommonWords.qml" line="271"/>
+        <source>Maximum power</source>
+        <translation>最大功率</translation>
     </message>
     <message id="common_words_minimum_current">
-      <location filename="../../components/CommonWords.qml" line="280"/>
-      <source>Minimum current</source>
-      <translation>最小电流</translation>
+        <location filename="../components/CommonWords.qml" line="280"/>
+        <source>Minimum current</source>
+        <translation>最小电流</translation>
+    </message>
+    <message id="common_words_none_errors">
+        <location filename="../components/CommonWords.qml" line="311"/>
+        <source>None</source>
+        <extracomment>Indicates there are no errors</extracomment>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message id="common_words_not_available">
+        <location filename="../components/CommonWords.qml" line="314"/>
+        <source>Not available</source>
+        <translation type="unfinished">不可用</translation>
+    </message>
+    <message id="common_words_off">
+        <location filename="../components/CommonWords.qml" line="320"/>
+        <source>Off</source>
+        <translation type="unfinished">关</translation>
+    </message>
+    <message id="common_words_ok">
+        <location filename="../components/CommonWords.qml" line="326"/>
+        <source>OK</source>
+        <translation type="unfinished">确认</translation>
     </message>
     <message id="common_words_overall_history">
-      <location filename="../../components/CommonWords.qml" line="342"/>
-      <source>Overall history</source>
-      <translation>总体历史记录</translation>
+        <location filename="../components/CommonWords.qml" line="342"/>
+        <source>Overall history</source>
+        <translation>总体历史记录</translation>
+    </message>
+    <message id="common_words_settings">
+        <location filename="../components/CommonWords.qml" line="407"/>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message id="common_words_unknown_status">
+        <location filename="../components/CommonWords.qml" line="488"/>
+        <source>Unknown</source>
+        <extracomment>Status = &quot;unknown&quot;</extracomment>
+        <translation type="unfinished">未知</translation>
     </message>
     <message id="common_words_yield_today">
-      <location filename="../../components/CommonWords.qml" line="514"/>
-      <source>Yield Today</source>
-      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <oldsource>Yield today</oldsource>
-      <translation>今日发电量</translation>
+        <location filename="../components/CommonWords.qml" line="514"/>
+        <source>Yield Today</source>
+        <oldsource>Yield today</oldsource>
+        <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+        <translation>今日发电量</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
-      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
-      <source>Firmware installed, device rebooting</source>
-      <oldsource>Firmware installed, rebooting.</oldsource>
-      <translation>固件已安装，设备正在重启</translation>
+        <location filename="../components/FirmwareUpdate.qml" line="79"/>
+        <source>Firmware installed, device rebooting</source>
+        <oldsource>Firmware installed, rebooting.</oldsource>
+        <translation>固件已安装，设备正在重启</translation>
     </message>
     <message id="digitalinputs_touch_input_control">
-      <location filename="../../data/DigitalInputs.qml" line="49"/>
-      <source>Touch input control</source>
-      <translation>触摸输入控制</translation>
+        <location filename="../data/DigitalInputs.qml" line="49"/>
+        <source>Touch input control</source>
+        <translation>触摸输入控制</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
-      <location filename="../../data/EvChargers.qml" line="112"/>
-      <source>Welded contacts test error (shorted)</source>
-      <oldsource>Welded contacts error</oldsource>
-      <translation>焊接触点测试错误（短路）</translation>
+        <location filename="../data/EvChargers.qml" line="112"/>
+        <source>Welded contacts test error (shorted)</source>
+        <oldsource>Welded contacts error</oldsource>
+        <translation>焊接触点测试错误（短路）</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
-      <location filename="../../data/EvChargers.qml" line="136"/>
-      <source>Switching to 3 phase</source>
-      <oldsource>Switching to 3-phase</oldsource>
-      <translation>切换到三相</translation>
+        <location filename="../data/EvChargers.qml" line="136"/>
+        <source>Switching to 3 phase</source>
+        <oldsource>Switching to 3-phase</oldsource>
+        <translation>切换到三相</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
-      <location filename="../../data/EvChargers.qml" line="139"/>
-      <source>Switching to 1 phase</source>
-      <oldsource>Switching to single phase</oldsource>
-      <translation>切换到单相</translation>
+        <location filename="../data/EvChargers.qml" line="139"/>
+        <source>Switching to 1 phase</source>
+        <oldsource>Switching to single phase</oldsource>
+        <translation>切换到单相</translation>
     </message>
     <message id="evchargers_status_stop_charging">
-      <location filename="../../data/EvChargers.qml" line="142"/>
-      <source>Stop charging</source>
-      <translation>停止充电</translation>
+        <location filename="../data/EvChargers.qml" line="142"/>
+        <source>Stop charging</source>
+        <translation>停止充电</translation>
     </message>
     <message id="evchargers_status_reserved">
-      <location filename="../../data/EvChargers.qml" line="146"/>
-      <source>Reserved</source>
-      <translation>保留</translation>
+        <location filename="../data/EvChargers.qml" line="146"/>
+        <source>Reserved</source>
+        <translation>保留</translation>
     </message>
     <message id="notification_description_and_value">
-      <location filename="../../components/NotificationDelegate.qml" line="77"/>
-      <source>%1 %2</source>
-      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
-      <translation>%1 %2</translation>
+        <location filename="../components/NotificationDelegate.qml" line="77"/>
+        <source>%1 %2</source>
+        <extracomment>%1 = notification description (e.g. &apos;High temperature&apos;), %2 = the value that triggered the notification (e.g. &apos;25 C&apos;)</extracomment>
+        <translation>%1 %2</translation>
     </message>
     <message id="controlcard_inverter_mode">
-      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
-      <source>Inverter mode</source>
-      <translation>逆变模式</translation>
+        <location filename="../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+        <source>Inverter mode</source>
+        <translation>逆变模式</translation>
     </message>
     <message id="inverter_ac-out_num">
-      <location filename="../../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
-      <source>AC Out L%1</source>
-      <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>交流输出 L%1</translation>
+        <location filename="../components/settings/InverterAcOutQuantityGroup.qml" line="45"/>
+        <source>AC Out L%1</source>
+        <extracomment>%1 = phase number (1-3)</extracomment>
+        <translation>交流输出 L%1</translation>
     </message>
     <message id="dc_input">
-      <location filename="../../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
-      <source>Input</source>
-      <extracomment>DC input measurement values</extracomment>
-      <translation>输入</translation>
+        <location filename="../components/settings/ListDcInputQuantityGroup.qml" line="16"/>
+        <source>Input</source>
+        <extracomment>DC input measurement values</extracomment>
+        <translation>输入</translation>
     </message>
     <message id="inverterCharger_mode_passthrough">
-      <location filename="../../data/InverterChargers.qml" line="93"/>
-      <source>Passthrough</source>
-      <translation>直通</translation>
+        <location filename="../data/InverterChargers.qml" line="93"/>
+        <source>Passthrough</source>
+        <translation>直通</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
-      <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>页面将在十秒后自动重新加载，以加载最新版本。</translation>
+        <location filename="../pages/DialogLayer.qml" line="57"/>
+        <source>Page will automatically reload in ten seconds to load the latest version.</source>
+        <translation>页面将在十秒后自动重新加载，以加载最新版本。</translation>
     </message>
     <message id="controlcard_inverter">
-      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="20"/>
-      <source>Inverter (%1)</source>
-      <extracomment>%1 = the inverter name</extracomment>
-      <translation>逆变器(%1)</translation>
+        <location filename="../pages/controlcards/InverterChargerCard.qml" line="20"/>
+        <source>Inverter (%1)</source>
+        <extracomment>%1 = the inverter name</extracomment>
+        <translation>逆变器(%1)</translation>
     </message>
     <message id="inverter_chargers_title">
-      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
-      <source>Inverter/Chargers</source>
-      <translation>逆变器/充电器</translation>
+        <location filename="../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+        <source>Inverter/Chargers</source>
+        <translation>逆变器/充电器</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
-      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
-      <source>No energy meters found
+        <location filename="../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+        <source>No energy meters found
 
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
-      <translation>未找到能源计量表
+        <translation>未找到能源计量表
 
 请注意，该菜单仅显示通过 RS485 连接的 Carlo Gavazzi 电表。对于任何其他仪表，包括通过以太网连接的 Carlo Gavazzi 仪表，请参见 Modbus TCP/UDP 设备菜单。</translation>
     </message>
     <message id="settings_minmax_autorange">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
-      <source>Auto-ranging</source>
-      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>自动范围</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+        <source>Auto-ranging</source>
+        <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+        <translation>自动范围</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
-      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
-      <translation>启用后，仪表和图形的最小值和最大值会根据过去的值自动调整。</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+        <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+        <translation>启用后，仪表和图形的最小值和最大值会根据过去的值自动调整。</translation>
     </message>
     <message id="settings_minmax_reset">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
-      <source>Reset all range values to zero</source>
-      <translation>将所有量程值重置为零</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+        <source>Reset all range values to zero</source>
+        <translation>将所有量程值重置为零</translation>
     </message>
     <message id="settings_minmax_reset_range_values">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
-      <source>Reset Range Values</source>
-      <translation>重置范围值</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+        <source>Reset Range Values</source>
+        <translation>重置范围值</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
-      <source>Are you sure that you want to reset all the values to zero?</source>
-      <translation>您确定要将所有数值重置为零？</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+        <source>Are you sure that you want to reset all the values to zero?</source>
+        <translation>您确定要将所有数值重置为零？</translation>
     </message>
     <message id="settings_minmax_ac_in_header_with_source">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
-      <source>%1 (%2)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
-      <translation>%1 (%2)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+        <source>%1 (%2)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;, %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+        <translation>%1 (%2)</translation>
     </message>
     <message id="settings_minmax_acout_max_acin1">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
-      <source>Maximum current: AC in 1 connected</source>
-      <translation>最大电流：1 个连接的交流电源</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+        <source>Maximum current: AC in 1 connected</source>
+        <translation>最大电流：1 个连接的交流电源</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
-      <source>Maximum current: AC in 2 connected</source>
-      <translation>最大电流：交流电，2 路连接</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+        <source>Maximum current: AC in 2 connected</source>
+        <translation>最大电流：交流电，2 路连接</translation>
     </message>
     <message id="settings_minmax_acout_max">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
-      <source>Maximum current: no AC inputs</source>
-      <translation>最大电流：无交流输入</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+        <source>Maximum current: no AC inputs</source>
+        <translation>最大电流：无交流输入</translation>
     </message>
     <message id="settings_minmax_dc_out">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
-      <source>DC output</source>
-      <translation>直流输出</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+        <source>DC output</source>
+        <translation>直流输出</translation>
     </message>
     <message id="settings_minmax_solar">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
-      <source>Solar</source>
-      <translation>太阳能</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+        <source>Solar</source>
+        <translation>太阳能</translation>
     </message>
     <message id="devicelist_motordrive_motorrpm">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
-      <source>Motor RPM</source>
-      <translation>电机RPM</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="18"/>
+        <source>Motor RPM</source>
+        <translation>电机RPM</translation>
     </message>
     <message id="devicelist_motordrive_motortemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
-      <source>Motor Temperature</source>
-      <translation>电机温度</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="26"/>
+        <source>Motor Temperature</source>
+        <translation>电机温度</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
-      <source>Controller Temperature</source>
-      <translation>控制器温度</translation>
+        <location filename="../pages/settings/devicelist/PageMotorDrive.qml" line="55"/>
+        <source>Controller Temperature</source>
+        <translation>控制器温度</translation>
     </message>
     <message id="cycle_history_active">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
-      <source>Active cycle</source>
-      <translation>周期已激活</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+        <source>Active cycle</source>
+        <translation>周期已激活</translation>
     </message>
     <message id="cycle_history_num">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
-      <source>Cycle %1</source>
-      <extracomment>%1 = cycle number</extracomment>
-      <translation>周期%1</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+        <source>Cycle %1</source>
+        <extracomment>%1 = cycle number</extracomment>
+        <translation>周期%1</translation>
     </message>
     <message id="cycle_history_dc_disconnect">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
-      <source>DC Disconnect</source>
-      <translation>直流断开</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+        <source>DC Disconnect</source>
+        <translation>直流断开</translation>
     </message>
     <message id="cycle_history_powered_off">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
-      <source>Powered off</source>
-      <translation>已切断电源</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+        <source>Powered off</source>
+        <translation>已切断电源</translation>
     </message>
     <message id="cycle_history_function_change">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
-      <source>Function change</source>
-      <translation>功能改变</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+        <source>Function change</source>
+        <translation>功能改变</translation>
     </message>
     <message id="cycle_history_firmware_update">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
-      <source>Firmware update</source>
-      <translation>固件更新</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+        <source>Firmware update</source>
+        <translation>固件更新</translation>
     </message>
     <message id="cycle_history_software_reset">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
-      <source>Software reset</source>
-      <translation>软件重置</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+        <source>Software reset</source>
+        <translation>软件重置</translation>
     </message>
     <message id="cycle_history_incomplete">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
-      <source>Incomplete</source>
-      <translation>不完整</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+        <source>Incomplete</source>
+        <translation>不完整</translation>
     </message>
     <message id="cycle_history_elapsed_time">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
-      <source>Elapsed time</source>
-      <translation>所用时间</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+        <source>Elapsed time</source>
+        <translation>所用时间</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
-      <source>Charge / maintain (Ah)</source>
-      <translation>充电/维护（Ah）</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+        <source>Charge / maintain (Ah)</source>
+        <translation>充电/维护（Ah）</translation>
     </message>
     <message id="cycle_history_battery_voltage">
-      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
-      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>电池 (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
+        <location filename="../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+        <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+        <translation>电池 (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="53"/>
-      <source>Low AC OUT voltage</source>
-      <translation>交流输出电压低</translation>
+        <location filename="../data/InverterChargers.qml" line="53"/>
+        <source>Low AC OUT voltage</source>
+        <translation>交流输出电压低</translation>
     </message>
     <message id="rs_alarm_high_ac_out_voltage">
-      <location filename="../../data/InverterChargers.qml" line="55"/>
-      <source>High AC OUT voltage</source>
-      <translation>交流输出电压高</translation>
+        <location filename="../data/InverterChargers.qml" line="55"/>
+        <source>High AC OUT voltage</source>
+        <translation>交流输出电压高</translation>
     </message>
     <message id="settings_multirs_total_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
-      <source>Total yield</source>
-      <translation>总计发电</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="84"/>
+        <source>Total yield</source>
+        <translation>总计发电</translation>
     </message>
     <message id="settings_multirs_system_yield">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
-      <source>System yield</source>
-      <translation>系统发电</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="92"/>
+        <source>System yield</source>
+        <translation>系统发电</translation>
     </message>
     <message id="common_words_daily_history">
-      <location filename="../../components/CommonWords.qml" line="126"/>
-      <source>Daily history</source>
-      <translation>每日历史记录</translation>
+        <location filename="../components/CommonWords.qml" line="126"/>
+        <source>Daily history</source>
+        <translation>每日历史记录</translation>
     </message>
     <message id="rs_alarm_no_alarms_to_be_configured">
-      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
-      <source>No alarms to be configured</source>
-      <translation>没有要配置的警报</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+        <source>No alarms to be configured</source>
+        <translation>没有要配置的警报</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
-      <source>Maximum PV voltage</source>
-      <translation>最高PV电压</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+        <source>Maximum PV voltage</source>
+        <translation>最高PV电压</translation>
     </message>
     <message id="inverter_maximum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
-      <source>Maximum battery voltage</source>
-      <translation>最高电池电压</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+        <source>Maximum battery voltage</source>
+        <translation>最高电池电压</translation>
     </message>
     <message id="inverter_minimum_battery_voltage">
-      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
-      <source>Minimum battery voltage</source>
-      <translation>最低电池电压</translation>
+        <location filename="../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+        <source>Minimum battery voltage</source>
+        <translation>最低电池电压</translation>
     </message>
     <message id="battery_bank_error">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
-      <source>Battery bank error</source>
-      <translation>电池组错误</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="89"/>
+        <source>Battery bank error</source>
+        <translation>电池组错误</translation>
     </message>
     <message id="battery_bank_error_voltage_not_supported">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
-      <source>Battery voltage not supported</source>
-      <translation>不支持电池电压</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="98"/>
+        <source>Battery voltage not supported</source>
+        <translation>不支持电池电压</translation>
     </message>
     <message id="battery_bank_error_incorrect_number_of_batteries">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
-      <source>Incorrect number of batteries</source>
-      <translation>电池数量不正确</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="101"/>
+        <source>Incorrect number of batteries</source>
+        <translation>电池数量不正确</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
-      <source>Invalid battery configuration</source>
-      <translation>电池配置无效</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="104"/>
+        <source>Invalid battery configuration</source>
+        <translation>电池配置无效</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
-      <source>Balancer status</source>
-      <translation>均衡器状态</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="97"/>
+        <source>Balancer status</source>
+        <translation>均衡器状态</translation>
     </message>
     <message id="lynxionsystem_balancer_balanced">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
-      <source>Balanced</source>
-      <translation>已均衡</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="104"/>
+        <source>Balanced</source>
+        <translation>已均衡</translation>
     </message>
     <message id="lynxionsystem_balancer_imbalance">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
-      <source>Imbalance</source>
-      <translation>不均衡</translation>
+        <location filename="../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+        <source>Imbalance</source>
+        <translation>不均衡</translation>
     </message>
     <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
-      <source>Use this option in systems that do not perform peak shaving.</source>
-      <translation>在不执行调峰的系统中使用此选项。</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+        <source>Use this option in systems that do not perform peak shaving.</source>
+        <translation>在不执行调峰的系统中使用此选项。</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
-      <source>Use this option for peak shaving.</source>
-      <oldsource>Use this option for peak shaving.
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+        <source>Use this option for peak shaving.</source>
+        <oldsource>Use this option for peak shaving.
 
 The peak shaving threshold is set using the AC input current limit setting.
 
 See documentation for further information.</oldsource>
-      <translation>在剃须高峰期使用该选项。</translation>
+        <translation>在剃须高峰期使用该选项。</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
-      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>峰值削波阈值通过交流输入电流限值设置来设定。更多信息请参阅文档。</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+        <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+        <translation>峰值削波阈值通过交流输入电流限值设置来设定。更多信息请参阅文档。</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
-      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>可以在该屏幕上更改导入和导出的削峰阈值。更多信息请参阅文档。</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+        <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+        <translation>可以在该屏幕上更改导入和导出的削峰阈值。更多信息请参阅文档。</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
-      <source>Limit system AC import current</source>
-      <translation>限制系统交流输入电流</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+        <source>Limit system AC import current</source>
+        <translation>限制系统交流输入电流</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
-      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>要使用该功能，必须将电网计量设置为外部计量，并安装最新的 ESS 助手。</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="104"/>
+        <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+        <translation>要使用该功能，必须将电网计量设置为外部计量，并安装最新的 ESS 助手。</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
-      <source>Maximum system import current (per phase)</source>
-      <translation>最大系统输入电流（每相）</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="111"/>
+        <source>Maximum system import current (per phase)</source>
+        <translation>最大系统输入电流（每相）</translation>
     </message>
     <message id="settings_ess_limit_ac_export_restrictions">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
-      <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>要使用此功能，必须将电网计量设置为外部计量。</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="144"/>
+        <source>Grid metering must be set to External meter to use this feature.</source>
+        <translation>要使用此功能，必须将电网计量设置为外部计量。</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
-      <source>Maximum system export current (per phase)</source>
-      <translation>最大系统输出电流（每相）</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="151"/>
+        <source>Maximum system export current (per phase)</source>
+        <translation>最大系统输出电流（每相）</translation>
     </message>
     <message id="settings_tcpip_wired">
-      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
-      <source>Wired</source>
-      <translation>有线</translation>
+        <location filename="../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+        <source>Wired</source>
+        <translation>有线</translation>
+    </message>
+    <message id="nav_brief">
+        <location filename="../pages/BriefPage.qml" line="155"/>
+        <source>Brief</source>
+        <translation type="unfinished">概要</translation>
     </message>
     <message id="nav_brief_close_side_panel_high_cpu">
-      <location filename="../../pages/BriefPage.qml" line="487"/>
-      <source>System load high, closing the side panel to reduce CPU load</source>
-      <translation>系统负载高，关闭侧板以减少 CPU 负载</translation>
+        <location filename="../pages/BriefPage.qml" line="487"/>
+        <source>System load high, closing the side panel to reduce CPU load</source>
+        <translation>系统负载高，关闭侧板以减少 CPU 负载</translation>
     </message>
     <message id="common_words_input_current_limit">
-      <location filename="../../components/CommonWords.qml" line="215"/>
-      <source>Input current limit</source>
-      <translation>输入限制电流</translation>
+        <location filename="../components/CommonWords.qml" line="215"/>
+        <source>Input current limit</source>
+        <translation>输入限制电流</translation>
     </message>
     <message id="rs_alarm_short_circuit">
-      <location filename="../../data/InverterChargers.qml" line="59"/>
-      <source>Short circuit</source>
-      <translation>短路</translation>
+        <location filename="../data/InverterChargers.qml" line="59"/>
+        <source>Short circuit</source>
+        <translation>短路</translation>
     </message>
     <message id="settings_ess_buying">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
-      <source>Buying</source>
-      <translation>买入</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+        <source>Buying</source>
+        <translation>买入</translation>
     </message>
     <message id="settings_ess_selling">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
-      <source>Selling</source>
-      <translation>卖出</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+        <source>Selling</source>
+        <translation>卖出</translation>
     </message>
     <message id="settings_ess_target_soc">
-      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
-      <source>Target SOC</source>
-      <translation>目标SOC</translation>
+        <location filename="../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+        <source>Target SOC</source>
+        <translation>目标SOC</translation>
     </message>
     <message id="settings_multirs_ac_out_phase">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
-      <source>AC out %1</source>
-      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
-      <translation>交流输出 %1</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+        <source>AC out %1</source>
+        <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+        <translation>交流输出 %1</translation>
     </message>
     <message id="settings_multirs_trackers">
-      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
-      <source>Trackers</source>
-      <translation>跟踪器</translation>
+        <location filename="../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+        <source>Trackers</source>
+        <translation>跟踪器</translation>
     </message>
     <message id="settings_rs_devices">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
-      <source>RS devices</source>
-      <translation>RS 设备</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="106"/>
+        <source>RS devices</source>
+        <translation>RS 设备</translation>
     </message>
     <message id="settings_page_debug_pause_electron_animations">
-      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
-      <source>Pause electron animations</source>
-      <translation>暂停电子动画</translation>
+        <location filename="../pages/settings/debug/PageDebug.qml" line="65"/>
+        <source>Pause electron animations</source>
+        <translation>暂停电子动画</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
-      <source>Total Capacity</source>
-      <translation>总容量</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="127"/>
+        <source>Total Capacity</source>
+        <translation>总容量</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
-      <source>Number of BMSes</source>
-      <translation>BMS 数量</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="148"/>
+        <source>Number of BMSes</source>
+        <translation>BMS 数量</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
-      <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
-      <translation>CAN 总线 BMS LV（500 kbit/s）</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="82"/>
+        <source>CAN-bus BMS LV (500 kbit/s)</source>
+        <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+        <translation>CAN 总线 BMS LV（500 kbit/s）</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
-      <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>CAN 总线 BMS HV（500 kbit/秒）</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="88"/>
+        <source>CAN-bus BMS HV (500 kbit/s)</source>
+        <translation>CAN 总线 BMS HV（500 kbit/秒）</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
-      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
-      <source>Limit system AC export current</source>
-      <translation>限制系统交流输出电流</translation>
+        <location filename="../pages/settings/PageSettingsHub4Peakshaving.qml" line="126"/>
+        <source>Limit system AC export current</source>
+        <translation>限制系统交流输出电流</translation>
     </message>
     <message id="settings_modbus_tcp_udp_devices">
-      <location filename="../../pages/SettingsPage.qml" line="83"/>
-      <source>Modbus TCP/UDP devices</source>
-      <translation>Modbus TCP/UDP 设备</translation>
+        <location filename="../pages/SettingsPage.qml" line="83"/>
+        <source>Modbus TCP/UDP devices</source>
+        <translation>Modbus TCP/UDP 设备</translation>
     </message>
     <message id="common_words_add_device">
-      <location filename="../../components/CommonWords.qml" line="17"/>
-      <source>Add device</source>
-      <translation>添加设备</translation>
+        <location filename="../components/CommonWords.qml" line="17"/>
+        <source>Add device</source>
+        <translation>添加设备</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
-      <source>Scan for devices</source>
-      <translation>扫描查找设备</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="37"/>
+        <source>Scan for devices</source>
+        <translation>扫描查找设备</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
-      <source>Saved devices</source>
-      <translation>保存的设备</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="45"/>
+        <source>Saved devices</source>
+        <translation>保存的设备</translation>
     </message>
     <message id="page_settings_modbus_discovered_devices">
-      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
-      <source>Discovered devices</source>
-      <translation>发现的设备</translation>
+        <location filename="../pages/settings/PageSettingsModbus.qml" line="51"/>
+        <source>Discovered devices</source>
+        <translation>发现的设备</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
-      <source>Add Modbus TCP/UDP device</source>
-      <translation>添加 Modbus TCP/UDP 设备</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+        <source>Add Modbus TCP/UDP device</source>
+        <translation>添加 Modbus TCP/UDP 设备</translation>
     </message>
     <message id="modbus_add_device_tcp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
-      <source>TCP</source>
-      <translation>TCP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+        <source>TCP</source>
+        <translation>TCP</translation>
     </message>
     <message id="modbus_add_device_udp">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
-      <source>UDP</source>
-      <translation>UDP</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
     <message id="modbus_add_device_protocol">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
-      <source>Protocol</source>
-      <translation>规程</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+        <source>Protocol</source>
+        <translation>规程</translation>
     </message>
     <message id="port_field_title">
-      <location filename="../../components/listitems/ListPortField.qml" line="13"/>
-      <source>Port</source>
-      <translation>端口</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="13"/>
+        <source>Port</source>
+        <translation>端口</translation>
     </message>
     <message id="modbus_add_device_unit">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
-      <source>Unit</source>
-      <translation>装置</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+        <source>Unit</source>
+        <translation>装置</translation>
     </message>
     <message id="settings_modbus_no_devices_saved">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
-      <source>No Modbus devices saved</source>
-      <translation>未保存 Modbus 设备</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+        <source>No Modbus devices saved</source>
+        <translation>未保存 Modbus 设备</translation>
     </message>
     <message id="page_settings_modbus_device_number">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
-      <source>Device %1</source>
-      <translation>设备 %1</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+        <source>Device %1</source>
+        <translation>设备 %1</translation>
     </message>
     <message id="page_settings_modbus_device_remove_device">
-      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
-      <source>Remove Modbus device?</source>
-      <translation>删除 Modbus 设备？</translation>
+        <location filename="../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+        <source>Remove Modbus device?</source>
+        <translation>删除 Modbus 设备？</translation>
     </message>
     <message id="settings_modbus_no_devices_discovered">
-      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
-      <source>No Modbus devices discovered</source>
-      <translation>未发现 Modbus 设备</translation>
+        <location filename="../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+        <source>No Modbus devices discovered</source>
+        <translation>未发现 Modbus 设备</translation>
     </message>
     <message id="settings_accharger_battery">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
-      <source>Battery %1</source>
-      <extracomment>%1 = battery number</extracomment>
-      <translation>电池 %1</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="54"/>
+        <source>Battery %1</source>
+        <extracomment>%1 = battery number</extracomment>
+        <translation>电池 %1</translation>
     </message>
     <message id="settings_accharger_current">
-      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
-      <source>AC current</source>
-      <translation>交流电流</translation>
+        <location filename="../pages/settings/devicelist/PageAcCharger.qml" line="81"/>
+        <source>AC current</source>
+        <translation>交流电流</translation>
     </message>
     <message id="generator_dialog_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
-      <source>Generator start/stop disabled</source>
-      <translation>发电机启停禁用</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="103"/>
+        <source>Generator start/stop disabled</source>
+        <translation>发电机启停禁用</translation>
     </message>
     <message id="generator_dialog_remote_start_disabled">
-      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
-      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
-      <translation>发电机组上的远程启动功能被禁用。GX 现在将无法启动或停止发电机组。在发电机组控制面板上启用它。</translation>
+        <location filename="../components/GeneratorManualControlButton.qml" line="106"/>
+        <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+        <translation>发电机组上的远程启动功能被禁用。GX 现在将无法启动或停止发电机组。在发电机组控制面板上启用它。</translation>
     </message>
     <message id="ac-in-genset_auto_start_functionality">
-      <location filename="../../components/PageGensetModel.qml" line="58"/>
-      <source>Auto start functionality</source>
-      <translation>自动启动功能</translation>
+        <location filename="../components/PageGensetModel.qml" line="58"/>
+        <source>Auto start functionality</source>
+        <translation>自动启动功能</translation>
+    </message>
+    <message id="settings_page_genset_generator_run_time">
+        <location filename="../components/PageGensetModel.qml" line="76"/>
+        <source>Current run time</source>
+        <translation type="unfinished">当前运行时间</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
-      <location filename="../../components/PageGensetModel.qml" line="84"/>
-      <source>Control status</source>
-      <translation>控制状态</translation>
+        <location filename="../components/PageGensetModel.qml" line="84"/>
+        <source>Control status</source>
+        <translation>控制状态</translation>
     </message>
     <message id="ac-in-genset_status">
-      <location filename="../../components/PageGensetModel.qml" line="107"/>
-      <source>Genset status</source>
-      <translation>发电机状态</translation>
+        <location filename="../components/PageGensetModel.qml" line="107"/>
+        <source>Genset status</source>
+        <translation>发电机状态</translation>
     </message>
     <message id="ac-in-genset_remote_start_mode">
-      <location filename="../../components/PageGensetModel.qml" line="185"/>
-      <source>Remote start mode</source>
-      <translation>远程启动模式</translation>
+        <location filename="../components/PageGensetModel.qml" line="185"/>
+        <source>Remote start mode</source>
+        <translation>远程启动模式</translation>
     </message>
     <message id="ac-in-genset_oil_pressure">
-      <location filename="../../components/PageGensetModel.qml" line="225"/>
-      <source>Oil pressure</source>
-      <oldsource>Oil Pressure</oldsource>
-      <translation>油压</translation>
+        <location filename="../components/PageGensetModel.qml" line="225"/>
+        <source>Oil pressure</source>
+        <oldsource>Oil Pressure</oldsource>
+        <translation>油压</translation>
     </message>
     <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="263"/>
-      <source>Scheduled charge levels</source>
-      <translation>预定的充电水平</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="263"/>
+        <source>Scheduled charge levels</source>
+        <translation>预定的充电水平</translation>
     </message>
     <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="266"/>
-      <source>Active (%1)</source>
-      <translation>活动 (%1)</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="266"/>
+        <source>Active (%1)</source>
+        <translation>活动 (%1)</translation>
     </message>
     <message id="common_words_manual_stop">
-      <location filename="../../components/CommonWords.qml" line="262"/>
-      <source>Manual stop</source>
-      <translation>手动停止</translation>
+        <location filename="../components/CommonWords.qml" line="262"/>
+        <source>Manual stop</source>
+        <translation>手动停止</translation>
     </message>
     <message id="common_words_open_circuit">
-      <location filename="../../components/CommonWords.qml" line="339"/>
-      <source>Open circuit</source>
-      <translation>开路</translation>
+        <location filename="../components/CommonWords.qml" line="339"/>
+        <source>Open circuit</source>
+        <translation>开路</translation>
     </message>
     <message id="common_words_format_error">
-      <location filename="../../components/CommonWords.qml" line="553"/>
-      <source>#%1 %2</source>
-      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
-      <translation>#%1 %2</translation>
+        <location filename="../components/CommonWords.qml" line="553"/>
+        <source>#%1 %2</source>
+        <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+        <translation>#%1 %2</translation>
     </message>
     <message id="settings_minmax_ac_in_not_available">
-      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
-      <source>%1 (not available)</source>
-      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
-      <translation>%1 (不可用)</translation>
+        <location filename="../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+        <source>%1 (not available)</source>
+        <extracomment>%1 = &apos;AC input 1&apos; or &apos;AC input 2&apos;</extracomment>
+        <translation>%1 (不可用)</translation>
     </message>
     <message id="application_content_touch_input_on">
-      <location filename="../../ApplicationContent.qml" line="71"/>
-      <source>Touch input on</source>
-      <translation>触摸输入打开</translation>
+        <location filename="../ApplicationContent.qml" line="71"/>
+        <source>Touch input on</source>
+        <translation>触摸输入打开</translation>
     </message>
     <message id="application_content_touch_input_off">
-      <location filename="../../ApplicationContent.qml" line="73"/>
-      <source>Touch input off</source>
-      <translation>触摸输入关闭</translation>
+        <location filename="../ApplicationContent.qml" line="73"/>
+        <source>Touch input off</source>
+        <translation>触摸输入关闭</translation>
     </message>
     <message id="application_content_touch_input_disabled">
-      <location filename="../../ApplicationContent.qml" line="88"/>
-      <source>Touch input disabled</source>
-      <translation>触摸输入已禁用</translation>
+        <location filename="../ApplicationContent.qml" line="88"/>
+        <source>Touch input disabled</source>
+        <translation>触摸输入已禁用</translation>
     </message>
     <message id="notifications_acknowledge_alerts">
-      <location filename="../../components/StatusBar.qml" line="127"/>
-      <source>Acknowledge alerts</source>
-      <translation>确认警报</translation>
+        <location filename="../components/StatusBar.qml" line="127"/>
+        <source>Acknowledge alerts</source>
+        <translation>确认警报</translation>
     </message>
     <message id="ac-in-genset_control_error_code">
-      <location filename="../../components/PageGensetModel.qml" line="100"/>
-      <source>Control error code</source>
-      <translation>控制错误代码</translation>
+        <location filename="../components/PageGensetModel.qml" line="100"/>
+        <source>Control error code</source>
+        <translation>控制错误代码</translation>
     </message>
     <message id="settings_batteries_intro">
-      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
-      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
-      <translation>单击概览页面上的电池图标时，可使用此菜单定义显示的电池数据。在 VRM 门户上也可以看到相同的选择。</translation>
+        <location filename="../pages/settings/PageSettingsBatteries.qml" line="45"/>
+        <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+        <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+        <translation>单击概览页面上的电池图标时，可使用此菜单定义显示的电池数据。在 VRM 门户上也可以看到相同的选择。</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
-      <source>System voltage</source>
-      <translation>系统电压[V]。</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBattery.qml" line="139"/>
+        <source>System voltage</source>
+        <translation>系统电压[V]。</translation>
     </message>
     <message id="batterydetails_connection_information">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
-      <source>Connection information</source>
-      <translation>连接信息</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+        <source>Connection information</source>
+        <translation>连接信息</translation>
     </message>
     <message id="settings_security_profile_indeterminate">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
-      <source>Please select...</source>
-      <translation>请选择...</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="109"/>
+        <source>Please select...</source>
+        <translation>请选择...</translation>
     </message>
     <message id="settings_security_profile_secured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
-      <source>Secured</source>
-      <translation>安全</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="113"/>
+        <source>Secured</source>
+        <translation>安全</translation>
     </message>
     <message id="settings_security_profile_secured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
-      <source>Password protected and the network communication is encrypted</source>
-      <translation>密码保护和网络通信加密</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="116"/>
+        <source>Password protected and the network communication is encrypted</source>
+        <translation>密码保护和网络通信加密</translation>
     </message>
     <message id="settings_security_profile_weak">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
-      <source>Weak</source>
-      <translation>弱</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="121"/>
+        <source>Weak</source>
+        <translation>弱</translation>
     </message>
     <message id="settings_security_profile_weak_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
-      <source>Password protected, but the network communication is not encrypted</source>
-      <translation>有密码保护，但网络通信未加密</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="124"/>
+        <source>Password protected, but the network communication is not encrypted</source>
+        <translation>有密码保护，但网络通信未加密</translation>
     </message>
     <message id="settings_security_profile_unsecured">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
-      <source>Unsecured</source>
-      <translation>不安全</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="129"/>
+        <source>Unsecured</source>
+        <translation>不安全</translation>
     </message>
     <message id="settings_security_profile_unsecured_caption">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
-      <source>No password and the network communication is not encrypted</source>
-      <translation>无密码，网络通信未加密</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="132"/>
+        <source>No password and the network communication is not encrypted</source>
+        <translation>无密码，网络通信未加密</translation>
+    </message>
+    <message id="settings_security_too_short_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="139"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation type="unfinished">密码长度至少为 8 个字符</translation>
+    </message>
+    <message id="settings_root_enter_password">
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="220"/>
+        <source>Enter password</source>
+        <translation type="unfinished">输入密码</translation>
     </message>
     <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation>密码长度至少为 8 个字符</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="225"/>
+        <source>Password needs to be at least 8 characters long</source>
+        <translation>密码长度至少为 8 个字符</translation>
     </message>
     <message id="settings_security_profile_secured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
-      <source>Select 'Secured' profile?</source>
-      <translation>选择 "安全 "配置文件？</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="172"/>
+        <source>Select &apos;Secured&apos; profile?</source>
+        <translation>选择 &quot;安全 &quot;配置文件？</translation>
     </message>
     <message id="settings_security_profile_weak_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
-      <source>Select 'Weak' profile?</source>
-      <translation>选择 "弱 "配置文件？</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="175"/>
+        <source>Select &apos;Weak&apos; profile?</source>
+        <translation>选择 &quot;弱 &quot;配置文件？</translation>
     </message>
     <message id="settings_security_profile_unsecured_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
-      <source>Select 'Unsecured' profile?</source>
-      <translation>选择 "不安全 "配置文件？</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="178"/>
+        <source>Select &apos;Unsecured&apos; profile?</source>
+        <translation>选择 &quot;不安全 &quot;配置文件？</translation>
     </message>
     <message id="settings_security_profile_secured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="186"/>
+        <source>• Local network services are password protected
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- 本地网络服务受密码保护
+        <translation>- 本地网络服务受密码保护
 - 网络通信已加密
 - 已启用与 VRM 的安全连接
 - 无法启用不安全设置</translation>
     </message>
     <message id="settings_security_profile_weak_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
-      <source>• Local network services are password protected
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="189"/>
+        <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- 本地网络服务受密码保护
+        <translation>- 本地网络服务受密码保护
 - 本地网站的非加密访问也已启用（HTTP/HTTPS）</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
-      <source>• Local network services do not need a password
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="192"/>
+        <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- 本地网络服务不需要密码
+        <translation>- 本地网络服务不需要密码
 - 本地网站的非加密访问也已启用（HTTP/HTTPS）</translation>
     </message>
     <message id="settings_root_password">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
-      <source>Root password</source>
-      <translation>根密码</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="217"/>
+        <source>Root password</source>
+        <translation>根密码</translation>
     </message>
     <message id="settings_logout">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
-      <source>Logout</source>
-      <translation>登出</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="271"/>
+        <source>Logout</source>
+        <translation>登出</translation>
     </message>
     <message id="settings_tailscale_logout_button">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
-      <source>Log out now</source>
-      <translation>立即退出</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="234"/>
+        <source>Log out now</source>
+        <translation>立即退出</translation>
     </message>
     <message id="settings_logout_dialog_title">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
-      <source>Log out?</source>
-      <translation>注销？</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="285"/>
+        <source>Log out?</source>
+        <translation>注销？</translation>
     </message>
     <message id="settings_logout_dialog_description">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
-      <source>This will disconnect all local network connections.</source>
-      <translation>这将断开所有本地网络连接。</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="287"/>
+        <source>This will disconnect all local network connections.</source>
+        <translation>这将断开所有本地网络连接。</translation>
     </message>
     <message id="settings_logout_dialog_accept_text">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
-      <source>Log out</source>
-      <translation>登出</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="289"/>
+        <source>Log out</source>
+        <translation>登出</translation>
     </message>
     <message id="settings_vrm_portal_readonly">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="52"/>
-      <source>Read-only</source>
-      <translation>只读</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="53"/>
+        <source>Read-only</source>
+        <translation>只读</translation>
     </message>
     <message id="settings_vrm_portal_full">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="54"/>
-      <source>Full</source>
-      <translation>全部</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="55"/>
+        <source>Full</source>
+        <translation>全部</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="74"/>
-      <source>Are you sure?</source>
-      <translation>你确定吗？</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="75"/>
+        <source>Are you sure?</source>
+        <translation>你确定吗？</translation>
     </message>
     <message id="settings_vrm_portal_mode_confirm_description">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="76"/>
-      <source>Changing this setting to Read-only or Off will lock you out.</source>
-      <translation>将此设置更改为只读或关闭将锁定您。</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="77"/>
+        <source>Changing this setting to Read-only or Off will lock you out.</source>
+        <translation>将此设置更改为只读或关闭将锁定您。</translation>
     </message>
     <message id="settings_services_mqtt_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="48"/>
-      <source>MQTT Access</source>
-      <translation>MQTT 访问</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="48"/>
+        <source>MQTT Access</source>
+        <translation>MQTT 访问</translation>
     </message>
     <message id="common_words_error_not_a_number">
-      <location filename="../../components/CommonWords.qml" line="168"/>
-      <source>'%1' is not a number.</source>
-      <translation>%1 "不是数字。</translation>
+        <location filename="../components/CommonWords.qml" line="168"/>
+        <source>&apos;%1&apos; is not a number.</source>
+        <translation>%1 &quot;不是数字。</translation>
     </message>
     <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/listitems/ListRadioButtonGroup.qml" line="160"/>
-      <source>Confirm</source>
-      <extracomment>Confirm password, and verify it if possible</extracomment>
-      <translation>是的，退订</translation>
+        <location filename="../components/listitems/ListRadioButtonGroup.qml" line="160"/>
+        <source>Confirm</source>
+        <extracomment>Confirm password, and verify it if possible</extracomment>
+        <translation>是的，退订</translation>
     </message>
     <message id="number_field_input_too_long">
-      <location filename="../../components/listitems/ListIntField.qml" line="21"/>
-      <source>Use a number with %1 digits or less.</source>
-      <translation>使用 %1 位或更少的数字。</translation>
+        <location filename="../components/listitems/ListIntField.qml" line="21"/>
+        <source>Use a number with %1 digits or less.</source>
+        <translation>使用 %1 位或更少的数字。</translation>
     </message>
     <message id="ip_address_input_not_valid">
-      <location filename="../../components/listitems/ListIpAddressField.qml" line="34"/>
-      <source>'%1' is not a valid IP address.</source>
-      <translation>%1 "不是有效的 IP 地址。</translation>
+        <location filename="../components/listitems/ListIpAddressField.qml" line="34"/>
+        <source>&apos;%1&apos; is not a valid IP address.</source>
+        <translation>%1 &quot;不是有效的 IP 地址。</translation>
     </message>
     <message id="port_input_not_valid">
-      <location filename="../../components/listitems/ListPortField.qml" line="26"/>
-      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
-      <translation>%1 "不是有效的端口号。请使用 0-65535 之间的数字。</translation>
+        <location filename="../components/listitems/ListPortField.qml" line="26"/>
+        <source>&apos;%1&apos; is not a valid port number. Use a number between 0-65535.</source>
+        <translation>%1 &quot;不是有效的端口号。请使用 0-65535 之间的数字。</translation>
     </message>
     <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation>%1 不是有效的单位编号。请使用 1-247 之间的数字。</translation>
+        <location filename="../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+        <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+        <translation>%1 不是有效的单位编号。请使用 1-247 之间的数字。</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
-      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
-      <source>Current run time</source>
-      <oldsource>Run time</oldsource>
-      <translation>当前运行时间</translation>
+        <location filename="../pages/settings/PageGenerator.qml" line="71"/>
+        <source>Current run time</source>
+        <oldsource>Run time</oldsource>
+        <translation>当前运行时间</translation>
     </message>
     <message id="ac-in-genset_error">
-      <location filename="../../components/PageGensetModel.qml" line="118"/>
-      <source>Genset error codes</source>
-      <translation>发电机组错误代码</translation>
+        <location filename="../components/PageGensetModel.qml" line="118"/>
+        <source>Genset error codes</source>
+        <translation>发电机组错误代码</translation>
     </message>
     <message id="genset_heatsink_temperature">
-      <location filename="../../components/PageGensetModel.qml" line="263"/>
-      <source>Heatsink temperature</source>
-      <translation>散热器温度</translation>
+        <location filename="../components/PageGensetModel.qml" line="263"/>
+        <source>Heatsink temperature</source>
+        <translation>散热器温度</translation>
+    </message>
+    <message id="genset_charge_voltage">
+        <location filename="../components/PageGensetModel.qml" line="329"/>
+        <source>Charge voltage</source>
+        <translation type="unfinished">充电电压</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
-      <location filename="../../components/PageGensetModel.qml" line="340"/>
-      <source>The charge voltage is currently controlled by the BMS.</source>
-      <translation>充电电压目前由 BMS 控制。</translation>
+        <location filename="../components/PageGensetModel.qml" line="340"/>
+        <source>The charge voltage is currently controlled by the BMS.</source>
+        <translation>充电电压目前由 BMS 控制。</translation>
     </message>
     <message id="genset_charge_current_limit">
-      <location filename="../../components/PageGensetModel.qml" line="346"/>
-      <source>Charge current limit</source>
-      <translation>充电电流限制</translation>
+        <location filename="../components/PageGensetModel.qml" line="346"/>
+        <source>Charge current limit</source>
+        <translation>充电电流限制</translation>
     </message>
     <message id="genset_bms_controlled">
-      <location filename="../../components/PageGensetModel.qml" line="356"/>
-      <source>BMS Controlled</source>
-      <translation>BMS控制</translation>
+        <location filename="../components/PageGensetModel.qml" line="356"/>
+        <source>BMS Controlled</source>
+        <translation>BMS控制</translation>
     </message>
     <message id="genset_bms_control_enabled_automatically">
-      <location filename="../../components/PageGensetModel.qml" line="362"/>
-      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>如果有BMS，BMS控制将自动启用。如果系统配置已更改或没有BMS，则进行重置。</translation>
+        <location filename="../components/PageGensetModel.qml" line="362"/>
+        <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+        <translation>如果有BMS，BMS控制将自动启用。如果系统配置已更改或没有BMS，则进行重置。</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
-      <source>Service timer disabled.</source>
-      <translation>服务计时器已禁用。</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+        <source>Service timer disabled.</source>
+        <translation>服务计时器已禁用。</translation>
     </message>
     <message id="settings_logging_vrm_portal">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
-      <source>VRM Portal</source>
-      <translation>VRM端口</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="45"/>
+        <source>VRM Portal</source>
+        <translation>VRM端口</translation>
     </message>
     <message id="settings_services_tailscale_remote_vpn_access">
-      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
-      <source>Tailscale (remote VPN access)</source>
-      <translation>Tailscale（远程 VPN 访问）</translation>
+        <location filename="../pages/settings/PageSettingsServices.qml" line="31"/>
+        <source>Tailscale (remote VPN access)</source>
+        <translation>Tailscale（远程 VPN 访问）</translation>
     </message>
     <message id="common_words_soc">
-      <location filename="../../components/CommonWords.qml" line="417"/>
-      <source>SOC %1</source>
-      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
-      <translation>SOC %1</translation>
+        <location filename="../components/CommonWords.qml" line="417"/>
+        <source>SOC %1</source>
+        <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+        <translation>SOC %1</translation>
     </message>
     <message id="settings_security_warning_profile_configuration_order">
-      <location filename="../../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
-      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
-      <translation>启用网络服务前必须配置安全配置文件，请参阅设置 - 常规。</translation>
+        <location filename="../components/settings/ListSecurityWarningSwitch.qml" line="15"/>
+        <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+        <translation>启用网络服务前必须配置安全配置文件，请参阅设置 - 常规。</translation>
     </message>
     <message id="settings_tailscale_replaced_invalid_characters">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
-      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
-      <translation>%1 "被替换为"%2"，因为其中包含无效字符。</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="36"/>
+        <source>&apos;%1&apos; was replaced with &apos;%2&apos; since it contained invalid characters.</source>
+        <translation>%1 &quot;被替换为&quot;%2&quot;，因为其中包含无效字符。</translation>
     </message>
     <message id="settings_tailscale_initializing">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
-      <source>Initializing...</source>
-      <translation>初始化...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="57"/>
+        <source>Initializing...</source>
+        <translation>初始化...</translation>
     </message>
     <message id="settings_tailscale_backend_starting">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
-      <source>Backend starting...</source>
-      <translation>后台启动...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="60"/>
+        <source>Backend starting...</source>
+        <translation>后台启动...</translation>
     </message>
     <message id="settings_tailscale_backend_stopped">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
-      <source>Backend stopped.</source>
-      <translation>后台停止。</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="63"/>
+        <source>Backend stopped.</source>
+        <translation>后台停止。</translation>
     </message>
     <message id="settings_tailscale_connection_failed">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
-      <source>Connection failed.</source>
-      <translation>连接失败。</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="66"/>
+        <source>Connection failed.</source>
+        <translation>连接失败。</translation>
     </message>
     <message id="settings_tailscale_logged_out">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
-      <source>This GX device is logged out of Tailscale.
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="69"/>
+        <source>This GX device is logged out of Tailscale.
 
 Please wait or check your internet connection.</source>
-      <translation>该 GX 设备已退出 Tailscale。
+        <translation>该 GX 设备已退出 Tailscale。
 
 请稍候或检查您的网络连接。</translation>
     </message>
     <message id="settings_tailscale_wait_for_response">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
-      <source>Waiting for a response from Tailscale...</source>
-      <translation>等待 Tailscale 的回复...</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="72"/>
+        <source>Waiting for a response from Tailscale...</source>
+        <translation>等待 Tailscale 的回复...</translation>
     </message>
     <message id="settings_tailscale_wait_for_login">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
-      <source>Connect this GX device to your Tailscale account by opening this link:</source>
-      <translation>打开此链接，将此 GX 设备连接到您的 Tailscale 账户：</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="75"/>
+        <source>Connect this GX device to your Tailscale account by opening this link:</source>
+        <translation>打开此链接，将此 GX 设备连接到您的 Tailscale 账户：</translation>
     </message>
     <message id="settings_tailscale_check_internet_connection">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
-      <source>Please wait or check your internet connection.</source>
-      <translation>请稍候或检查您的网络连接。</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="83"/>
+        <source>Please wait or check your internet connection.</source>
+        <translation>请稍候或检查您的网络连接。</translation>
     </message>
     <message id="settings_tailscale_unknown_state">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
-      <source>Unknown state: #%1</source>
-      <extracomment>%1 = number code for the connect state</extracomment>
-      <translation>未知状态：#%1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="87"/>
+        <source>Unknown state: #%1</source>
+        <extracomment>%1 = number code for the connect state</extracomment>
+        <translation>未知状态：#%1</translation>
     </message>
     <message id="settings_tailscale_error">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
-      <source>ERROR: %1</source>
-      <translation>错误： %1</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="92"/>
+        <source>ERROR: %1</source>
+        <translation>错误： %1</translation>
     </message>
     <message id="settings_tailscale_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
-      <source>WiFi</source>
-      <translation>Wi-Fi</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="108"/>
+        <source>WiFi</source>
+        <translation>Wi-Fi</translation>
     </message>
     <message id="settings_tailscale_disable_to_edit">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
-      <source>Disable Tailscale to edit these settings.</source>
-      <translation>禁用 Tailscale 可编辑这些设置。</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="128"/>
+        <source>Disable Tailscale to edit these settings.</source>
+        <translation>禁用 Tailscale 可编辑这些设置。</translation>
     </message>
     <message id="settings_tailscale_enable">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
-      <source>Enable Tailscale</source>
-      <translation>启用Tailscale</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="169"/>
+        <source>Enable Tailscale</source>
+        <translation>启用Tailscale</translation>
     </message>
     <message id="settings_tailscale_machinename">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
-      <source>Machine name</source>
-      <translation>机器名称</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="207"/>
+        <source>Machine name</source>
+        <translation>机器名称</translation>
     </message>
     <message id="settings_tailscale_ipv4">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
-      <source>IPv4</source>
-      <translation>IPv4</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="218"/>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
     </message>
     <message id="settings_tailscale_ipv6">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
-      <source>IPv6</source>
-      <translation>IPv6</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="225"/>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
     </message>
     <message id="settings_tailscale_logout">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
-      <source>Logout from Tailscale account</source>
-      <translation>注销 Tailscale 账户</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="232"/>
+        <source>Logout from Tailscale account</source>
+        <translation>注销 Tailscale 账户</translation>
     </message>
     <message id="settings_tailscale_local_network_access">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
-      <source>Local network access</source>
-      <translation>本地网络访问</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="242"/>
+        <source>Local network access</source>
+        <translation>本地网络访问</translation>
     </message>
     <message id="settings_tailscale_local_network_access_ethernet">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
-      <source>Access local ethernet network</source>
-      <translation>访问本地以太网网络</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="256"/>
+        <source>Access local ethernet network</source>
+        <translation>访问本地以太网网络</translation>
     </message>
     <message id="settings_tailscale_local_network_access_wifi">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
-      <source>Access local WiFi network</source>
-      <translation>访问本地 WiFi 网络</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="263"/>
+        <source>Access local WiFi network</source>
+        <translation>访问本地 WiFi 网络</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
-      <source>Custom network(s)</source>
-      <translation>自定义网络</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="270"/>
+        <source>Custom network(s)</source>
+        <translation>自定义网络</translation>
     </message>
     <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
-      <source>Example: 192.168.1.0/24</source>
-      <translation>例如：192.168.1.0/24</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="273"/>
+        <source>Example: 192.168.1.0/24</source>
+        <translation>例如：192.168.1.0/24</translation>
     </message>
     <message id="settings_tailscale_local_network_access_explanation">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
-      <source>Explanation:
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="286"/>
+        <source>Explanation:
 
 This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
 
 The custom networks field accepts a comma-separated list of CIDR notation subnets.
 
 After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
-      <translation>解释：
+        <translation>解释：
 
 Tailscale 将此功能称为子网路由，允许远程访问本地网络中的其他设备。
 
@@ -7384,2988 +8026,3056 @@ Tailscale 将此功能称为子网路由，允许远程访问本地网络中的�
 添加/启用新网络后，需要在 Tailscale 管理控制台中批准一次。</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
-      <source>Custom "tailscale up" arguments</source>
-      <translation>自定义 "Tailscale up "参数</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="313"/>
+        <source>Custom &quot;tailscale up&quot; arguments</source>
+        <translation>自定义 &quot;Tailscale up &quot;参数</translation>
     </message>
     <message id="settings_tailscale_advanced_custom_server_url">
-      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
-      <source>Custom server URL (Headscale)</source>
-      <translation>自定义服务器 URL（Headscale）</translation>
+        <location filename="../pages/settings/PageSettingsTailscale.qml" line="324"/>
+        <source>Custom server URL (Headscale)</source>
+        <translation>自定义服务器 URL（Headscale）</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
-      <location filename="../../components/PageGensetModel.qml" line="53"/>
-      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>该发电机组控制器需要一个辅助继电器来控制，但未配置辅助继电器。请在设置 → 继电器下将继电器 1 配置为 "已连接的发电机组辅助继电器"。</translation>
+        <location filename="../components/PageGensetModel.qml" line="53"/>
+        <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to &quot;Connected genset helper relay&quot;.</source>
+        <translation>该发电机组控制器需要一个辅助继电器来控制，但未配置辅助继电器。请在设置 → 继电器下将继电器 1 配置为 &quot;已连接的发电机组辅助继电器&quot;。</translation>
     </message>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
-      <source>High starter battery voltage alarms</source>
-      <oldsource>High starter batttery voltage alarms</oldsource>
-      <translation>启动电池电压过高报警</translation>
+        <location filename="../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+        <source>High starter battery voltage alarms</source>
+        <oldsource>High starter batttery voltage alarms</oldsource>
+        <translation>启动电池电压过高报警</translation>
     </message>
     <message id="settings_generator_condition_skip_warmup">
-      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
-      <source>Skip generator warm-up</source>
-      <translation>跳过发电机预热</translation>
+        <location filename="../pages/settings/GeneratorCondition.qml" line="138"/>
+        <source>Skip generator warm-up</source>
+        <translation>跳过发电机预热</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Up, but no services (500 kbit/s)</source>
-      <translation>正常运行，但无服务（500 kbit/s）</translation>
+        <location filename="../pages/settings/PageSettingsCanbus.qml" line="112"/>
+        <source>Up, but no services (500 kbit/s)</source>
+        <translation>正常运行，但无服务（500 kbit/s）</translation>
     </message>
     <message id="settings_root_password_changed_to">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
-      <source>Root password changed to %1</source>
-      <translation>根密码更改为 %1</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="231"/>
+        <source>Root password changed to %1</source>
+        <translation>根密码更改为 %1</translation>
     </message>
     <message id="settings_relay_genset_helper_relay">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
-      <source>Connected genset helper relay</source>
-      <translation>已连接发电机组辅助继电器</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="30"/>
+        <source>Connected genset helper relay</source>
+        <translation>已连接发电机组辅助继电器</translation>
     </message>
     <message id="settings_system_ac_position">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
-      <source>Position of AC loads</source>
-      <translation>交流负载的位置</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="88"/>
+        <source>Position of AC loads</source>
+        <translation>交流负载的位置</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
-      <source>AC input &amp; output</source>
-      <translation>交流电输入和输出</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="93"/>
+        <source>AC input &amp; output</source>
+        <translation>交流电输入和输出</translation>
     </message>
     <message id="settings_system_ac_input_and_output_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="95"/>
-      <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
-      <translation>当逆变器/充电器的输入端存在交流负载时，请使用此选项。如果不确定，请使用此选项。</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="95"/>
+        <source>Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure.</source>
+        <translation>当逆变器/充电器的输入端存在交流负载时，请使用此选项。如果不确定，请使用此选项。</translation>
     </message>
     <message id="settings_system_ac_output_only">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
-      <source>AC output only</source>
-      <translation>仅交流输出</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="100"/>
+        <source>AC output only</source>
+        <translation>仅交流输出</translation>
     </message>
     <message id="settings_system_ac_output_only_description">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
-      <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
-      <translation>当系统使用电网表，但所有交流负载都在逆变器/充电器的输出上时，请使用此选项。</translation>
+        <location filename="../pages/settings/PageSettingsSystem.qml" line="102"/>
+        <source>Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger.</source>
+        <translation>当系统使用电网表，但所有交流负载都在逆变器/充电器的输出上时，请使用此选项。</translation>
     </message>
     <message id="cgwacs_battery_schedule_monthly">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="23"/>
-      <source>Monthly</source>
-      <translation>每月</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="23"/>
+        <source>Monthly</source>
+        <translation>每月</translation>
     </message>
     <message id="acInputs_evcharger">
-      <location filename="../../data/AcInputs.qml" line="28"/>
-      <source>EV Charger</source>
-      <translation>EVCS</translation>
+        <location filename="../data/AcInputs.qml" line="28"/>
+        <source>EV Charger</source>
+        <translation>EVCS</translation>
     </message>
     <message id="acInputs_heat_pump">
-      <location filename="../../data/AcInputs.qml" line="30"/>
-      <source>Heat pump</source>
-      <translation>热泵</translation>
+        <location filename="../data/AcInputs.qml" line="30"/>
+        <source>Heat pump</source>
+        <translation>热泵</translation>
     </message>
     <message id="overview_widget_essential_loads_title">
-      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
-      <source>Essential Loads</source>
-      <translation>关键负载</translation>
+        <location filename="../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+        <source>Essential Loads</source>
+        <translation>关键负载</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
-      <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
-      <translation>根据配置的自动启动条件启动和停止发电机。</translation>
+        <location filename="../pages/controlcards/GeneratorCard.qml" line="66"/>
+        <source>Start and stop the generator based on the configured autostart conditions.</source>
+        <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+        <translation>根据配置的自动启动条件启动和停止发电机。</translation>
     </message>
     <message id="page_genset_model_dc_genset_settings">
-      <location filename="../../components/PageGensetModel.qml" line="302"/>
-      <source>DC genset settings</source>
-      <translation>直流发电机组设置</translation>
+        <location filename="../components/PageGensetModel.qml" line="302"/>
+        <source>DC genset settings</source>
+        <translation>直流发电机组设置</translation>
     </message>
     <message id="alternator_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
-      <source>Alternator Temperature</source>
-      <translation>交流发电机温度</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+        <source>Alternator Temperature</source>
+        <translation>交流发电机温度</translation>
     </message>
     <message id="engine_temperature">
-      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
-      <source>Engine Temperature</source>
-      <translation>发动机温度</translation>
+        <location filename="../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+        <source>Engine Temperature</source>
+        <translation>发动机温度</translation>
     </message>
     <message id="page_settings_run_time_and_service_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
-      <source>Total run time</source>
-      <translation>总运行时间</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+        <source>Total run time</source>
+        <translation>总运行时间</translation>
     </message>
     <message id="settings_network_security_profile">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
-      <source>Network security profile</source>
-      <translation>网络安全配置</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="104"/>
+        <source>Network security profile</source>
+        <translation>网络安全配置</translation>
     </message>
     <message id="charger_history_last_x_days">
-      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
-      <source>Last %1 days</source>
-      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
-      <translation>最近 %1 天</translation>
+        <location filename="../pages/solar/SolarHistoryPage.qml" line="62"/>
+        <source>Last %1 days</source>
+        <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+        <translation>最近 %1 天</translation>
     </message>
     <message id="generator_start_dialog_will_stop_in_x">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
-      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
-      <translation>发电机将在 %1 时停止，除非启用了自动启动条件，使其继续运行。</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+        <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+        <translation>发电机将在 %1 时停止，除非启用了自动启动条件，使其继续运行。</translation>
     </message>
     <message id="generator_start_dialog_will_run_until_manually_stopped">
-      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
-      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
-      <translation>发电机将一直运行，直到手动停止，除非启用了自动启动条件使其继续运行。</translation>
+        <location filename="../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+        <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+        <translation>发电机将一直运行，直到手动停止，除非启用了自动启动条件使其继续运行。</translation>
     </message>
     <message id="settings_display_classic_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
-      <source>Classic UI</source>
-      <translation>传统界面</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="194"/>
+        <source>Classic UI</source>
+        <translation>传统界面</translation>
     </message>
     <message id="settings_display_new_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
-      <source>New UI</source>
-      <translation>新的用户界面</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="199"/>
+        <source>New UI</source>
+        <translation>新的用户界面</translation>
     </message>
     <message id="settings_language_change_succeeded">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
-      <source>Successfully changed language!</source>
-      <translation>成功更改语言！</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
-      <source>Power limiting</source>
-      <translation>功率限制</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="142"/>
+        <source>Successfully changed language!</source>
+        <translation>成功更改语言！</translation>
     </message>
     <message id="settings_ess_rs_information">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
-      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
-      <translation>对于 Multi-RS 和 HS19 设备，可在 RS 系统产品页面上进行 ESS 设置。</translation>
+        <location filename="../pages/settings/PageSettingsHub4.qml" line="31"/>
+        <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+        <translation>对于 Multi-RS 和 HS19 设备，可在 RS 系统产品页面上进行 ESS 设置。</translation>
     </message>
     <message id="settings_relay_genset_start_stop">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
-      <source>Genset start/stop</source>
-      <translation>发电机组启动/停止</translation>
+        <location filename="../pages/settings/PageSettingsRelay.qml" line="28"/>
+        <source>Genset start/stop</source>
+        <translation>发电机组启动/停止</translation>
     </message>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
-      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>如果没有选择 "设置/常规 "中的 "网络安全配置文件"，则无法切换固件版本。</translation>
+        <location filename="../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+        <source>Switching firmware version is not possible without &quot;Network Security Profile&quot; in &quot;Settings / General&quot; being selected.</source>
+        <translation>如果没有选择 &quot;设置/常规 &quot;中的 &quot;网络安全配置文件&quot;，则无法切换固件版本。</translation>
     </message>
     <message id="cgwacs_battery_schedule_duration">
-      <location filename="../../components/settings/ChargeScheduleItem.qml" line="143"/>
-      <source>Duration</source>
-      <oldsource>Duration (hh:mm)</oldsource>
-      <translation>期限</translation>
+        <location filename="../components/settings/ChargeScheduleItem.qml" line="143"/>
+        <source>Duration</source>
+        <oldsource>Duration (hh:mm)</oldsource>
+        <translation>期限</translation>
     </message>
     <message id="rssystem_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
-      <source>System alarms</source>
-      <translation>系统警报</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+        <source>System alarms</source>
+        <translation>系统警报</translation>
     </message>
     <message id="rs_no_system_alarms">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
-      <source>No system alarms</source>
-      <translation>无系统警报</translation>
+        <location filename="../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+        <source>No system alarms</source>
+        <translation>无系统警报</translation>
     </message>
     <message id="welcome_page_back">
-      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
-      <source>Back</source>
-      <translation>返回</translation>
+        <location filename="../pages/welcome/WelcomePage.qml" line="94"/>
+        <source>Back</source>
+        <translation>返回</translation>
     </message>
     <message id="welcome_whatsnew">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
-      <source>What's New</source>
-      <translation>最新</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="35"/>
+        <source>What&apos;s New</source>
+        <translation>最新</translation>
     </message>
     <message id="welcome_skip">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
-      <source>Skip</source>
-      <translation>跳过</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="45"/>
+        <source>Skip</source>
+        <translation>跳过</translation>
     </message>
     <message id="welcome_landing_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
-      <source>Welcome!</source>
-      <translation>欢迎光临</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="64"/>
+        <source>Welcome!</source>
+        <translation>欢迎光临</translation>
     </message>
     <message id="welcome_landing_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
-      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+        <location filename="../pages/welcome/WelcomeView.qml" line="70"/>
+        <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
 
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
-      <translation>我们很高兴为您介绍一个完全重新设计的界面，它将增强 GX 的可用性和美观性。
+        <translation>我们很高兴为您介绍一个完全重新设计的界面，它将增强 GX 的可用性和美观性。
 
 通过精简导航和全新外观，您所喜爱的一切现在都更容易访问，视觉效果也更吸引人。</translation>
     </message>
     <message id="welcome_colors_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
-      <source>Dark - light mode</source>
-      <translation>深色 - 浅色模式</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="74"/>
+        <source>Dark - light mode</source>
+        <translation>深色 - 浅色模式</translation>
     </message>
     <message id="welcome_colors_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
-      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>不同的环境需要不同的显示设置。暗模式和亮模式可确保无论您身在何处，都能获得最佳的观看体验。</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="78"/>
+        <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+        <translation>不同的环境需要不同的显示设置。暗模式和亮模式可确保无论您身在何处，都能获得最佳的观看体验。</translation>
     </message>
     <message id="welcome_brief_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
-      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>以简洁明了的布局呈现您所需的所有关键信息。其核心部分是一个以环为特色的可定制部件，让您一眼就能快速访问您的系统见解。</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="87"/>
+        <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+        <translation>以简洁明了的布局呈现您所需的所有关键信息。其核心部分是一个以环为特色的可定制部件，让您一眼就能快速访问您的系统见解。</translation>
     </message>
     <message id="welcome_overview_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
-      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>我们更新的概览面板提供实时系统数据，让您更轻松地进行监控。</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="95"/>
+        <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+        <translation>我们更新的概览面板提供实时系统数据，让您更轻松地进行监控。</translation>
     </message>
     <message id="welcome_controls_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
-      <source>Controls</source>
-      <translation>控制</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="99"/>
+        <source>Controls</source>
+        <translation>控制</translation>
     </message>
     <message id="welcome_controls_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="103"/>
-      <source>All the day to day controls are now combined together in the new Controls pane. </source>
-      <translation>现在，所有日常控制功能都合并到了新的 "控制 "窗格中。 </translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="102"/>
+        <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+        <oldsource>All the day to day controls are now combined together in the new Controls pane. </oldsource>
+        <translation type="unfinished">现在，所有日常控制功能都合并到了新的 &quot;控制 &quot;窗格中。 </translation>
     </message>
     <message id="welcome_units_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="107"/>
-      <source>Watts &amp; Amps</source>
-      <translation>瓦和安培数</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="106"/>
+        <source>Watts &amp; Amps</source>
+        <translation>瓦和安培数</translation>
     </message>
     <message id="welcome_units_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="111"/>
-      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
-      <translation>现在您可以在瓦和安培之间切换。选择最适合您偏好的单位。</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="110"/>
+        <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+        <translation>现在您可以在瓦和安培之间切换。选择最适合您偏好的单位。</translation>
     </message>
     <message id="welcome_more_title">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="115"/>
-      <source>Learn more</source>
-      <translation>知道更多</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="114"/>
+        <source>Learn more</source>
+        <translation>知道更多</translation>
     </message>
     <message id="welcome_more_text_wasm">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
-      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
-      <extracomment>%1 = link to URL with more information</extracomment>
-      <translation>访问以下链接，了解有关《用户界面更新指南》的更多信息。</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="119"/>
+        <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <extracomment>%1 = link to URL with more information</extracomment>
+        <translation>访问以下链接，了解有关《用户界面更新指南》的更多信息。</translation>
     </message>
     <message id="welcome_more_text">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="122"/>
-      <source>Scan the QR code to find out more about the Renewed UI.</source>
-      <translation>扫描二维码，了解有关 "更新的用户界面 "的更多信息。</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="121"/>
+        <source>Scan the QR code to find out more about the Renewed UI.</source>
+        <translation>扫描二维码，了解有关 &quot;更新的用户界面 &quot;的更多信息。</translation>
     </message>
     <message id="welcome_done">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
-      <source>Done</source>
-      <translation>完成</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="137"/>
+        <source>Done</source>
+        <translation>完成</translation>
     </message>
     <message id="welcome_next">
-      <location filename="../../pages/welcome/WelcomeView.qml" line="140"/>
-      <source>Next</source>
-      <translation>下一个</translation>
+        <location filename="../pages/welcome/WelcomeView.qml" line="139"/>
+        <source>Next</source>
+        <translation>下一个</translation>
     </message>
     <message id="devicelist_solarcharger_error">
-      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
-      <source>Error: #%1</source>
-      <extracomment>%1 = error number</extracomment>
-      <oldsource>Error: %1</oldsource>
-      <translation>错误：#%1</translation>
+        <location filename="../pages/settings/devicelist/DeviceListPage.qml" line="75"/>
+        <source>Error: #%1</source>
+        <oldsource>Error: %1</oldsource>
+        <extracomment>%1 = error number</extracomment>
+        <translation>错误：#%1</translation>
     </message>
     <message id="charger_alarms_header_active_errors">
-      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
-      <source>Active Error</source>
-      <translation>活动错误</translation>
+        <location filename="../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+        <source>Active Error</source>
+        <translation>活动错误</translation>
     </message>
     <message id="page_settings_run_time_and_service_generator_total_run_time">
-      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
-      <source>Generator total run time (hours)</source>
-      <translation>发电机总运行时间（小时）</translation>
+        <location filename="../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+        <source>Generator total run time (hours)</source>
+        <translation>发电机总运行时间（小时）</translation>
     </message>
     <message id="settings_startpage_name">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
-      <source>Start page</source>
-      <translation>启动页</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+        <source>Start page</source>
+        <translation>启动页</translation>
     </message>
     <message id="settings_display_onscreen_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
-      <source>User interface</source>
-      <translation>用户界面</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="185"/>
+        <source>User interface</source>
+        <translation>用户界面</translation>
     </message>
     <message id="settings_display_remote_console_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
-      <source>User interface (Remote Console)</source>
-      <translation>用户界面（远程控制台）</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="187"/>
+        <source>User interface (Remote Console)</source>
+        <translation>用户界面（远程控制台）</translation>
     </message>
     <message id="settings_app_restarted">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
-      <source>%1 updated</source>
-      <extracomment>%1 = The name of the setting being updated</extracomment>
-      <translation>%1 已更新</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="234"/>
+        <source>%1 updated</source>
+        <extracomment>%1 = The name of the setting being updated</extracomment>
+        <translation>%1 已更新</translation>
     </message>
     <message id="settings_switch_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
-      <source>User interface will switch to %1.</source>
-      <extracomment>%1 = the UI version that the system is switching to</extracomment>
-      <translation>用户界面将切换到 %1。</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="238"/>
+        <source>User interface will switch to %1.</source>
+        <extracomment>%1 = the UI version that the system is switching to</extracomment>
+        <translation>用户界面将切换到 %1。</translation>
     </message>
     <message id="settings_has_switched_ui">
-      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
-      <source>%1 is set to %2</source>
-      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
-      <translation>%1 设置为 %2</translation>
-    </message>
-    <message id="page_settings_fronius_inverter_power_limiting_label">
-      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
-      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>本光伏逆变器支持功率限制。如果会影响正常运行，请禁用此设置。</translation>
+        <location filename="../pages/settings/PageSettingsDisplay.qml" line="242"/>
+        <source>%1 is set to %2</source>
+        <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+        <translation>%1 设置为 %2</translation>
     </message>
     <message id="press_ok_to_reboot">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
-      <source>Press 'OK' to reboot</source>
-      <translation>按 "确定 "重新启动</translation>
+        <location filename="../pages/settings/PageSettingsGeneral.qml" line="309"/>
+        <source>Press &apos;OK&apos; to reboot</source>
+        <translation>按 &quot;确定 &quot;重新启动</translation>
     </message>
     <message id="page_settings_nodered_factory_reset">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
-      <source>Node-RED factory reset</source>
-      <translation>Node-RED 出厂重置</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+        <source>Node-RED factory reset</source>
+        <translation>Node-RED 出厂重置</translation>
     </message>
     <message id="page_settings_nodered_factory_reset_confirmation">
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
-      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
-      <translation>您确定要将 Node-RED 重置为出厂默认设置吗？这将删除您的所有流量。</translation>
+        <location filename="../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+        <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+        <translation>您确定要将 Node-RED 重置为出厂默认设置吗？这将删除您的所有流量。</translation>
     </message>
     <message id="settings_connection_status">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="178"/>
-      <source>Connection status</source>
-      <translation>连接状态</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="179"/>
+        <source>Connection status</source>
+        <translation>连接状态</translation>
     </message>
     <message id="settings_connection_error_https_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="219"/>
-      <source>Connection status (HTTPS channel)</source>
-      <translation>连接状态（HTTPS 通道）</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="220"/>
+        <source>Connection status (HTTPS channel)</source>
+        <translation>连接状态（HTTPS 通道）</translation>
     </message>
     <message id="settings_connection_error_http_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="221"/>
-      <source>Connection status (HTTP channel)</source>
-      <translation>连接状态（HTTP 通道）</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="222"/>
+        <source>Connection status (HTTP channel)</source>
+        <translation>连接状态（HTTP 通道）</translation>
     </message>
     <message id="settings_connection_error_realtime_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="239"/>
-      <source>Connection status (MQTT Real-time channel)</source>
-      <translation>连接状态（MQTT 实时通道）</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="240"/>
+        <source>Connection status (MQTT Real-time channel)</source>
+        <translation>连接状态（MQTT 实时通道）</translation>
     </message>
     <message id="settings_connection_error_rpc_channel">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="246"/>
-      <source>Connection status (MQTT RPC channel)</source>
-      <translation>连接状态（MQTT RPC 通道）</translation>
+        <location filename="../pages/settings/PageSettingsLogger.qml" line="247"/>
+        <source>Connection status (MQTT RPC channel)</source>
+        <translation>连接状态（MQTT RPC 通道）</translation>
     </message>
     <message id="controlcard_generator_autostarted">
-      <location filename="../../components/CommonWords.qml" line="80"/>
-      <source>Auto-started • %1</source>
-      <translation>自动启动 - %1</translation>
+        <location filename="../components/CommonWords.qml" line="80"/>
+        <source>Auto-started • %1</source>
+        <translation>自动启动 - %1</translation>
     </message>
     <message id="settings_relay_deactivation_value">
-      <location filename="../../components/settings/TemperatureRelaySettings.qml" line="89"/>
-      <source>Deactivation value</source>
-      <oldsource>Deativation value</oldsource>
-      <translation>禁用值</translation>
+        <location filename="../components/settings/TemperatureRelaySettings.qml" line="89"/>
+        <source>Deactivation value</source>
+        <oldsource>Deativation value</oldsource>
+        <translation>禁用值</translation>
     </message>
     <message id="generator_not_running">
-      <location filename="../../data/Generators.qml" line="67"/>
-      <source>Not running</source>
-      <translation>不运行</translation>
+        <location filename="../data/Generators.qml" line="67"/>
+        <source>Not running</source>
+        <translation>不运行</translation>
     </message>
     <message id="settings_loss_of_communication">
-      <location filename="../../data/Generators.qml" line="76"/>
-      <source>Loss of communication</source>
-      <translation>通讯中断</translation>
+        <location filename="../data/Generators.qml" line="76"/>
+        <source>Loss of communication</source>
+        <translation>通讯中断</translation>
     </message>
     <message id="settings_soc_condition">
-      <location filename="../../data/Generators.qml" line="79"/>
-      <source>SOC condition</source>
-      <translation>SOC 条件</translation>
+        <location filename="../data/Generators.qml" line="79"/>
+        <source>SOC condition</source>
+        <translation>SOC 条件</translation>
     </message>
     <message id="settings_ac_load_condition">
-      <location filename="../../data/Generators.qml" line="82"/>
-      <source>AC load condition</source>
-      <translation>交流负载条件</translation>
+        <location filename="../data/Generators.qml" line="82"/>
+        <source>AC load condition</source>
+        <translation>交流负载条件</translation>
     </message>
     <message id="settings_battery_current_condition">
-      <location filename="../../data/Generators.qml" line="85"/>
-      <source>Battery current condition</source>
-      <translation>电池电流状况</translation>
+        <location filename="../data/Generators.qml" line="85"/>
+        <source>Battery current condition</source>
+        <translation>电池电流状况</translation>
     </message>
     <message id="settings_battery_voltage_condition">
-      <location filename="../../data/Generators.qml" line="88"/>
-      <source>Battery voltage condition</source>
-      <translation>电池电压状况</translation>
+        <location filename="../data/Generators.qml" line="88"/>
+        <source>Battery voltage condition</source>
+        <translation>电池电压状况</translation>
     </message>
     <message id="settings_inverter_overload_condition">
-      <location filename="../../data/Generators.qml" line="94"/>
-      <source>Inverter overload condition</source>
-      <translation>逆变器过载条件</translation>
+        <location filename="../data/Generators.qml" line="94"/>
+        <source>Inverter overload condition</source>
+        <translation>逆变器过载条件</translation>
     </message>
     <message id="ess_flags">
-      <location filename="../../components/SystemReason.qml" line="15"/>
-      <source>ESS %1</source>
-      <translation>ESS %1</translation>
+        <location filename="../components/SystemReason.qml" line="15"/>
+        <source>ESS %1</source>
+        <translation>ESS %1</translation>
     </message>
     <message id="systemreason_charge_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="47"/>
-      <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 充电/放电禁用</translation>
+        <location filename="../components/SystemReason.qml" line="47"/>
+        <source>ESS %1 Charge/Discharge Disabled</source>
+        <translation>ESS %1 充电/放电禁用</translation>
     </message>
     <message id="systemreason_charge_disabled">
-      <location filename="../../components/SystemReason.qml" line="50"/>
-      <source>ESS %1 Charge Disabled</source>
-      <translation>ESS %1 充电禁用</translation>
+        <location filename="../components/SystemReason.qml" line="50"/>
+        <source>ESS %1 Charge Disabled</source>
+        <translation>ESS %1 充电禁用</translation>
     </message>
     <message id="systemreason_discharge_disabled">
-      <location filename="../../components/SystemReason.qml" line="53"/>
-      <source>ESS %1 Discharge Disabled</source>
-      <translation>ESS %1 放电禁用</translation>
+        <location filename="../components/SystemReason.qml" line="53"/>
+        <source>ESS %1 Discharge Disabled</source>
+        <translation>ESS %1 放电禁用</translation>
+    </message>
+    <message id="startpage_option_brief_without_panel">
+        <location filename="../data/StartPageConfiguration.qml" line="22"/>
+        <source>Brief</source>
+        <extracomment>The &apos;Brief&apos; page</extracomment>
+        <translation type="unfinished">概要</translation>
     </message>
     <message id="startpage_option_brief_with_panel">
-      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
-      <source>Brief (side panel open)</source>
-      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
-      <translation>概要（侧面板打开）</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="28"/>
+        <source>Brief (side panel open)</source>
+        <extracomment>The &apos;Brief&apos; page, with the side panel opened</extracomment>
+        <translation>概要（侧面板打开）</translation>
+    </message>
+    <message id="startpage_option_overview">
+        <location filename="../data/StartPageConfiguration.qml" line="34"/>
+        <source>Overview</source>
+        <extracomment>The &apos;Overview&apos; page</extracomment>
+        <translation type="unfinished">总览</translation>
     </message>
     <message id="startpage_option_levels_tanks">
-      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
-      <source>Levels (Tanks)</source>
-      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
-      <translation>液位（水箱）</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="40"/>
+        <source>Levels (Tanks)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Tanks&quot; section opened</extracomment>
+        <translation>液位（水箱）</translation>
     </message>
     <message id="startpage_option_levels_environment">
-      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
-      <source>Levels (Environment)</source>
-      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
-      <translation>液位（环境）</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="46"/>
+        <source>Levels (Environment)</source>
+        <extracomment>The &apos;Levels&apos; page, with the &quot;Environment&quot; section opened</extracomment>
+        <translation>液位（环境）</translation>
     </message>
     <message id="startpage_option_battery list">
-      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
-      <source>Battery list</source>
-      <translation>电池清单</translation>
+        <location filename="../data/StartPageConfiguration.qml" line="51"/>
+        <source>Battery list</source>
+        <translation>电池清单</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
-      <source>GX device has been updated</source>
-      <translation>GX 设备已更新</translation>
+        <location filename="../pages/DialogLayer.qml" line="55"/>
+        <source>GX device has been updated</source>
+        <translation>GX 设备已更新</translation>
     </message>
     <message id="settings_startpage_timeout_minutes" numerus="yes">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
-      <source>After %n minute(s)</source>
-      <translation>
-        <numerusform>%n 分钟后</numerusform>
-      </translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+        <source>After %n minute(s)</source>
+        <translation>
+            <numerusform>%n 分钟后</numerusform>
+        </translation>
     </message>
     <message id="settings_startpage_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
-      <source>Go to this page when the application starts.</source>
-      <translation>启动应用程序时，请转到此页面。</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+        <source>Go to this page when the application starts.</source>
+        <translation>启动应用程序时，请转到此页面。</translation>
     </message>
     <message id="settings_startpage_timeout">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
-      <source>Timeout</source>
-      <translation>超时</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+        <source>Timeout</source>
+        <translation>超时</translation>
     </message>
     <message id="settings_startpage_timeout_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
-      <source>Revert to the start page when the application is inactive.</source>
-      <translation>当应用程序处于非活动状态时，返回到启动页。</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+        <source>Revert to the start page when the application is inactive.</source>
+        <translation>当应用程序处于非活动状态时，返回到启动页。</translation>
     </message>
     <message id="settings_startpage_auto_description">
-      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
-      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>静止一分钟后，如果当前页面在此列表中，则选择该页面作为启动页。</translation>
+        <location filename="../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+        <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+        <translation>静止一分钟后，如果当前页面在此列表中，则选择该页面作为启动页。</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
-      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
-      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>该电流限制在系统配置中是固定的，无法调整。</translation>
+        <location filename="../components/CurrentLimitButton.qml" line="30"/>
+        <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>该电流限制在系统配置中是固定的，无法调整。</translation>
     </message>
     <message id="inverter_mode_not_adjustable">
-      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
-      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
-      <translation>该模式在系统配置中是固定的，无法调整。</translation>
+        <location filename="../components/InverterChargerModeButton.qml" line="39"/>
+        <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+        <translation>该模式在系统配置中是固定的，无法调整。</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
-      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
-      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
-      <translation>。发电机启动/停止功能未启用。进入继电器设置，将功能设置为 "发电机组启动/停止"。</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>摩洛哥标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>中非西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>南非标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>纳米比亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>埃及标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>非洲东部标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>阿根廷标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>南美东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>格陵兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>蒙得维的亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>纽芬兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>南美东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Standard Time</source>
-      <translation>大西洋标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>巴西中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>太平洋南美洲标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Paraguay Standard Time</source>
-      <translation>巴拉圭标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>SA Western Standard Time</source>
-      <translation>南美西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>Venezuela Standard Time</source>
-      <translation>委内瑞拉标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Eastern Standard Time</source>
-      <translation>东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>南美太平洋标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>US Eastern Standard Time</source>
-      <translation>美国东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>Canada Central Standard Time</source>
-      <translation>加拿大中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Central America Standard Time</source>
-      <translation>中美洲标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>中部标准时间（墨西哥）</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time</source>
-      <translation>中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>山区标准时间（墨西哥）</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time</source>
-      <translation>山区标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>US Mountain Standard Time</source>
-      <translation>美国山区标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>太平洋标准时间（墨西哥）</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time</source>
-      <translation>太平洋标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Alaskan Standard Time</source>
-      <translation>阿拉斯加标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>夏威夷-阿留申</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>新西兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>太平洋中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>太平洋西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>澳大利亚西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>东南亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>中亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>西亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>非洲东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>太平洋南美洲标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>南美西部标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>西欧标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>堪察加标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>马加丹标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>符拉迪沃斯托克标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>雅库茨克标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>东京标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>韩国标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>新加坡标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>乌兰巴托标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>台北标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>北亚东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>中国标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>东南亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>北亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>缅甸标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>中亚北部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>中亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>孟加拉国标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>尼泊尔标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>斯里兰卡标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>印度标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>西亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>巴基斯坦标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>叶卡特琳堡标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>格鲁吉亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>高加索标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>阿塞拜疆标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>阿拉伯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>阿富汗标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>伊朗标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>阿拉伯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>阿拉伯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>叙利亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>中东标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>约旦标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>以色列标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>格林尼治标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>亚速尔群岛标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>佛得角标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>塔斯马尼亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>澳大利亚东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>澳大利亚东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>澳大利亚中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>澳大利亚中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>澳大利亚西部标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT </source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>大西洋中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>Dateline Standard Time</source>
-      <translation>国际日期变更线标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>中欧标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>欧洲中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>罗曼斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>西欧标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>东欧标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>白俄罗斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>俄罗斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>土耳其标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>毛里求斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>圣诞岛标准时</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>汤加标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>斐济标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>新西兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>太平洋中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>太平洋西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>萨摩亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>夏威夷标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>东部岛屿标准时</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../pages/settings/PageRelayGenerator.qml" line="25"/>
+        <source>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Genset start/stop&quot;</source>
+        <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to &quot;Generator start/stop&quot;</oldsource>
+        <translation>。发电机启动/停止功能未启用。进入继电器设置，将功能设置为 &quot;发电机组启动/停止&quot;。</translation>
+    </message>
+    <message id="temperature_type_unknown">
+        <location filename="../data/EnvironmentInputs.qml" line="77"/>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message id="brief_solar_yield">
+        <location filename="../pages/BriefSidePanel.qml" line="18"/>
+        <source>Solar yield</source>
+        <translation type="unfinished">太阳能发电量</translation>
+    </message>
+    <message id="brief_dc_input">
+        <location filename="../pages/BriefSidePanel.qml" line="207"/>
+        <source>DC input</source>
+        <translation type="unfinished">直流输入</translation>
+    </message>
+    <message id="brief_ac_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="248"/>
+        <source>AC Loads</source>
+        <translation type="unfinished">交流负载</translation>
+    </message>
+    <message id="brief_dc_loads">
+        <location filename="../pages/BriefSidePanel.qml" line="276"/>
+        <source>DC Loads</source>
+        <translation type="unfinished">直流负载</translation>
+    </message>
+    <message id="nav_overview">
+        <location filename="../pages/OverviewPage.qml" line="397"/>
+        <source>Overview</source>
+        <translation type="unfinished">总览</translation>
+    </message>
+    <message id="settings_state">
+        <location filename="../pages/settings/PageCanbusStatus.qml" line="101"/>
+        <source>State</source>
+        <translation type="unfinished">状态</translation>
+    </message>
+    <message id="inverter_pv">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="66"/>
+        <source>PV</source>
+        <translation type="unfinished">光伏</translation>
+    </message>
+    <message id="inverter_total_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="86"/>
+        <source>Total yield</source>
+        <translation type="unfinished">总计发电</translation>
+    </message>
+    <message id="inverter_system_yield">
+        <location filename="../pages/settings/devicelist/inverter/PageInverter.qml" line="94"/>
+        <source>System yield</source>
+        <translation type="unfinished">系统发电</translation>
+    </message>
+    <message id="vebus_device_alarm_only">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
+        <source>Alarm only</source>
+        <translation type="unfinished">只报警</translation>
+    </message>
+    <message id="vebus_device_alarms_and_warnings">
+        <location filename="../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
+        <source>Alarms &amp; warnings</source>
+        <translation type="unfinished">报警&amp;警告</translation>
+    </message>
+    <message id="vebus_device_alarm_group_warning">
+        <location filename="../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+</context>
+<context>
     <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>无错误</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+        <source>No error</source>
+        <translation>无错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>未知错误：%1</translation>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+        <source>Unknown error: %1</source>
+        <translation>未知错误：%1</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>BmsError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>无错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="10"/>
+        <source>No error</source>
+        <translation>无错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>电池初始化错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="13"/>
+        <source>Battery initialization error</source>
+        <translation>电池初始化错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>无电池连接</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="16"/>
+        <source>No batteries connected</source>
+        <translation>无电池连接</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>未知电池</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="19"/>
+        <source>Unknown battery</source>
+        <translation>未知电池</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>不同电池类型</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="22"/>
+        <source>Different battery types</source>
+        <translation>不同电池类型</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>电池数不正确</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="25"/>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="40"/>
+        <source>No. of batteries incorrect</source>
+        <translation>电池数不正确</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt未找到</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="28"/>
+        <source>Lynx Shunt not found</source>
+        <translation>Lynx Shunt未找到</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>电池测量错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="31"/>
+        <source>Battery measure error</source>
+        <translation>电池测量错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>内部计算错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="34"/>
+        <source>Internal calculation error</source>
+        <translation>内部计算错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>串联电池数不正确</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="37"/>
+        <source>No. of batteries in series incorrect</source>
+        <translation>串联电池数不正确</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>硬件错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="44"/>
+        <source>Hardware error</source>
+        <translation>硬件错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>看门狗错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="47"/>
+        <source>Watchdog error</source>
+        <translation>看门狗错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>过电压</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="50"/>
+        <source>Over voltage</source>
+        <translation>过电压</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>低电压</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="53"/>
+        <source>Under voltage</source>
+        <translation>低电压</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>温度过高</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="56"/>
+        <source>Over temperature</source>
+        <translation>温度过高</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>温度过低</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="59"/>
+        <source>Under temperature</source>
+        <translation>温度过低</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>充电不足待机</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="62"/>
+        <source>Under-charge standby</source>
+        <translation>充电不足待机</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>ADC错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="65"/>
+        <source>ADC error</source>
+        <translation>ADC错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>电池通讯错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="68"/>
+        <source>Battery comm. error</source>
+        <translation>电池通讯错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>预充错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="71"/>
+        <source>Pre-Charge error</source>
+        <translation>预充错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>安全接触器错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="75"/>
+        <source>Safety contactor error</source>
+        <translation>安全接触器错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>电池更新错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="79"/>
+        <source>Battery update error</source>
+        <translation>电池更新错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>BMS 线缆故障</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="82"/>
+        <source>BMS cable error</source>
+        <translation>BMS 线缆故障</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>参考电压错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="85"/>
+        <source>Reference voltage failure</source>
+        <translation>参考电压错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>系统电压错误</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="88"/>
+        <source>Wrong system voltage</source>
+        <translation>系统电压错误</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>预充时间到</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="91"/>
+        <source>Pre charge timeout</source>
+        <translation>预充时间到</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>ATC/ATD故障</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="94"/>
+        <source>ATC/ATD failure</source>
+        <translation>ATC/ATD故障</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>校准数据丢失</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="98"/>
+        <source>Calibration data lost</source>
+        <translation>校准数据丢失</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>设置无效</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="102"/>
+        <source>Settings invalid</source>
+        <translation>设置无效</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>联锁</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="105"/>
+        <source>Interlock</source>
+        <translation>联锁</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>紧急停止</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="108"/>
+        <source>Emergency stop</source>
+        <translation>紧急停止</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>通信超时</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="111"/>
+        <source>Communication timeout</source>
+        <translation>通信超时</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>安全锁</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="114"/>
+        <source>Safety lock</source>
+        <translation>安全锁</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>终端温度过高</translation>
+        <location filename="../src/veutil/src/qt/bms_error.cpp" line="117"/>
+        <source>Terminal over temperature</source>
+        <translation>终端温度过高</translation>
     </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>无错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>电池温度高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>电池电压高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>温度检测线接线错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>温度检测线丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>电压检测线接线错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>电压检测线丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>电池高线损失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>电池电压低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>电池纹波电压大</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>电池低荷电状态</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>电池中点电压问题</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>电池温度过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>充电器温度高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>充电器过流</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>充电器反向电流</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>充电器快充时间超时</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>充电器电流感应问题</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>内部温度传感接线错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>内部温度传感丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>未检测到充电器风扇</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>充电器风扇过流</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>充电器端子过热</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>充电器短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>充电器功率级问题</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>过充保护</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>输入电压高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>输入电流过大</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>输入功率过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>输入极性问题</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>输入电压缺失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>输入关闭（无重试）</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>输入中断（重试）</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>输入内部故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>光伏隔离失效</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>检测到接地故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>逆变器过载</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>逆变器温度过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>逆变器峰值电流</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>逆变器内部直流电平</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>逆变器交流电平错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>逆变器功率级故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>逆变器连接到交流</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>ACIN1继电器测试故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>ACIN2继电器测试故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>设备消失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>不兼容设备</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>BMS连接丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>网络配置错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>相位旋转</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>多路交流输入</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>相位过载</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>内存写入错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>CPU温度太高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>通讯丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>校准数据丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>固件不兼容</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>硬件不兼容</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>设置无效</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>参考电压异常</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>检测失败</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>历史记录无效</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>千瓦时计数器无效</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>直流电压错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>GFCI 传感器错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>3V3电源错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>5V电源错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>12V电源错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>15V电源错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>PV输入关断</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>将开关置于解锁位置以修改设置。</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="100"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>使用D-Bus数据源：连接到指定的D-Bus地址。</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="101"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>地址</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="105"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>使用D-Bus数据源：连接到默认的D-Bus地址</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="110"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>使用MQTT数据源：连接到指定的MQTT代理地址。</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="111"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>地址</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="116"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>MQTT 数据源设备门户 ID。</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="117"/>
-      <source>portalId</source>
-      <translation>门户ID</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>MQTT VRM Web 主机分片</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="122"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>分片</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>MQTT data source username</source>
-      <translation>MQTT 数据源用户名</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="127"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>用户</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="131"/>
-      <source>MQTT data source password</source>
-      <translation>MQTT数据源密码</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>通过</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="136"/>
-      <source>MQTT data source token</source>
-      <translation>MQTT 数据源令牌</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="137"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>令牌代码</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="141"/>
-      <source>Enable FPS counter</source>
-      <translation>启用 FPS 计数器</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>Skip splash screen</source>
-      <translation>跳过启动画面</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="149"/>
-      <source>Use mock data source for testing.</source>
-      <translation>使用模拟数据源进行测试。</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation>设备关闭</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation>新旧MK2混合</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation>预期的设备错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation>未检测到其他设备</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation>交流输出过电压</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation>DDC（直接数字控制）程序出错</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation>无Assistant的VE.Bus BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation>接地继电器测试失败</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation>系统时间同步错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation>电网继电器测试故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation>配置与第二个MCU不匹配</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation>设备传输出错</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation>等待配置或软件狗丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation>主相位丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation>过电压发生</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation>从设备没有交流电输入!</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation>设备不可作为从机</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation>系统保护功能启动</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation>固件不兼容</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation>内部错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation>继电器测试失败会阻止连接</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation>VE.Bus错误</translation>
-    </message>
-  </context>
-  <context>
-    <name>Wakespeed</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
-      <source>Unknown error: </source>
-      <translation>未知错误：</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
-      <source>Internal error</source>
-      <translation>内部错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
-      <source>No error</source>
-      <translation>无错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
-      <source>Battery high temperature</source>
-      <translation>电池温度高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
-      <source>Battery high voltage</source>
-      <translation>电池电压高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
-      <source>Battery low voltage</source>
-      <translation>电池电压低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
-      <source>Battery voltage exceeded configured max</source>
-      <translation>电池电压超过设置最大值</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
-      <source>Alternator high temperature</source>
-      <translation>发动机高温</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
-      <source>Alternator high RPM</source>
-      <translation>发动机高RPM</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
-      <source>Field drive FET high temperature</source>
-      <translation>驱动场效应管高温</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
-      <source>Required sensor missing</source>
-      <translation>缺少所需的传感器</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
-      <source>Alternator low voltage</source>
-      <translation>发电机低电压</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
-      <source>Alternator high voltage offset</source>
-      <translation>发电机高压偏移</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
-      <source>Alternator Voltage exceeded configured max</source>
-      <translation>发电机电压超出配置的最大值</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
-      <source>Alternator high voltage</source>
-      <translation>底盘发电机电压过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
-      <source>Battery disconnected</source>
-      <translation>电池断开</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
-      <source>Battery high voltage disconnect</source>
-      <translation>电池高压断开</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
-      <source>Battery instance ouf of range</source>
-      <translation>电池实例超出范围</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
-      <source>Too many BMS's</source>
-      <translation>太多的BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
-      <source>Battery about to disconnect</source>
-      <translation>电池即将断开</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
-      <source>Too many devices to track</source>
-      <translation>太多的设备需要跟踪</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
-      <source>Battery low voltage disconnect</source>
-      <translation>电池低压断开</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
-      <source>Battery high current disconnect</source>
-      <translation>电池大电流断开</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
-      <source>Battery high temperature disconnect</source>
-      <translation>电池高温断开</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
-      <source>Battery low temperature disconnect</source>
-      <translation>电池低温断开</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
-      <source>BMS connection lost</source>
-      <translation>BMS连接丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
-      <source>ATC Disabled</source>
-      <translation>ATC禁用</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
-      <source>DC/DC converter not ready</source>
-      <translation>DC/DC 转换器未就绪</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
-      <source>DC/DC high primary voltage</source>
-      <translation>DC/DC 一次电压太高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
-      <source>DC/DC low primary voltage</source>
-      <translation>DC/DC 一次电压太低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
-      <source>DC/DC high secondary voltage</source>
-      <translation>DC/DC 二次电压太高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
-      <source>DC/DC low secondary voltage</source>
-      <translation>DC/DC 低二次电压</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
-      <source>DC/DC high temperature</source>
-      <translation>DC/DC高温</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
-      <source>DC/DC misconfiguration</source>
-      <translation>DC/DC错误配置</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
-      <source>Battery temperature sensor defective</source>
-      <translation>电池温度传感器故障</translation>
-    </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CRE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>未知错误：</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="838"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="843"/>
+        <source>Unknown error: </source>
+        <translation>未知错误：</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
+    <name>ChargerError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="7"/>
+        <source>No error</source>
+        <translation>无错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="9"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="103"/>
+        <source>Battery high temperature</source>
+        <translation>电池温度高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="10"/>
+        <source>Battery high voltage</source>
+        <translation>电池电压高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="11"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="12"/>
+        <source>Battery Tsense miswired</source>
+        <translation>温度检测线接线错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="13"/>
+        <source>Battery Tsense missing</source>
+        <translation>温度检测线丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="14"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="15"/>
+        <source>Battery Vsense miswired</source>
+        <translation>电压检测线接线错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="16"/>
+        <source>Battery Vsense missing</source>
+        <translation>电压检测线丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="17"/>
+        <source>Battery high wire losses</source>
+        <translation>电池高线损失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="18"/>
+        <source>Battery low voltage</source>
+        <translation>电池电压低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="19"/>
+        <source>Battery high ripple voltage</source>
+        <translation>电池纹波电压大</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="20"/>
+        <source>Battery low state of charge</source>
+        <translation>电池低荷电状态</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="21"/>
+        <source>Battery mid-point voltage issue</source>
+        <translation>电池中点电压问题</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="22"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="104"/>
+        <source>Battery temperature too low</source>
+        <translation>电池温度过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="24"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="106"/>
+        <source>Charger high temperature</source>
+        <translation>充电器温度高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="25"/>
+        <source>Charger excessive current</source>
+        <translation>充电器过流</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="26"/>
+        <source>Charger negative current</source>
+        <translation>充电器反向电流</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="27"/>
+        <source>Charger bulk time expired</source>
+        <translation>充电器快充时间超时</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="28"/>
+        <source>Charger current sensor issue</source>
+        <translation>充电器电流感应问题</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="29"/>
+        <source>Internal Tsensor miswired</source>
+        <translation>内部温度传感接线错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="30"/>
+        <source>Internal Tsensor missing</source>
+        <translation>内部温度传感丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="31"/>
+        <source>Charger fan not detected</source>
+        <translation>未检测到充电器风扇</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="32"/>
+        <source>Charger fan over-current</source>
+        <translation>充电器风扇过流</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="33"/>
+        <source>Charger terminal overheat</source>
+        <translation>充电器端子过热</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="34"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="107"/>
+        <source>Charger short circuit</source>
+        <translation>充电器短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="35"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="108"/>
+        <source>Charger power stage issue</source>
+        <translation>充电器功率级问题</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="36"/>
+        <source>Over-charge protection</source>
+        <translation>过充保护</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="38"/>
+        <source>Input high voltage</source>
+        <translation>输入电压高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="39"/>
+        <source>Input excessive current</source>
+        <translation>输入电流过大</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="40"/>
+        <source>Input excessive power</source>
+        <translation>输入功率过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="41"/>
+        <source>Input polarity issue</source>
+        <translation>输入极性问题</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="42"/>
+        <source>Input voltage absent</source>
+        <translation>输入电压缺失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="43"/>
+        <source>Input shutdown (no retries)</source>
+        <translation>输入关闭（无重试）</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="44"/>
+        <source>Input shutdown (retry)</source>
+        <translation>输入中断（重试）</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="45"/>
+        <source>Input internal failure</source>
+        <translation>输入内部故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="47"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="48"/>
+        <source>PV isolation failure</source>
+        <translation>光伏隔离失效</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="49"/>
+        <source>Ground fault detected</source>
+        <translation>检测到接地故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="51"/>
+        <source>Inverter overload</source>
+        <translation>逆变器过载</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="52"/>
+        <source>Inverter temp too high</source>
+        <translation>逆变器温度过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="53"/>
+        <source>Inverter peak current</source>
+        <translation>逆变器峰值电流</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="54"/>
+        <source>Inverter internal DC level</source>
+        <translation>逆变器内部直流电平</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="55"/>
+        <source>Inverter wrong ACout level</source>
+        <translation>逆变器交流电平错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="56"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="57"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="59"/>
+        <source>Inverter powerstage fault</source>
+        <translation>逆变器功率级故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="58"/>
+        <source>Inverter connected to AC</source>
+        <translation>逆变器连接到交流</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="60"/>
+        <source>ACIN1 relay test fault</source>
+        <translation>ACIN1继电器测试故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="61"/>
+        <source>ACIN2 relay test fault</source>
+        <translation>ACIN2继电器测试故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="63"/>
+        <source>Device disappeared</source>
+        <translation>设备消失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="64"/>
+        <source>Incompatible device</source>
+        <translation>不兼容设备</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="65"/>
+        <source>BMS connection lost</source>
+        <translation>BMS连接丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="66"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="67"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="68"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="69"/>
+        <source>Network misconfigured</source>
+        <translation>网络配置错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="70"/>
+        <source>Phase rotation</source>
+        <translation>相位旋转</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="71"/>
+        <source>Multiple AC inputs</source>
+        <translation>多路交流输入</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="72"/>
+        <source>Phase overload</source>
+        <translation>相位过载</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="74"/>
+        <source>Memory write error</source>
+        <translation>内存写入错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="75"/>
+        <source>CPU temperature too high</source>
+        <translation>CPU温度太高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="76"/>
+        <source>Communication lost</source>
+        <translation>通讯丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="77"/>
+        <source>Calibration data lost</source>
+        <translation>校准数据丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="78"/>
+        <source>Incompatible firmware</source>
+        <translation>固件不兼容</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="79"/>
+        <source>Incompatible hardware</source>
+        <translation>硬件不兼容</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="80"/>
+        <source>Settings invalid</source>
+        <translation>设置无效</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="81"/>
+        <source>Reference voltage failed</source>
+        <translation>参考电压异常</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="82"/>
+        <source>Tester fail</source>
+        <translation>检测失败</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="83"/>
+        <source>History invalid</source>
+        <translation>历史记录无效</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="84"/>
+        <source>kWh counters invalid</source>
+        <translation>千瓦时计数器无效</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="86"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="87"/>
+        <source>DC voltage error</source>
+        <translation>直流电压错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="88"/>
+        <source>GFCI sensor error</source>
+        <translation>GFCI 传感器错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="89"/>
+        <source>3V3 supply error</source>
+        <translation>3V3电源错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="90"/>
+        <source>5V supply error</source>
+        <translation>5V电源错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="91"/>
+        <source>12V supply error</source>
+        <translation>12V电源错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="92"/>
+        <source>15V supply error</source>
+        <translation>15V电源错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="94"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="95"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="96"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="97"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="98"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="99"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="100"/>
+        <location filename="../src/veutil/src/qt/charger_error.cpp" line="101"/>
+        <source>PV Input shutdown</source>
+        <translation>PV输入关断</translation>
+    </message>
+</context>
+<context>
     <name>DEIF</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>未知错误：</translation>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="857"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="862"/>
+        <source>Unknown error: </source>
+        <translation>未知错误：</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DSE</name>
     <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>未知错误：</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>未知错误：</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>无错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>交流电压L1过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>交流电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>交流电压L1过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>交流电压过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>交流频率L1过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>交流频率过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>交流频率L1过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>交流频率过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>交流电流L1过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>交流电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>交流功率L1过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>交流功率过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>紧急停止</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>伺服电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>油压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>油压过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>引擎温度过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>引擎温度过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>线圈温度过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>线圈温度过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>排气温度过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>排气温度过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>电子温度低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>电子温度高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>启动电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>启动电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>点火电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>辉光电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>冷启动辅助电压过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>冷启动辅助电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>燃油保持磁铁电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>燃料吸持磁铁电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>停止电磁阀保持线圈电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>点火开关吸持线圈电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>停机电磁阀牵引线圈电压过低 </translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>点火开关吸合线圈电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>风扇/水泵电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>风扇/水泵电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>电流传感器电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>电流传感器电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>升压输出电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>升压输出电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>总线供电电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>总线供电电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>启动电池电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>启动电池电压过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>转速过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>转速过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>意外停车/燃油供应问题</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>电源接触器电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>电力接触器电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>交流电压L2过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>交流电压L2过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>交流频率L2过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>交流频率L2过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>交流电流L2过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>交流功率L2过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>交流电压L3过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>交流电压L3过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>交流频率L3过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>交流频率L3过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>交流电流L3过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>交流功率L3过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>逆变器输出电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>输出逆变器电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>通用输出 (1A) 电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>通用输出 (1A) 电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>通用输出 (5A) 电压过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>通用输出 (5A) 电流过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>AGT 直流电压 1 低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>AGT 直流电压 1 高电平</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>AGT 直流电流 1 低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>AGT 直流电流 1 高电平</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>AGT 直流电压 2 低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>AGT 直流电压 2 高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>AGT 直流电流 2 低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>AGT 直流电流 2 高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>AGT B6 冷却器低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>AGT B6 高冷却器</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>AGT B6 轨 (-) 低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>AGT B6 轨 (-) 高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>AGT B6 轨 (+) 低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>AGT B6 轨 (+) 高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>燃料温度过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>燃料温度过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>油位过低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>丢失控制单元</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>丢失面板</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>需要服务</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>丢失3相模块</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>丢失AGT模块</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>同步故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>外部 ECU 丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>进口空气过滤器</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>诊断信息（ECU）</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>丢失同步模块</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>负载平衡故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>同步模式停用</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>红色停车灯 (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>琥珀色警示灯 (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>故障指示灯 (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>保护灯 (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>旋转磁场错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>油位传感器丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>不使用逆变器启动</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>1 号总线丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>启动请求被拒绝</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>拒绝远程启动</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>强制关闭负载继电器</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>同步模块已脱机</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>丢失的 BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>转换器直流链路电压低/反向</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>转换器直流链路电流低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>转换器直流预充电电压低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>转换器直流预充电电压高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>转换器 IGBT/MOSFET 驱动器错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>转换器误差 功率控制回路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>转换器交流频率检测</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>转换器控制值故障</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>出厂设置已更改</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>在管理模式下更改参数</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>人工干预（外部系统）</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>初始化失败</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>看门狗</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>逆变器温度过高 L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>逆变器温度过高 L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>逆变器温度过高 L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>逆变器温度过高 直流链路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>逆变器过载</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>逆变器通讯丢失</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>直流过载</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>直流过电压</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>无连接</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>无错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>未知错误：%1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>未知错误：</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>油压</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>缸盖温度过高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>充电控制</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>速度高于预期</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>超速</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>温度高于预期</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>过热断路/电源短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>温度过高对地短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>模拟设定点高/电源短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>模拟设定点低电平/对地短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>TSC1 报文接收超时</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>CM1 报文接收超时</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>电池电压高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>电池电压低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>速度信号失真</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>内部 5V 传感器电源高电平</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>内部 5V 传感器电源电压低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>气压高</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>气压偏低</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>输出燃油泵与电源短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>输出燃油泵对地短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>输出辉光塞与电源短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>输出辉光塞对地短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>喷油器开路/低端对地短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>喷油器线圈内部短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>喷油器低压侧与电源短路</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>服务时间到期</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>处理器故障</translation>
-    </message>
-  </context>
-  <context>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="242"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="247"/>
+        <source>Unknown error: </source>
+        <translation>未知错误：</translation>
+    </message>
+</context>
+<context>
     <name>EnvironmentInputs</name>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>电池</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="18"/>
+        <source>Battery</source>
+        <translation>电池</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>冰箱</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="24"/>
+        <source>Fridge</source>
+        <translation>冰箱</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>通用</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="30"/>
+        <source>Generic</source>
+        <translation>通用</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>房间</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="36"/>
+        <source>Room</source>
+        <translation>房间</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>户外</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="42"/>
+        <source>Outdoor</source>
+        <translation>户外</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>加热器</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="48"/>
+        <source>Water Heater</source>
+        <translation>加热器</translation>
     </message>
     <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>冰箱</translation>
+        <location filename="../data/EnvironmentInputs.qml" line="54"/>
+        <source>Freezer</source>
+        <translation>冰箱</translation>
     </message>
-  </context>
+</context>
+<context>
+    <name>FischerPanda</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="87"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="92"/>
+        <source>Unknown error: </source>
+        <translation>未知错误：</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="98"/>
+        <source>No error</source>
+        <translation>无错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage L1 too low</source>
+        <translation>交流电压L1过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="101"/>
+        <source>AC voltage too low</source>
+        <translation>交流电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage L1 too high</source>
+        <translation>交流电压L1过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="102"/>
+        <source>AC voltage too high</source>
+        <translation>交流电压过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency L1 too low</source>
+        <translation>交流频率L1过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="103"/>
+        <source>AC frequency too low</source>
+        <translation>交流频率过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency L1 too high</source>
+        <translation>交流频率L1过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="104"/>
+        <source>AC frequency too high</source>
+        <translation>交流频率过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current L1 too high</source>
+        <translation>交流电流L1过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="105"/>
+        <source>AC current too high</source>
+        <translation>交流电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power L1 too high</source>
+        <translation>交流功率L1过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="106"/>
+        <source>AC power too high</source>
+        <translation>交流功率过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="107"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="231"/>
+        <source>Emergency stop</source>
+        <translation>紧急停止</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="108"/>
+        <source>Servo current too high</source>
+        <translation>伺服电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="109"/>
+        <source>Oil pressure too low</source>
+        <translation>油压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="110"/>
+        <source>Oil pressure too high</source>
+        <translation>油压过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="111"/>
+        <source>Engine temperature too low</source>
+        <translation>引擎温度过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="112"/>
+        <source>Engine temperature too high</source>
+        <translation>引擎温度过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="113"/>
+        <source>Winding temperature too low</source>
+        <translation>线圈温度过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="114"/>
+        <source>Winding temperature too high</source>
+        <translation>线圈温度过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="115"/>
+        <source>Exhaust temperature too low</source>
+        <translation>排气温度过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="116"/>
+        <source>Exhaust temperature too high</source>
+        <translation>排气温度过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="117"/>
+        <source>Electronic temperature low</source>
+        <translation>电子温度低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="118"/>
+        <source>Electronic temperature high</source>
+        <translation>电子温度高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="119"/>
+        <source>Starter voltage too low</source>
+        <translation>启动电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="120"/>
+        <source>Starter current too high</source>
+        <translation>启动电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="121"/>
+        <source>Glow voltage too low</source>
+        <translation>点火电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="122"/>
+        <source>Glow current too high</source>
+        <translation>辉光电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="123"/>
+        <source>Cold-Start-Aid voltage too high</source>
+        <translation>冷启动辅助电压过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="124"/>
+        <source>Cold-Start-Aid current too high</source>
+        <translation>冷启动辅助电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="125"/>
+        <source>Fuel holding magnet voltage too low</source>
+        <translation>燃油保持磁铁电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="126"/>
+        <source>Fuel holding magnet current too high</source>
+        <translation>燃料吸持磁铁电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="127"/>
+        <source>Stop solenoid hold coil voltage too low</source>
+        <translation>停止电磁阀保持线圈电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="128"/>
+        <source>Stop solenoid hold coil current too high</source>
+        <translation>点火开关吸持线圈电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="129"/>
+        <source>Stop solenoid pull coil voltage too low </source>
+        <translation>停机电磁阀牵引线圈电压过低 </translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="130"/>
+        <source>Stop solenoid pull coil current too high</source>
+        <translation>点火开关吸合线圈电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="131"/>
+        <source>Fan/water pump voltage too low</source>
+        <translation>风扇/水泵电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="132"/>
+        <source>Fan/water pump current too high</source>
+        <translation>风扇/水泵电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="133"/>
+        <source>Current sensor voltage low</source>
+        <translation>电流传感器电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="134"/>
+        <source>Current sensor current high</source>
+        <translation>电流传感器电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="135"/>
+        <source>Boost output voltage too low</source>
+        <translation>升压输出电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="136"/>
+        <source>Boost output current too high</source>
+        <translation>升压输出电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="137"/>
+        <source>Bus supply voltage too low</source>
+        <translation>总线供电电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="138"/>
+        <source>Bus supply current too high</source>
+        <translation>总线供电电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="139"/>
+        <source>Starter battery voltage too low</source>
+        <translation>启动电池电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="140"/>
+        <source>Starter battery voltage too high</source>
+        <translation>启动电池电压过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="141"/>
+        <source>Rotation too low</source>
+        <translation>转速过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="142"/>
+        <source>Rotation too high</source>
+        <translation>转速过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="143"/>
+        <source>Unexpected stop/problem with fuel supply</source>
+        <translation>意外停车/燃油供应问题</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="144"/>
+        <source>Power contactor voltage too low</source>
+        <translation>电源接触器电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="145"/>
+        <source>Power contactor current too high</source>
+        <translation>电力接触器电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="146"/>
+        <source>AC voltage L2 too low</source>
+        <translation>交流电压L2过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="147"/>
+        <source>AC voltage L2 too high</source>
+        <translation>交流电压L2过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="148"/>
+        <source>AC frequency L2 too low</source>
+        <translation>交流频率L2过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="149"/>
+        <source>AC frequency L2 too high</source>
+        <translation>交流频率L2过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="150"/>
+        <source>AC current L2 too high</source>
+        <translation>交流电流L2过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="151"/>
+        <source>AC power L2 too high</source>
+        <translation>交流功率L2过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="152"/>
+        <source>AC voltage L3 too low</source>
+        <translation>交流电压L3过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="153"/>
+        <source>AC voltage L3 too high</source>
+        <translation>交流电压L3过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="154"/>
+        <source>AC frequency L3 too low</source>
+        <translation>交流频率L3过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="155"/>
+        <source>AC frequency L3 too high</source>
+        <translation>交流频率L3过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="156"/>
+        <source>AC current L3 too high</source>
+        <translation>交流电流L3过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="157"/>
+        <source>AC power L3 too high</source>
+        <translation>交流功率L3过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="158"/>
+        <source>Output Inverter voltage too low</source>
+        <translation>逆变器输出电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="159"/>
+        <source>Output Inverter current too  high</source>
+        <translation>输出逆变器电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="160"/>
+        <source>Universal output (1A) voltage too low</source>
+        <translation>通用输出 (1A) 电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="161"/>
+        <source>Universal output (1A) current too high</source>
+        <translation>通用输出 (1A) 电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="162"/>
+        <source>Universal output (5A) voltage too low</source>
+        <translation>通用输出 (5A) 电压过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="163"/>
+        <source>Universal output (5A) current too high</source>
+        <translation>通用输出 (5A) 电流过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="164"/>
+        <source>AGT DC voltage 1 low</source>
+        <translation>AGT 直流电压 1 低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="165"/>
+        <source>AGT DC voltage 1 high</source>
+        <translation>AGT 直流电压 1 高电平</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="166"/>
+        <source>AGT DC current 1 low</source>
+        <translation>AGT 直流电流 1 低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="167"/>
+        <source>AGT DC current 1 high</source>
+        <translation>AGT 直流电流 1 高电平</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="168"/>
+        <source>AGT DC voltage 2 low</source>
+        <translation>AGT 直流电压 2 低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="169"/>
+        <source>AGT DC voltage 2 high</source>
+        <translation>AGT 直流电压 2 高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="170"/>
+        <source>AGT DC current 2 low</source>
+        <translation>AGT 直流电流 2 低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="171"/>
+        <source>AGT DC current 2 high</source>
+        <translation>AGT 直流电流 2 高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="172"/>
+        <source>AGT B6 cooler low</source>
+        <translation>AGT B6 冷却器低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="173"/>
+        <source>AGT B6 cooler high</source>
+        <translation>AGT B6 高冷却器</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="174"/>
+        <source>AGT B6 rail (-) low</source>
+        <translation>AGT B6 轨 (-) 低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="175"/>
+        <source>AGT B6 rail (-) high</source>
+        <translation>AGT B6 轨 (-) 高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="176"/>
+        <source>AGT B6 rail (+) low</source>
+        <translation>AGT B6 轨 (+) 低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="177"/>
+        <source>AGT B6 rail (+) high</source>
+        <translation>AGT B6 轨 (+) 高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="178"/>
+        <source>Fuel temperature too low</source>
+        <translation>燃料温度过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="179"/>
+        <source>Fuel temperature too high</source>
+        <translation>燃料温度过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="180"/>
+        <source>Fuel level too low</source>
+        <translation>油位过低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="183"/>
+        <source>Lost control unit</source>
+        <translation>丢失控制单元</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="184"/>
+        <source>Lost panel</source>
+        <translation>丢失面板</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="185"/>
+        <source>Service needed</source>
+        <translation>需要服务</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="186"/>
+        <source>Lost 3-phase module</source>
+        <translation>丢失3相模块</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="187"/>
+        <source>Lost AGT module</source>
+        <translation>丢失AGT模块</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="188"/>
+        <source>Synchronization failure</source>
+        <translation>同步故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="189"/>
+        <source>Lost external ECU</source>
+        <translation>外部 ECU 丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="190"/>
+        <source>Intake airfilter</source>
+        <translation>进口空气过滤器</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="191"/>
+        <source>Diagnostic message (ECU)</source>
+        <translation>诊断信息（ECU）</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="192"/>
+        <source>Lost sync. module</source>
+        <translation>丢失同步模块</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="193"/>
+        <source>Load-balance failed</source>
+        <translation>负载平衡故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="194"/>
+        <source>Sync-mode deactivated</source>
+        <translation>同步模式停用</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="195"/>
+        <source>Red Stop Lamp (RSL)</source>
+        <translation>红色停车灯 (RSL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="196"/>
+        <source>Amber Warning Lamp (AWL)</source>
+        <translation>琥珀色警示灯 (AWL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="197"/>
+        <source>Malfunction Indicator Lamp (MIL)</source>
+        <translation>故障指示灯 (MIL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="198"/>
+        <source>Protect Lamp (PL)</source>
+        <translation>保护灯 (PL)</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="199"/>
+        <source>Rotating field wrong</source>
+        <translation>旋转磁场错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="200"/>
+        <source>Fuel level sensor lost</source>
+        <translation>油位传感器丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="201"/>
+        <source>Starting without inverter</source>
+        <translation>不使用逆变器启动</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="202"/>
+        <source>Bus #1 dead</source>
+        <translation>1 号总线丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="203"/>
+        <source>Start request denied</source>
+        <translation>启动请求被拒绝</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="204"/>
+        <source>Remote start denied</source>
+        <translation>拒绝远程启动</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="205"/>
+        <source>Forced switch off load relay</source>
+        <translation>强制关闭负载继电器</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="206"/>
+        <source>Synchronization Module is offline</source>
+        <translation>同步模块已脱机</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="207"/>
+        <source>Lost BMS</source>
+        <translation>丢失的 BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="208"/>
+        <source>Converter DC Link Voltage Low/Reverse</source>
+        <translation>转换器直流链路电压低/反向</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="209"/>
+        <source>Converter DC Link Current Low</source>
+        <translation>转换器直流链路电流低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="210"/>
+        <source>Converter DC Precharge Voltage Low</source>
+        <translation>转换器直流预充电电压低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="211"/>
+        <source>Converter DC Precharge Voltage High</source>
+        <translation>转换器直流预充电电压高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="212"/>
+        <source>Converter IGBT/MOSFET Driver Error</source>
+        <translation>转换器 IGBT/MOSFET 驱动器错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="213"/>
+        <source>Converter Error Power Control Loop</source>
+        <translation>转换器误差 功率控制回路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="214"/>
+        <source>Converter AC Frequency Detection</source>
+        <translation>转换器交流频率检测</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="215"/>
+        <source>Converter Control Value Fail</source>
+        <translation>转换器控制值故障</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="216"/>
+        <source>Factory setting changed</source>
+        <translation>出厂设置已更改</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="217"/>
+        <source>Parameter changed in admin mode</source>
+        <translation>在管理模式下更改参数</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="218"/>
+        <source>Manual Intervention (ext. System)</source>
+        <translation>人工干预（外部系统）</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="221"/>
+        <source>Init failed</source>
+        <translation>初始化失败</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="222"/>
+        <source>Watchdog</source>
+        <translation>看门狗</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="223"/>
+        <source>Inverter temperature high L1</source>
+        <translation>逆变器温度过高 L1</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="224"/>
+        <source>Inverter temperature high L2</source>
+        <translation>逆变器温度过高 L2</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="225"/>
+        <source>Inverter temperature high L3</source>
+        <translation>逆变器温度过高 L3</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="226"/>
+        <source>Inverter temperature high DC link</source>
+        <translation>逆变器温度过高 直流链路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="227"/>
+        <source>Inverter overload</source>
+        <translation>逆变器过载</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="228"/>
+        <source>Inverter communication lost</source>
+        <translation>逆变器通讯丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="229"/>
+        <source>DC overload</source>
+        <translation>直流过载</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="230"/>
+        <source>DC overvoltage</source>
+        <translation>直流过电压</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="232"/>
+        <source>No connection</source>
+        <translation>无连接</translation>
+    </message>
+</context>
+<context>
+    <name>GensetError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="68"/>
+        <source>No error</source>
+        <translation>无错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="79"/>
+        <source>Unknown error: %1</source>
+        <translation>未知错误：%1</translation>
+    </message>
+</context>
+<context>
+    <name>Hatz</name>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="778"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="784"/>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="790"/>
+        <source>Unknown error: </source>
+        <translation>未知错误：</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="797"/>
+        <source>Oil pressure</source>
+        <translation>油压</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="798"/>
+        <source>Cylinder head overtemperature</source>
+        <translation>缸盖温度过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="799"/>
+        <source>Charge control</source>
+        <translation>充电控制</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="800"/>
+        <source>Speed higher than expected</source>
+        <translation>速度高于预期</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="801"/>
+        <source>Overspeed</source>
+        <translation>超速</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="803"/>
+        <source>Oiltemperature higher than expected</source>
+        <translation>温度高于预期</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="804"/>
+        <source>Oiltemperature open circuit / short to power</source>
+        <translation>过热断路/电源短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="805"/>
+        <source>Oiltemperature short to ground</source>
+        <translation>温度过高对地短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="806"/>
+        <source>Analog setpoint high / short to power</source>
+        <translation>模拟设定点高/电源短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="807"/>
+        <source>Analog setpoint low / short to ground</source>
+        <translation>模拟设定点低电平/对地短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="808"/>
+        <source>TSC1 message receive timeout</source>
+        <translation>TSC1 报文接收超时</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="809"/>
+        <source>CM1 message receive timeout</source>
+        <translation>CM1 报文接收超时</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="810"/>
+        <source>Battery voltage high</source>
+        <translation>电池电压高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="811"/>
+        <source>Battery voltage low</source>
+        <translation>电池电压低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="812"/>
+        <source>Speed signal distorted</source>
+        <translation>速度信号失真</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="813"/>
+        <source>Internal 5V sensor supply high</source>
+        <translation>内部 5V 传感器电源高电平</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="814"/>
+        <source>Internal 5V sensor supply low</source>
+        <translation>内部 5V 传感器电源电压低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="815"/>
+        <source>Barometric pressure high</source>
+        <translation>气压高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="816"/>
+        <source>Barometric pressure low</source>
+        <translation>气压偏低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="817"/>
+        <source>Output fuelpump short to power</source>
+        <translation>输出燃油泵与电源短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="818"/>
+        <source>Output fuelpump short to ground</source>
+        <translation>输出燃油泵对地短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="819"/>
+        <source>Output glow plug short to power</source>
+        <translation>输出辉光塞与电源短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="820"/>
+        <source>Output glow plug short to ground</source>
+        <translation>输出辉光塞对地短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="821"/>
+        <source>Injector open circuit/low side short to ground</source>
+        <translation>喷油器开路/低端对地短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="822"/>
+        <source>Injector coil internal short circuit</source>
+        <translation>喷油器线圈内部短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="823"/>
+        <source>Injector low side short to power</source>
+        <translation>喷油器低压侧与电源短路</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="824"/>
+        <source>Service hours expired</source>
+        <translation>服务时间到期</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/genset_error.cpp" line="828"/>
+        <source>Processor failure</source>
+        <translation>处理器故障</translation>
+    </message>
+</context>
+<context>
+    <name>PageAcInSetup</name>
+    <message>
+        <location filename="../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="124"/>
+        <source>Set the switch in an unlocked position to modify the settings.</source>
+        <translation>将开关置于解锁位置以修改设置。</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../src/main.cpp" line="100"/>
+        <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+        <translation>使用D-Bus数据源：连接到指定的D-Bus地址。</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="101"/>
+        <source>address</source>
+        <comment>D-Bus address</comment>
+        <translation>地址</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="105"/>
+        <source>Use D-Bus data source: connect to the default D-Bus address</source>
+        <translation>使用D-Bus数据源：连接到默认的D-Bus地址</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="110"/>
+        <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+        <translation>使用MQTT数据源：连接到指定的MQTT代理地址。</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="111"/>
+        <source>address</source>
+        <comment>MQTT broker address</comment>
+        <translation>地址</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="116"/>
+        <source>MQTT data source device portal id.</source>
+        <translation>MQTT 数据源设备门户 ID。</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="117"/>
+        <source>portalId</source>
+        <translation>门户ID</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="121"/>
+        <source>MQTT VRM webhost shard</source>
+        <translation>MQTT VRM Web 主机分片</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="122"/>
+        <source>shard</source>
+        <comment>MQTT VRM webhost shard</comment>
+        <translation>分片</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="126"/>
+        <source>MQTT data source username</source>
+        <translation>MQTT 数据源用户名</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="127"/>
+        <source>user</source>
+        <comment>MQTT broker username.</comment>
+        <translation>用户</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="131"/>
+        <source>MQTT data source password</source>
+        <translation>MQTT数据源密码</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="132"/>
+        <source>pass</source>
+        <comment>MQTT broker password.</comment>
+        <translation>通过</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="136"/>
+        <source>MQTT data source token</source>
+        <translation>MQTT 数据源令牌</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="137"/>
+        <source>token</source>
+        <comment>MQTT broker auth token.</comment>
+        <translation>令牌代码</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="141"/>
+        <source>Enable FPS counter</source>
+        <translation>启用 FPS 计数器</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="145"/>
+        <source>Skip splash screen</source>
+        <translation>跳过启动画面</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="149"/>
+        <source>Use mock data source for testing.</source>
+        <translation>使用模拟数据源进行测试。</translation>
+    </message>
+</context>
+<context>
+    <name>TzAfricaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="10"/>
+        <source>Morocco Standard Time</source>
+        <translation>摩洛哥标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="11"/>
+        <source>W. Central Africa Standard Time</source>
+        <translation>中非西部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="12"/>
+        <source>South Africa Standard Time</source>
+        <translation>南非标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="13"/>
+        <source>Namibia Standard Time</source>
+        <translation>纳米比亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="14"/>
+        <source>Egypt Standard Time</source>
+        <translation>埃及标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAfricaData.qml" line="15"/>
+        <source>E. Africa Standard Time</source>
+        <translation>非洲东部标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzAmericaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="10"/>
+        <source>Argentina Standard Time</source>
+        <translation>阿根廷标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="11"/>
+        <source>E. South America Standard Time</source>
+        <translation>南美东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="12"/>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="13"/>
+        <source>Greenland Standard Time</source>
+        <translation>格陵兰标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="14"/>
+        <source>Montevideo Standard Time</source>
+        <translation>蒙得维的亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="15"/>
+        <source>Newfoundland Standard Time</source>
+        <translation>纽芬兰标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="16"/>
+        <source>SA Eastern Standard Time</source>
+        <translation>南美东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="17"/>
+        <source>Atlantic Standard Time</source>
+        <translation>大西洋标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="18"/>
+        <source>Central Brazilian Standard Time</source>
+        <translation>巴西中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="19"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>太平洋南美洲标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="20"/>
+        <source>Paraguay Standard Time</source>
+        <translation>巴拉圭标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="21"/>
+        <source>SA Western Standard Time</source>
+        <translation>南美西部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="22"/>
+        <source>Venezuela Standard Time</source>
+        <translation>委内瑞拉标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="23"/>
+        <source>Eastern Standard Time</source>
+        <translation>东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="24"/>
+        <source>SA Pacific Standard Time</source>
+        <translation>南美太平洋标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="25"/>
+        <source>US Eastern Standard Time</source>
+        <translation>美国东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="26"/>
+        <source>Canada Central Standard Time</source>
+        <translation>加拿大中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="27"/>
+        <source>Central America Standard Time</source>
+        <translation>中美洲标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="28"/>
+        <source>Central Standard Time (Mexico)</source>
+        <translation>中部标准时间（墨西哥）</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="29"/>
+        <source>Central Standard Time</source>
+        <translation>中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="30"/>
+        <source>Mountain Standard Time (Mexico)</source>
+        <translation>山区标准时间（墨西哥）</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="31"/>
+        <source>Mountain Standard Time</source>
+        <translation>山区标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="32"/>
+        <source>US Mountain Standard Time</source>
+        <translation>美国山区标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="33"/>
+        <source>Pacific Standard Time (Mexico)</source>
+        <translation>太平洋标准时间（墨西哥）</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="34"/>
+        <source>Pacific Standard Time</source>
+        <translation>太平洋标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="35"/>
+        <source>Alaskan Standard Time</source>
+        <translation>阿拉斯加标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAmericaData.qml" line="36"/>
+        <source>Hawaii-Aleutian</source>
+        <translation>夏威夷-阿留申</translation>
+    </message>
+</context>
+<context>
+    <name>TzAntarcticaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+        <source>New Zealand Standard Time</source>
+        <translation>新西兰标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>太平洋中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+        <source>West Pacific Standard Time</source>
+        <translation>太平洋西部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+        <source>W. Australia Standard Time</source>
+        <translation>澳大利亚西部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+        <source>SE Asia Standard Time</source>
+        <translation>东南亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+        <source>Central Asia Standard Time</source>
+        <translation>中亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+        <source>West Asia Standard Time</source>
+        <translation>西亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+        <source>E. Africa Standard Time</source>
+        <translation>非洲东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+        <source>Pacific SA Standard Time</source>
+        <translation>太平洋南美洲标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+        <source>SA Western Standard Time</source>
+        <translation>南美西部标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzArcticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzArcticData.qml" line="10"/>
+        <source>W. Europe Standard Time</source>
+        <translation>西欧标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzAsiaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="10"/>
+        <source>Kamchatka Standard Time</source>
+        <translation>堪察加标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="11"/>
+        <source>Magadan Standard Time</source>
+        <translation>马加丹标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="12"/>
+        <source>Vladivostok Standard Time</source>
+        <translation>符拉迪沃斯托克标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="13"/>
+        <source>Yakutsk Standard Time</source>
+        <translation>雅库茨克标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="14"/>
+        <source>Tokyo Standard Time</source>
+        <translation>东京标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="15"/>
+        <source>Korea Standard Time</source>
+        <translation>韩国标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="16"/>
+        <source>Singapore Standard Time</source>
+        <translation>新加坡标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="17"/>
+        <source>Ulaanbaatar Standard Time</source>
+        <translation>乌兰巴托标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="18"/>
+        <source>Taipei Standard Time</source>
+        <translation>台北标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="19"/>
+        <source>North Asia East Standard Time</source>
+        <translation>北亚东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="20"/>
+        <source>China Standard Time</source>
+        <translation>中国标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="21"/>
+        <source>SE Asia Standard Time</source>
+        <translation>东南亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="22"/>
+        <source>North Asia Standard Time</source>
+        <translation>北亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="23"/>
+        <source>Myanmar Standard Time</source>
+        <translation>缅甸标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="24"/>
+        <source>N. Central Asia Standard Time</source>
+        <translation>中亚北部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="25"/>
+        <source>Central Asia Standard Time</source>
+        <translation>中亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="26"/>
+        <source>Bangladesh Standard Time</source>
+        <translation>孟加拉国标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="27"/>
+        <source>Nepal Standard Time</source>
+        <translation>尼泊尔标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="28"/>
+        <source>Sri Lanka Standard Time</source>
+        <translation>斯里兰卡标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="29"/>
+        <source>India Standard Time</source>
+        <translation>印度标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="30"/>
+        <source>West Asia Standard Time</source>
+        <translation>西亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="31"/>
+        <source>Pakistan Standard Time</source>
+        <translation>巴基斯坦标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="32"/>
+        <source>Ekaterinburg Standard Time</source>
+        <translation>叶卡特琳堡标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="33"/>
+        <source>Georgian Standard Time</source>
+        <translation>格鲁吉亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="34"/>
+        <source>Caucasus Standard Time</source>
+        <translation>高加索标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="35"/>
+        <source>Azerbaijan Standard Time</source>
+        <translation>阿塞拜疆标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="36"/>
+        <source>Arabian Standard Time</source>
+        <translation>阿拉伯标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="37"/>
+        <source>Afghanistan Standard Time</source>
+        <translation>阿富汗标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="38"/>
+        <source>Iran Standard Time</source>
+        <translation>伊朗标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="39"/>
+        <source>Arabic Standard Time</source>
+        <translation>阿拉伯标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="40"/>
+        <source>Arab Standard Time</source>
+        <translation>阿拉伯标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="41"/>
+        <source>Syria Standard Time</source>
+        <translation>叙利亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="42"/>
+        <source>Middle East Standard Time</source>
+        <translation>中东标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="43"/>
+        <source>Jordan Standard Time</source>
+        <translation>约旦标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAsiaData.qml" line="44"/>
+        <source>Israel Standard Time</source>
+        <translation>以色列标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzAtlanticData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+        <source>Greenwich Standard Time</source>
+        <translation>格林尼治标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+        <source>Azores Standard Time</source>
+        <translation>亚速尔群岛标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+        <source>Cape Verde Standard Time</source>
+        <translation>佛得角标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzAustraliaData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+        <source>Tasmania Standard Time</source>
+        <translation>塔斯马尼亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+        <source>E. Australia Standard Time</source>
+        <translation>澳大利亚东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+        <source>AUS Eastern Standard Time</source>
+        <translation>澳大利亚东部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+        <source>Cen. Australia Standard Time</source>
+        <translation>澳大利亚中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+        <source>AUS Central Standard Time</source>
+        <translation>澳大利亚中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+        <source>W. Australia Standard Time</source>
+        <translation>澳大利亚西部标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzEtcData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="10"/>
+        <source>GMT +12</source>
+        <translation>GMT +12</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="11"/>
+        <source>GMT </source>
+        <translation>GMT</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="12"/>
+        <source>Mid-Atlantic Standard Time</source>
+        <translation>大西洋中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="13"/>
+        <source>GMT -02</source>
+        <translation>GMT -02</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="14"/>
+        <source>GMT -11</source>
+        <translation>GMT -11</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEtcData.qml" line="15"/>
+        <source>Dateline Standard Time</source>
+        <translation>国际日期变更线标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzEuropeData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="10"/>
+        <source>GMT Standard Time</source>
+        <translation>GMT标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="11"/>
+        <source>Central Europe Standard Time</source>
+        <translation>中欧标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="12"/>
+        <source>Central European Standard Time</source>
+        <translation>欧洲中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="13"/>
+        <source>Romance Standard Time</source>
+        <translation>罗曼斯标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="14"/>
+        <source>W. Europe Standard Time</source>
+        <translation>西欧标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="15"/>
+        <source>E. Europe Standard Time</source>
+        <translation>东欧标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="16"/>
+        <source>FLE Standard Time</source>
+        <translation>FLE标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="17"/>
+        <source>GTB Standard Time</source>
+        <translation>GTB标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="18"/>
+        <source>Belarus Standard Time</source>
+        <translation>白俄罗斯标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="19"/>
+        <source>Russian Standard Time</source>
+        <translation>俄罗斯标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzEuropeData.qml" line="20"/>
+        <source>Turkey Standard Time</source>
+        <translation>土耳其标准时间</translation>
+    </message>
+</context>
+<context>
+    <name>TzIndianData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="10"/>
+        <source>Mauritius Standard Time</source>
+        <translation>毛里求斯标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzIndianData.qml" line="11"/>
+        <source>Christmas Island Standard Time</source>
+        <translation>圣诞岛标准时</translation>
+    </message>
+</context>
+<context>
+    <name>TzPacificData</name>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="10"/>
+        <source>Tonga Standard Time</source>
+        <translation>汤加标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="11"/>
+        <source>Fiji Standard Time</source>
+        <translation>斐济标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="12"/>
+        <source>New Zealand Standard Time</source>
+        <translation>新西兰标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="13"/>
+        <source>Central Pacific Standard Time</source>
+        <translation>太平洋中部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="14"/>
+        <source>West Pacific Standard Time</source>
+        <translation>太平洋西部标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="15"/>
+        <source>Samoa Standard Time</source>
+        <translation>萨摩亚标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="16"/>
+        <source>Hawaiian Standard Time</source>
+        <translation>夏威夷标准时间</translation>
+    </message>
+    <message>
+        <location filename="../pages/settings/tz/TzPacificData.qml" line="17"/>
+        <source>Easter Island Standard Time</source>
+        <translation>东部岛屿标准时</translation>
+    </message>
+</context>
+<context>
+    <name>VebusError</name>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+        <source>Device switched off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+        <source>Mixed old/new MK2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+        <source>Expected devices error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+        <source>No other device detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+        <source>Overvoltage on AC-out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+        <source>DDC program error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+        <source>VE.Bus BMS without assistant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+        <source>Ground relay test failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+        <source>System time sync error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+        <source>Grid relay test fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+        <source>Config mismatch with 2nd mcu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+        <source>Device transmit error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+        <source>Awaiting configuration or dongle missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+        <source>Phase master missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+        <source>Overvoltage has occurred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+        <source>Slave does not have AC input!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+        <source>Device can&apos;t be slave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+        <source>System protection initiated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+        <source>Firmware incompatibiltiy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+        <source>Internal error</source>
+        <translation type="unfinished">内部错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+        <source>Failing relay test prevents connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+        <source>VE.Bus error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Wakespeed</name>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+        <source>Unknown error: </source>
+        <translation>未知错误：</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+        <source>Internal error</source>
+        <translation>内部错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+        <source>No error</source>
+        <translation>无错误</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+        <source>Battery high temperature</source>
+        <translation>电池温度高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+        <source>Battery high voltage</source>
+        <translation>电池电压高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+        <source>Battery low voltage</source>
+        <translation>电池电压低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+        <source>Battery voltage exceeded configured max</source>
+        <translation>电池电压超过设置最大值</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+        <source>Alternator high temperature</source>
+        <translation>发动机高温</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+        <source>Alternator high RPM</source>
+        <translation>发动机高RPM</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+        <source>Field drive FET high temperature</source>
+        <translation>驱动场效应管高温</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+        <source>Required sensor missing</source>
+        <translation>缺少所需的传感器</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+        <source>Alternator low voltage</source>
+        <translation>发电机低电压</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+        <source>Alternator high voltage offset</source>
+        <translation>发电机高压偏移</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+        <source>Alternator Voltage exceeded configured max</source>
+        <translation>发电机电压超出配置的最大值</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+        <source>Alternator high voltage</source>
+        <translation>底盘发电机电压过高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+        <source>Battery disconnected</source>
+        <translation>电池断开</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+        <source>Battery high voltage disconnect</source>
+        <translation>电池高压断开</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+        <source>Battery instance ouf of range</source>
+        <translation>电池实例超出范围</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+        <source>Too many BMS&apos;s</source>
+        <translation>太多的BMS</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+        <source>Battery about to disconnect</source>
+        <translation>电池即将断开</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+        <source>Too many devices to track</source>
+        <translation>太多的设备需要跟踪</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+        <source>Battery low voltage disconnect</source>
+        <translation>电池低压断开</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+        <source>Battery high current disconnect</source>
+        <translation>电池大电流断开</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+        <source>Battery high temperature disconnect</source>
+        <translation>电池高温断开</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+        <source>Battery low temperature disconnect</source>
+        <translation>电池低温断开</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+        <source>BMS connection lost</source>
+        <translation>BMS连接丢失</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+        <source>ATC Disabled</source>
+        <translation>ATC禁用</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+        <source>DC/DC converter not ready</source>
+        <translation>DC/DC 转换器未就绪</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+        <source>DC/DC high primary voltage</source>
+        <translation>DC/DC 一次电压太高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+        <source>DC/DC low primary voltage</source>
+        <translation>DC/DC 一次电压太低</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+        <source>DC/DC high secondary voltage</source>
+        <translation>DC/DC 二次电压太高</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+        <source>DC/DC low secondary voltage</source>
+        <translation>DC/DC 低二次电压</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+        <source>DC/DC high temperature</source>
+        <translation>DC/DC高温</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+        <source>DC/DC misconfiguration</source>
+        <translation>DC/DC错误配置</translation>
+    </message>
+    <message>
+        <location filename="../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+        <source>Battery temperature sensor defective</source>
+        <translation>电池温度传感器故障</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
We previously disabled automatic-update of in-source .ts files. This means that we rely on lupdate to update the build-dir copies before lrelease runs on those.

In some cases, this is causing problems.

This commit updates the in-source versions with the latest build-dir copies, so that at least for now, it must be in sync.

TODO: fix this properly in future.

Contributes to issue #1661